### PR TITLE
ci: fail incomplete docs translation runs

### DIFF
--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -326,9 +326,11 @@ jobs:
               | node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync(0, "utf8")); process.stdout.write(data.sha || "");'
           )"
           if [ "${current_source_sha}" != "${SOURCE_SHA}" ]; then
-            echo "stale=true" >> "${GITHUB_OUTPUT}"
-            echo "changed_count=0" >> "${GITHUB_OUTPUT}"
-            echo "incomplete_count=0" >> "${GITHUB_OUTPUT}"
+            {
+              echo "stale=true"
+              echo "changed_count=0"
+              echo "incomplete_count=0"
+            } >> "${GITHUB_OUTPUT}"
             {
               echo "### Translation finalizer skipped"
               echo

--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -328,6 +328,7 @@ jobs:
           if [ "${current_source_sha}" != "${SOURCE_SHA}" ]; then
             echo "stale=true" >> "${GITHUB_OUTPUT}"
             echo "changed_count=0" >> "${GITHUB_OUTPUT}"
+            echo "incomplete_count=0" >> "${GITHUB_OUTPUT}"
             {
               echo "### Translation finalizer skipped"
               echo
@@ -418,6 +419,11 @@ jobs:
           with out.open("a", encoding="utf-8") as fh:
             fh.write("stale=false\n")
             fh.write(f"changed_count={len(status)}\n")
+            fh.write(f"incomplete_count={len(missing_or_failed)}\n")
+
+          incomplete_path = Path(".openclaw-sync/i18n-incomplete-locales.txt")
+          incomplete_path.parent.mkdir(exist_ok=True)
+          incomplete_path.write_text("\n".join(missing_or_failed) + ("\n" if missing_or_failed else ""), encoding="utf-8")
 
           summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
           with summary.open("a", encoding="utf-8") as fh:
@@ -509,3 +515,13 @@ jobs:
         run: |
           set -euo pipefail
           gh workflow run pages.yml --ref main
+
+      - name: Fail incomplete translation run
+        if: steps.apply.outputs.stale != 'true' && steps.apply.outputs.incomplete_count != '0'
+        run: |
+          {
+            echo "Translation finished with missing or failed locales."
+            echo "Successful locale artifacts were applied before this failure when available."
+            cat .openclaw-sync/i18n-incomplete-locales.txt
+          } >&2
+          exit 1


### PR DESCRIPTION
## Summary

- keep applying and committing successful locale artifacts in Translate All
- mark the finalizer output as incomplete when locale artifacts are missing or carry `failed_reason`
- fail the Translate All run after successful artifacts are processed when the translation set is incomplete

## Related CI / Incident

- Translate All run: https://github.com/openclaw/docs/actions/runs/27171783139
- The run concluded as GitHub Actions success even though locale artifacts reported `failed_reason: translation failed` and `changed_count: 0`.
- The finalizer summary ended with `changed paths: 0`, so stale localized files such as `docs/zh-CN/channels/line.md` were not rewritten while the workflow still looked green.
- The source-side translation failure fix is tracked separately in https://github.com/openclaw/openclaw/pull/91578.

## Verification

- local finalizer fixture: complete artifact set reports `incomplete_count=0`
- local finalizer fixture: one failed locale plus one missing locale reports `incomplete_count=2` and writes the failed/missing locale list
- `python -c` YAML parse for `.github/workflows/translate-all.yml`
- `actionlint .github/workflows/translate-all.yml`
- `git diff --check`
- autoreview clean: no accepted/actionable findings

## Notes

This preserves the existing partial-success design from `ci: tolerate failed locale translation artifacts`: successful locale artifacts can still be applied and deployed. The run is only marked failed at the end so maintainers do not mistake an incomplete or zero-change translation pass for a fully successful refresh.
