### PR TITLE
fix(docs): preserve Mermaid chart line breaks

### DIFF
--- a/scripts/docs-site/elements-fixture.mjs
+++ b/scripts/docs-site/elements-fixture.mjs
@@ -256,6 +256,11 @@ sequenceDiagram
   Gateway-->>User: healthy
 </Mermaid>
 
+\`\`\`mermaid
+flowchart LR
+  A["Ready<br>state"] --> B["Rendered"]
+\`\`\`
+
 <Mermaid>
 flowchart LR
   Broken -->

--- a/scripts/docs-site/mdx-ish.mjs
+++ b/scripts/docs-site/mdx-ish.mjs
@@ -204,8 +204,8 @@ export function renderMdxish(markdown, md) {
 function preprocess(input) {
   let out = input.replace(/\r\n/g, "\n");
   out = out.replace(/^import\s+.+?;?\s*$/gm, "");
-  out = out.replace(/<br\s*\/?>/gi, "\n");
   out = out.replace(/<Mermaid\b[^>]*>([\s\S]*?)<\/Mermaid>/g, (_, body) => `\n${marker("mermaidBlock", body)}\n`);
+  out = replaceBreaksOutsideFences(out);
 
   out = out.replace(/<Card\b([^>]*)\/>/g, (_, attrs) => `${marker("cardSelf", attrs)}\n`);
   out = out.replace(/<Card\b([^>]*)>/g, (_, attrs) => `\n${marker("cardOpen", attrs)}\n`);
@@ -254,6 +254,23 @@ function preprocess(input) {
   out = out.replace(/<([A-Z][A-Za-z0-9_.-]*)([^>]*)>/g, (_, name, attrs) => escapeHtml(`<${name}${attrs}>`));
   out = out.replace(/<\/([A-Z][A-Za-z0-9_.-]*)>/g, (_, name) => escapeHtml(`</${name}>`));
   return dedentComponentChildren(out);
+}
+
+function replaceBreaksOutsideFences(input) {
+  const lines = input.split("\n");
+  let fence = null;
+  return lines.map((line) => {
+    const marker = line.match(/^ {0,3}(`{3,}|~{3,})/)?.[1];
+    if (marker) {
+      if (!fence) {
+        fence = { char: marker[0], length: marker.length };
+      } else if (marker[0] === fence.char && marker.length >= fence.length) {
+        fence = null;
+      }
+      return line;
+    }
+    return fence ? line : line.replace(/<br\s*\/?>/gi, "\n");
+  }).join("\n");
 }
 
 function postprocess(html) {

--- a/scripts/docs-site/smoke.mjs
+++ b/scripts/docs-site/smoke.mjs
@@ -310,6 +310,8 @@ for (const marker of [
   'class="oc-tile-group"',
   'class="oc-tile"',
   'class="oc-mermaid"',
+  'Ready&lt;br&gt;state',
+  'Broken --&gt;',
   'data-code-copy',
   'class="code-line is-highlighted"',
   'data-prompt-copy',

--- a/scripts/docs-site/visual-smoke.mjs
+++ b/scripts/docs-site/visual-smoke.mjs
@@ -74,6 +74,10 @@ async function checkDesktop() {
   await expectVisible(page, ".oc-tile-group .oc-tile", "tiles");
   await expectVisible(page, ".oc-mermaid", "mermaid block");
   await page.locator(".oc-mermaid.is-rendered svg").first().waitFor({ state: "visible", timeout: 10000 });
+  await page.waitForFunction(() =>
+    [...document.querySelectorAll(".oc-mermaid.is-rendered")]
+      .some((block) => block.getAttribute("data-mermaid")?.includes("<br>") && block.querySelector("svg"))
+  );
   await page.locator(".oc-mermaid.is-error pre code").first().waitFor({ state: "visible", timeout: 10000 });
   const mermaidErrorLeak = await page.evaluate(() => ({
     bodyText: document.body.innerText.includes("Syntax error in text"),


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`). This is an AI-assisted follow-up PR prepared from a local maintainer checkout.

## Summary

The Mermaid bomb fix is merged in #11, but one existing valid chart still exposed a separate renderer risk.
The docs preprocessor was turning `<br>` inside Mermaid fences into real newlines before Mermaid rendered the diagram.
This change preserves fenced Mermaid source while keeping the existing `<br>` behavior for normal prose, so valid charts with Mermaid line breaks keep rendering.

Follow-up to #11.

## What Changed

The docs shell now avoids applying the global HTML break conversion inside fenced code blocks.
That keeps Mermaid diagrams with labels like `Ready<br>state` intact before the client renderer sees them.

- Added `replaceBreaksOutsideFences()` in `scripts/docs-site/mdx-ish.mjs`.
- Moved `<Mermaid>` component extraction before break replacement so component bodies are preserved too.
- Added a valid Mermaid fixture that uses `<br>` and an invalid fixture marker to the smoke coverage.
- Added a visual-smoke assertion that a `<br>` Mermaid diagram renders as SVG.

## Testing

I tested the exact existing chart shape that was risky and the docs shell gates that cover renderer changes.
The generated docs build and smoke gate passed, and browser checks confirmed valid Mermaid charts still render.

- `node --check scripts/docs-site/smoke.mjs && node --check scripts/docs-site/mdx-ish.mjs && node --check scripts/docs-site/visual-smoke.mjs`
- `make docs-check`
- Generated-site Playwright sweep: 209 Mermaid pages, 228 Mermaid blocks, 228 rendered, 0 failures.
- Targeted post-build Playwright check for `/concepts/architecture`, `/start/openclaw`, and `/__elements`: architecture/start rendered their `<br>` charts; the hidden invalid fixture stayed contained with no leaked parser-error SVG.
- `git diff --check`

## Real behavior proof

Behavior addressed: Existing Mermaid charts that use `<br>` inside diagram labels keep rendering after the Mermaid error containment fix.
Real environment tested: Local generated `dist/docs-site` served over an ephemeral `127.0.0.1` HTTP server with Playwright Chromium.
Exact steps or command run after this patch: Built with `make docs-check`, swept every generated non-fixture page containing Mermaid, then loaded `/concepts/architecture`, `/start/openclaw`, and `/__elements` in Chromium.
Evidence after fix: The full sweep reported `{"pages":209,"totalBlocks":228,"totalRendered":228,"failures":[]}`.
Observed result after fix: Existing Mermaid pages rendered successfully, `<br>` diagrams rendered as SVG, and the intentionally invalid fixture did not leak Mermaid's "Syntax error in text" artifact.
What was not tested: I did not rerun the older `npm run docs:visual` end-to-end because it previously passed the Mermaid assertions and then failed on an unrelated unauthenticated local docs-chat sidebar assertion.

## Risks

Risk is low because the change narrows preprocessing instead of broadening it.
Normal prose still converts `<br>` to line breaks, while fenced code and Mermaid source are preserved for the renderer.
