### PR TITLE
fix(docs): route edit source links to owning repos

### DIFF
--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -8,6 +8,7 @@ import matter from "gray-matter";
 import { ignoredDocDirs, ignoredDocFiles, localeLabels, mintlifyLocaleToDir, rtlLocales } from "./config.mjs";
 import { siteCss, siteJs } from "./assets.mjs";
 import { createMarkdownRenderer, renderMdxish } from "./mdx-ish.mjs";
+import { editSourceUrlForPage, frontmatterSourcePath, readSourceMetadata } from "./edit-source.mjs";
 import { elementsFixture } from "./elements-fixture.mjs";
 import { renderPageOgSvg } from "./og-card-template.mjs";
 
@@ -16,6 +17,7 @@ const docsDir = path.join(root, "docs");
 const siteAssetsDir = path.join(root, "scripts", "docs-site");
 const outDir = path.join(root, "dist", "docs-site");
 const config = JSON.parse(fs.readFileSync(path.join(docsDir, "docs.json"), "utf8"));
+const sourceMetadata = readSourceMetadata(root);
 const md = createMarkdownRenderer();
 const basePath = normalizeBasePath(process.env.DOCS_SITE_BASE_PATH ?? "");
 const legacyBasePath = normalizeBasePath(process.env.DOCS_SITE_LEGACY_BASE_PATH ?? "/docs");
@@ -116,6 +118,7 @@ function collectPages(localeList) {
         slug,
         file,
         rel,
+        sourcePath: frontmatterSourcePath(parsed.data),
         raw,
         title,
         summary: parsed.data.summary ?? "",
@@ -360,8 +363,9 @@ function breadcrumbs(page, nav) {
 
 function pageTools(page) {
   const canonicalUrl = `${docsOrigin()}${pageRoute(page)}`;
-  const editUrl = `https://github.com/openclaw/openclaw/edit/main/docs/${page.rel}`;
-  return `<div class="page-tools" data-page-tools data-page-url="${escapeAttr(canonicalUrl)}"><button type="button" data-copy-page>Copy page</button><a href="${escapeAttr(editUrl)}">Edit source</a></div>`;
+  const editUrl = editSourceUrlForPage(page, sourceMetadata);
+  const editLink = editUrl ? `<a href="${escapeAttr(editUrl)}">Edit source</a>` : "";
+  return `<div class="page-tools" data-page-tools data-page-url="${escapeAttr(canonicalUrl)}"><button type="button" data-copy-page>Copy page</button>${editLink}</div>`;
 }
 
 function pageStatus(page) {

--- a/scripts/docs-site/edit-source.mjs
+++ b/scripts/docs-site/edit-source.mjs
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const defaultSourceRepositories = {
+  openclaw: "openclaw/openclaw",
+  clawhub: "openclaw/clawhub",
+};
+
+export function readSourceMetadata(root) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(root, ".openclaw-sync", "source.json"), "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+export function frontmatterSourcePath(data) {
+  const sourcePath = data?.["x-i18n"]?.source_path;
+  return typeof sourcePath === "string" ? normalizeDocRel(sourcePath) : "";
+}
+
+export function editSourceUrlForPage(page, sourceMetadata = {}) {
+  const target = editSourceTargetForPage(page, sourceMetadata);
+  if (!target) return "";
+  return `https://github.com/${target.repository}/edit/main/${encodePath(target.path)}`;
+}
+
+export function editSourceTargetForPage(page, sourceMetadata = {}) {
+  if (page?.hidden) return null;
+
+  const rel = normalizeDocRel(page?.sourcePath || page?.rel || "");
+  if (!rel || rel.startsWith(".") || rel.includes("\0")) return null;
+
+  if (rel === "clawhub/index.md" || rel.startsWith("clawhub/")) {
+    const sourcePath = clawHubSourcePath(rel);
+    if (!sourcePath) return null;
+    return {
+      owner: "clawhub",
+      repository: sourceRepository(sourceMetadata, "clawhub"),
+      path: `docs/${sourcePath}`,
+    };
+  }
+
+  return {
+    owner: "openclaw",
+    repository: sourceRepository(sourceMetadata, "openclaw"),
+    path: `docs/${rel}`,
+  };
+}
+
+function sourceRepository(sourceMetadata, source) {
+  return normalizeRepositorySlug(
+    sourceMetadata?.sources?.[source]?.repository || (source === "openclaw" ? sourceMetadata?.repository : ""),
+    defaultSourceRepositories[source],
+  );
+}
+
+function clawHubSourcePath(rel) {
+  const inner = rel.slice("clawhub/".length);
+  if (!inner) return "";
+  if (/^index\.mdx?$/iu.test(inner)) return "clawhub.md";
+  return inner.replace(/\/index\.mdx?$/iu, "/README.md");
+}
+
+function normalizeDocRel(value) {
+  const normalized = String(value).replaceAll("\\", "/").replace(/^\/+/, "");
+  const collapsed = path.posix.normalize(normalized);
+  return collapsed === "." || collapsed.startsWith("../") ? "" : collapsed;
+}
+
+function normalizeRepositorySlug(value, fallback) {
+  const raw = String(value || "").trim().replace(/\.git$/u, "").replace(/\/$/u, "");
+  const githubMatch = raw.match(/github\.com[:/]([^/\s]+\/[^/\s]+)$/u);
+  const slug = githubMatch?.[1] ?? raw;
+  return /^[^/\s]+\/[^/\s]+$/u.test(slug) ? slug : fallback;
+}
+
+function encodePath(value) {
+  return String(value).split("/").map(encodeURIComponent).join("/");
+}

--- a/scripts/docs-site/smoke.mjs
+++ b/scripts/docs-site/smoke.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
+import matter from "gray-matter";
+
+import { localeLabels } from "./config.mjs";
+import { editSourceUrlForPage, frontmatterSourcePath, readSourceMetadata } from "./edit-source.mjs";
 
 const root = process.cwd();
 const site = path.join(root, "dist", "docs-site");
+const docsDir = path.join(root, "docs");
+const sourceMetadata = readSourceMetadata(root);
 const expectedOrigin = (process.env.DOCS_SITE_CANONICAL_ORIGIN
   ?? (process.env.DOCS_SITE_CNAME ? `https://${process.env.DOCS_SITE_CNAME}` : "https://docs.openclaw.ai"))
   .replace(/\/$/, "");
@@ -374,6 +380,7 @@ if (elementsIndex.includes('href="http://SKILL.md"')) {
 if (!/class="breadcrumbs"/.test(index) || !/data-copy-page/.test(index) || !/class="page-feedback"/.test(index)) {
   throw new Error("index: page reader affordances are missing");
 }
+assertEditSourceLinks();
 if (!/function initCodeGroups/.test(siteJs) || !/className="oc-code-tab"/.test(siteJs) || !/preferredCodeTab/.test(siteJs)) {
   throw new Error("assets: code group tabs are missing");
 }
@@ -433,3 +440,103 @@ if (!/href="https:\/\/x\.com\/i\/status\/2010878524543131691"/.test(showcase)) {
   throw new Error("showcase: external card href was not rendered");
 }
 console.log(`docs site smoke ok: shell, routing, skin, and hidden fixture checks passed (${artifactMode})`);
+
+function assertEditSourceLinks() {
+  const htmlFiles = walkHtml(site);
+  let checked = 0;
+  let missingEdit = 0;
+  for (const file of htmlFiles) {
+    const rel = path.relative(site, file).replaceAll(path.sep, "/");
+    const html = fs.readFileSync(file, "utf8");
+    if (rel === "__elements/index.html") {
+      if (/data-page-tools|Edit source/.test(html)) {
+        throw new Error("__elements: hidden component fixture should not expose page tools");
+      }
+      continue;
+    }
+
+    const tools = html.match(/<div class="page-tools"[\s\S]*?<\/div>/u)?.[0];
+    if (!tools) continue;
+    checked += 1;
+
+    const page = pageForRenderedHtml(rel);
+    if (!page) {
+      if (/Edit source/.test(tools)) throw new Error(`${rel}: edit source link has no canonical source page`);
+      missingEdit += 1;
+      continue;
+    }
+
+    const expected = editSourceUrlForPage(page, sourceMetadata);
+    const actual = tools.match(/<a href="([^"]+)">Edit source<\/a>/u)?.[1] ?? "";
+    if (!expected) {
+      if (actual) throw new Error(`${rel}: unexpected edit source link ${actual}`);
+      missingEdit += 1;
+      continue;
+    }
+    if (actual !== expected) {
+      throw new Error(`${rel}: edit source link ${actual || "(missing)"} should be ${expected}`);
+    }
+  }
+
+  if (checked < 100) {
+    throw new Error(`edit source audit: expected many rendered page tools, checked ${checked}`);
+  }
+
+  assertEditSourceSample("clawhub/index.html", "https://github.com/openclaw/clawhub/edit/main/docs/clawhub.md");
+  assertEditSourceSample("clawhub/publishing/index.html", "https://github.com/openclaw/clawhub/edit/main/docs/publishing.md");
+  assertEditSourceSample("ar/clawhub/publishing/index.html", "https://github.com/openclaw/clawhub/edit/main/docs/publishing.md");
+  assertEditSourceSample("de/channels/index.html", "https://github.com/openclaw/openclaw/edit/main/docs/channels/index.md");
+  if (missingEdit > 0) {
+    console.log(`edit source audit: ${missingEdit} page tool(s) intentionally have no edit source link`);
+  }
+}
+
+function assertEditSourceSample(rel, expected) {
+  const file = path.join(site, rel);
+  if (!fs.existsSync(file)) {
+    throw new Error(`edit source audit: missing sample ${rel}`);
+  }
+  const html = fs.readFileSync(file, "utf8");
+  if (!html.includes(`href="${expected}"`)) {
+    throw new Error(`${rel}: expected edit source link ${expected}`);
+  }
+}
+
+function pageForRenderedHtml(htmlRel) {
+  const segments = htmlRel.split("/");
+  if (segments.at(-1) !== "index.html") return null;
+  segments.pop();
+
+  const locale = localeLabels[segments[0]] ? segments.shift() : "en";
+  const route = segments.join("/");
+  const base = locale === "en" ? docsDir : path.join(docsDir, locale);
+  const sourceFile = findSourcePageFile(base, route);
+  if (!sourceFile) return null;
+
+  const raw = fs.readFileSync(sourceFile, "utf8");
+  const parsed = matter(raw);
+  return {
+    rel: path.relative(base, sourceFile).replaceAll(path.sep, "/"),
+    sourcePath: frontmatterSourcePath(parsed.data),
+  };
+}
+
+function findSourcePageFile(base, route) {
+  const candidates = route
+    ? [`${route}/index.md`, `${route}/index.mdx`, `${route}.md`, `${route}.mdx`]
+    : ["index.md", "index.mdx"];
+  for (const candidate of candidates) {
+    const file = path.join(base, candidate);
+    if (fs.existsSync(file)) return file;
+  }
+  return "";
+}
+
+function walkHtml(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return walkHtml(full);
+    return entry.isFile() && entry.name.endsWith(".html") ? [full] : [];
+  });
+}


### PR DESCRIPTION
## Summary

- Route edit-source links through the docs source map so mirrored pages point back to their owning repo/path.
- Keep ClawHub-owned docs pointing at `openclaw/clawhub` instead of the mirror repo.
- Add smoke coverage for source-map-backed edit links.

## Proof

- `/clawhub/` `Edit source` now targets `https://github.com/openclaw/clawhub/edit/main/docs/clawhub.md`.
- `/channels/` `Edit source` still targets `https://github.com/openclaw/openclaw/edit/main/docs/channels/index.md`.

## Verification

- `git merge-tree --write-tree origin/main HEAD`
- `git diff --check origin/main..HEAD`
- `node --check scripts/docs-site/assets.mjs scripts/docs-site/build.mjs scripts/docs-site/smoke.mjs`

Full docs build intentionally not run.

