### PR TITLE
ci: split docs translation lanes

### DIFF
--- a/.github/workflows/translate-finalize-reusable.yml
+++ b/.github/workflows/translate-finalize-reusable.yml
@@ -1,0 +1,338 @@
+name: Translate Finalize Reusable
+
+on:
+  workflow_call:
+    inputs:
+      source_sha:
+        required: true
+        type: string
+      mode:
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  finalize:
+    name: Commit successful locale artifacts
+    runs-on: ubuntu-latest
+    concurrency:
+      group: docs-i18n-finalize
+      cancel-in-progress: false
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download locale artifacts
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: i18n-*-${{ inputs.source_sha }}
+          path: .openclaw-sync/i18n-artifacts
+
+      - name: Apply locale artifacts
+        id: apply
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          MODE: ${{ inputs.mode }}
+          EXPECTED_LOCALES: zh-cn=zh-CN zh-tw=zh-TW ja-jp=ja-JP es=es pt-br=pt-BR ko=ko de=de fr=fr ar=ar it=it vi=vi nl=nl fa=fa tr=tr uk=uk id=id pl=pl th=th
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main:refs/remotes/origin/main
+          git checkout -B main refs/remotes/origin/main
+
+          current_source_sha="$(
+            git show HEAD:.openclaw-sync/source.json \
+              | node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync(0, "utf8")); process.stdout.write(data.sha || "");'
+          )"
+          export CURRENT_SOURCE_SHA="${current_source_sha}"
+
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          import shutil
+          import subprocess
+          from pathlib import Path
+
+          source_sha = os.environ["SOURCE_SHA"]
+          current_source_sha = os.environ["CURRENT_SOURCE_SHA"]
+          source_current = current_source_sha == source_sha
+          expected_pairs = os.environ["EXPECTED_LOCALES"].split()
+          expected = dict(pair.split("=", 1) for pair in expected_pairs)
+          root = Path(".openclaw-sync/i18n-artifacts")
+          source_hash_re = re.compile(r'^x-i18n:\n(?:[ \t]+.*\n)*?[ \t]+source_hash: ([0-9a-f]{64})$', re.M)
+
+          applied = []
+          no_changes = []
+          stale = []
+          invalid = []
+          failed = []
+          skipped_stale_pages = []
+          skipped_stale_deletes = []
+          skipped_stale_tm = []
+          seen = set()
+
+          def read_lines(path: Path) -> list[str]:
+            if not path.exists():
+              return []
+            return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+          def source_hash(path: Path) -> str:
+            return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          def translated_source_hash(path: Path) -> str:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            match = source_hash_re.search(text)
+            if not match:
+              return ""
+            return match.group(1).strip()
+
+          def locale_doc_source(locale: str, rel: str) -> Path | None:
+            prefix = f"docs/{locale}/"
+            if not rel.startswith(prefix):
+              return None
+            return Path("docs") / rel[len(prefix):]
+
+          def tm_path(locale: str, rel: str) -> bool:
+            return rel == f"docs/.i18n/{locale}.tm.jsonl"
+
+          def should_apply_changed(locale: str, rel: str, payload_file: Path) -> tuple[bool, str]:
+            if source_current:
+              return True, ""
+            if tm_path(locale, rel):
+              return False, f"{locale}: translation memory"
+            source = locale_doc_source(locale, rel)
+            if source is None or payload_file.suffix.lower() not in {".md", ".mdx"}:
+              return False, f"{locale}: unsupported stale path {rel}"
+            if not source.exists():
+              return False, f"{locale}: source missing for {rel}"
+            payload_hash = translated_source_hash(payload_file)
+            current_hash = source_hash(source)
+            if payload_hash == current_hash:
+              return True, ""
+            return False, f"{locale}: {rel}"
+
+          def should_apply_deleted(locale: str, rel: str) -> tuple[bool, str]:
+            if source_current:
+              return True, ""
+            if tm_path(locale, rel):
+              return False, f"{locale}: translation memory"
+            source = locale_doc_source(locale, rel)
+            if source is None:
+              return False, f"{locale}: unsupported stale delete {rel}"
+            if source.exists():
+              return False, f"{locale}: {rel}"
+            return True, ""
+
+          if root.exists():
+            for artifact in sorted(path for path in root.iterdir() if path.is_dir()):
+              metadata_path = artifact / "metadata.json"
+              if not metadata_path.exists():
+                invalid.append(f"{artifact.name}: missing metadata.json")
+                continue
+              try:
+                metadata = json.loads(metadata_path.read_text())
+              except Exception as exc:
+                invalid.append(f"{artifact.name}: invalid metadata ({exc})")
+                continue
+
+              slug = metadata.get("locale_slug")
+              locale = metadata.get("locale")
+              if slug not in expected or expected[slug] != locale:
+                invalid.append(f"{artifact.name}: unexpected locale {locale!r}/{slug!r}")
+                continue
+              if metadata.get("source_sha") != source_sha:
+                stale.append(f"{locale}: {metadata.get('source_sha')}")
+                continue
+
+              seen.add(slug)
+              failed_reason = metadata.get("failed_reason") or ""
+              if failed_reason:
+                failed.append(f"{locale}: {failed_reason}")
+                continue
+
+              changed = read_lines(artifact / "changed-files.txt")
+              deleted = read_lines(artifact / "deleted-files.txt")
+              payload = artifact / "payload"
+              applied_any = False
+
+              for rel in deleted:
+                apply_delete, reason = should_apply_deleted(locale, rel)
+                if not apply_delete:
+                  skipped_stale_deletes.append(reason)
+                  continue
+                path = Path(rel)
+                if path.exists():
+                  path.unlink()
+                  applied_any = True
+
+              for rel in changed:
+                source = payload / rel
+                if not source.exists():
+                  invalid.append(f"{artifact.name}: missing payload file {rel}")
+                  continue
+                apply_change, reason = should_apply_changed(locale, rel, source)
+                if not apply_change:
+                  if "translation memory" in reason:
+                    skipped_stale_tm.append(reason)
+                  else:
+                    skipped_stale_pages.append(reason)
+                  continue
+                target = Path(rel)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, target)
+                applied_any = True
+
+              if applied_any:
+                applied.append(locale)
+              elif changed or deleted:
+                no_changes.append(f"{locale} (all stale)")
+              else:
+                no_changes.append(locale)
+
+          missing = [expected[slug] for slug in expected if slug not in seen]
+          missing_or_failed = missing + failed
+          status = subprocess.run(
+              ["git", "status", "--porcelain", "--untracked-files=all", "--", "docs"],
+              check=True,
+              text=True,
+              stdout=subprocess.PIPE,
+          ).stdout.splitlines()
+
+          out = Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as fh:
+            fh.write("stale=false\n")
+            fh.write(f"base_source_sha={current_source_sha}\n")
+            fh.write(f"changed_count={len(status)}\n")
+            fh.write(f"incomplete_count={len(missing_or_failed)}\n")
+
+          incomplete_path = Path(".openclaw-sync/i18n-incomplete-locales.txt")
+          incomplete_path.parent.mkdir(exist_ok=True)
+          incomplete_path.write_text("\n".join(missing_or_failed) + ("\n" if missing_or_failed else ""), encoding="utf-8")
+
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a", encoding="utf-8") as fh:
+            fh.write("### Translation finalizer\n\n")
+            fh.write(f"- mode: `{os.environ['MODE']}`\n")
+            fh.write(f"- artifact source: `{source_sha}`\n")
+            fh.write(f"- current source: `{current_source_sha}`\n")
+            fh.write(f"- changed paths: `{len(status)}`\n")
+            if applied:
+              fh.write(f"- applied locales: {', '.join(applied)}\n")
+            if no_changes:
+              fh.write(f"- locales with no changes: {', '.join(no_changes)}\n")
+            if missing_or_failed:
+              fh.write(f"- missing or failed locales: {', '.join(missing_or_failed)}\n")
+            if stale:
+              fh.write(f"- stale artifacts ignored: {', '.join(stale)}\n")
+            if skipped_stale_pages:
+              sample = ", ".join(skipped_stale_pages[:20])
+              fh.write(f"- stale pages skipped: `{len(skipped_stale_pages)}`")
+              if sample:
+                fh.write(f" ({sample})")
+              fh.write("\n")
+            if skipped_stale_deletes:
+              sample = ", ".join(skipped_stale_deletes[:20])
+              fh.write(f"- stale deletes skipped: `{len(skipped_stale_deletes)}`")
+              if sample:
+                fh.write(f" ({sample})")
+              fh.write("\n")
+            if skipped_stale_tm:
+              sample = ", ".join(sorted(set(skipped_stale_tm))[:20])
+              fh.write(f"- stale translation memory skipped: `{len(skipped_stale_tm)}`")
+              if sample:
+                fh.write(f" ({sample})")
+              fh.write("\n")
+            if invalid:
+              fh.write(f"- invalid artifacts ignored: {'; '.join(invalid)}\n")
+
+          print(f"changed paths: {len(status)}")
+          PY
+
+      - name: Set up Node
+        if: steps.apply.outputs.changed_count != '0'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install
+        if: steps.apply.outputs.changed_count != '0'
+        run: npm ci
+
+      - name: Install librsvg2-bin
+        if: steps.apply.outputs.changed_count != '0'
+        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
+
+      - name: Check aggregate docs
+        if: steps.apply.outputs.changed_count != '0'
+        run: npm run docs:check
+
+      - name: Commit aggregate translation refresh
+        if: steps.apply.outputs.changed_count != '0'
+        env:
+          BASE_SOURCE_SHA: ${{ steps.apply.outputs.base_source_sha }}
+        run: |
+          set -euo pipefail
+
+          remote_source_sha() {
+            git show refs/remotes/origin/main:.openclaw-sync/source.json 2>/dev/null \
+              | node -e 'const fs = require("node:fs"); try { const data = JSON.parse(fs.readFileSync(0, "utf8")); if (data.sha) process.stdout.write(data.sha); } catch {}' \
+              || true
+          }
+
+          ensure_base_current() {
+            current_source_sha="$(remote_source_sha)"
+            if [ -n "${current_source_sha}" ] && [ "${current_source_sha}" != "${BASE_SOURCE_SHA}" ]; then
+              echo "Source moved from ${BASE_SOURCE_SHA} to ${current_source_sha}; skipping aggregate translation commit."
+              exit 0
+            fi
+          }
+
+          git config user.name "openclaw-docs-i18n[bot]"
+          git config user.email "openclaw-docs-i18n[bot]@users.noreply.github.com"
+          git add docs
+          git commit -m "chore(i18n): refresh translations"
+
+          for attempt in 1 2 3 4 5; do
+            if git fetch origin main:refs/remotes/origin/main; then
+              ensure_base_current
+              if git rebase origin/main; then
+                ensure_base_current
+                if git push origin HEAD:main; then
+                  exit 0
+                fi
+              fi
+              git rebase --abort >/dev/null 2>&1 || true
+            fi
+            echo "Aggregate translation push attempt ${attempt} failed; retrying."
+            sleep $((attempt * 2))
+          done
+
+          echo "Failed to push aggregate translations after retries."
+          exit 1
+
+      - name: Dispatch aggregate docs deploy
+        if: steps.apply.outputs.changed_count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run pages.yml --ref main
+
+      - name: Fail incomplete translation run
+        if: steps.apply.outputs.stale != 'true' && steps.apply.outputs.incomplete_count != '0'
+        run: |
+          {
+            echo "Translation finished with missing or failed locales."
+            echo "Successful locale artifacts were applied before this failure when available."
+            cat .openclaw-sync/i18n-incomplete-locales.txt
+          } >&2
+          exit 1

--- a/.github/workflows/translate-incremental.yml
+++ b/.github/workflows/translate-incremental.yml
@@ -1,34 +1,30 @@
-name: Translate Full
+name: Translate Incremental
 
 on:
   push:
     branches:
       - main
     paths:
-      - "docs/.i18n/glossary.*.json"
-  repository_dispatch:
-    types:
-      - translate-all-release
-      - translate-ar-release
-      - translate-de-release
-      - translate-es-release
-      - translate-fa-release
-      - translate-fr-release
-      - translate-id-release
-      - translate-it-release
-      - translate-ja-jp-release
-      - translate-ko-release
-      - translate-nl-release
-      - translate-pl-release
-      - translate-pt-br-release
-      - translate-th-release
-      - translate-tr-release
-      - translate-uk-release
-      - translate-vi-release
-      - translate-zh-cn-release
-      - translate-zh-tw-release
-  schedule:
-    - cron: "17 3 * * 0"
+      - "docs/**"
+      - "!docs/ar/**"
+      - "!docs/de/**"
+      - "!docs/es/**"
+      - "!docs/fa/**"
+      - "!docs/fr/**"
+      - "!docs/id/**"
+      - "!docs/it/**"
+      - "!docs/ja-JP/**"
+      - "!docs/ko/**"
+      - "!docs/nl/**"
+      - "!docs/pl/**"
+      - "!docs/pt-BR/**"
+      - "!docs/th/**"
+      - "!docs/tr/**"
+      - "!docs/uk/**"
+      - "!docs/vi/**"
+      - "!docs/zh-CN/**"
+      - "!docs/zh-TW/**"
+      - "!docs/.i18n/**"
   workflow_dispatch:
     inputs:
       cooldown_seconds:
@@ -42,7 +38,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: docs-i18n-full
+  group: docs-i18n-incremental
   cancel-in-progress: true
 
 jobs:
@@ -65,17 +61,18 @@ jobs:
         id: prepare
         env:
           EVENT_NAME: ${{ github.event_name }}
-          REQUESTED_COOLDOWN_SECONDS: ${{ inputs.cooldown_seconds || github.event.client_payload.cooldown_seconds || '' }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          REQUESTED_COOLDOWN_SECONDS: ${{ inputs.cooldown_seconds || '' }}
           DEFAULT_COOLDOWN_SECONDS: ${{ vars.OPENCLAW_DOCS_TRANSLATION_COOLDOWN_SECONDS || '3600' }}
           DEFAULT_MAX_WAIT_SECONDS: ${{ vars.OPENCLAW_DOCS_TRANSLATION_MAX_WAIT_SECONDS || vars.OPENCLAW_DOCS_TRANSLATION_COOLDOWN_SECONDS || '3600' }}
         run: |
           set -euo pipefail
 
-          mode="full"
+          mode="incremental"
           cooldown="${REQUESTED_COOLDOWN_SECONDS}"
           if [ -z "${cooldown}" ]; then
             case "${EVENT_NAME}" in
-              push|repository_dispatch) cooldown="${DEFAULT_COOLDOWN_SECONDS}" ;;
+              push) cooldown="${DEFAULT_COOLDOWN_SECONDS}" ;;
               *) cooldown="0" ;;
             esac
           fi
@@ -134,22 +131,51 @@ jobs:
             fi
           done
 
+          should_translate="true"
+          if [ "${EVENT_NAME}" = "push" ] && [ -n "${BEFORE_SHA}" ]; then
+            changed_paths="$(git diff --name-only "${BEFORE_SHA}" "${publish_ref}" || true)"
+            if printf '%s\n' "${changed_paths}" | grep -Eq '^docs/\.i18n/glossary\..*\.json$'; then
+              echo "Glossary changed; full lane owns this translation."
+              should_translate="false"
+            elif ! printf '%s\n' "${changed_paths}" | node -e '
+              const fs = require("node:fs");
+              const locales = new Set([
+                "ar", "de", "es", "fa", "fr", "id", "it", "ja-JP", "ko", "nl",
+                "pl", "pt-BR", "th", "tr", "uk", "vi", "zh-CN", "zh-TW",
+              ]);
+              const paths = fs.readFileSync(0, "utf8").split(/\r?\n/).filter(Boolean);
+              const hasTranslatable = paths.some((path) => {
+                if (!path.startsWith("docs/")) return false;
+                const rel = path.slice("docs/".length);
+                const first = rel.split("/", 1)[0];
+                if (locales.has(first)) return false;
+                if (rel.startsWith(".generated/") || rel.startsWith(".i18n/")) return false;
+                return /\.(md|mdx)$/i.test(rel);
+              });
+              process.exit(hasTranslatable ? 0 : 1);
+            '
+            then
+              echo "No translatable docs changed after cooldown; skipping translation matrix."
+              should_translate="false"
+            fi
+          fi
+
           {
             echo "mode=${mode}"
             echo "publish_ref=${publish_ref}"
-            echo "should_translate=true"
+            echo "should_translate=${should_translate}"
             echo "source_repository=${source_repository}"
             echo "source_sha=${source_sha}"
           } >> "${GITHUB_OUTPUT}"
 
           {
-            echo "### Translate Full"
+            echo "### Translate Incremental"
             echo
             echo "- mode: \`${mode}\`"
             echo "- publish ref: \`${publish_ref}\`"
             echo "- source: \`${source_repository}@${source_sha}\`"
             echo "- cooldown seconds: \`${cooldown}\`"
-            echo "- should translate: \`true\`"
+            echo "- should translate: \`${should_translate}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   translate:

--- a/.github/workflows/translate-locale-reusable.yml
+++ b/.github/workflows/translate-locale-reusable.yml
@@ -55,23 +55,9 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `sha=${data.sha}\n`);
           NODE
 
-      - name: Skip stale queued source
+      - name: Allow requested source
         id: stale
-        env:
-          SOURCE_SHA: ${{ steps.meta.outputs.sha }}
         run: |
-          set -euo pipefail
-          git fetch origin main:refs/remotes/origin/main
-          remote_source_sha="$(
-            git show refs/remotes/origin/main:.openclaw-sync/source.json 2>/dev/null \
-              | node -e 'const fs = require("node:fs"); try { const data = JSON.parse(fs.readFileSync(0, "utf8")); if (data.sha) process.stdout.write(data.sha); } catch {}' \
-              || true
-          )"
-          if [ -n "$remote_source_sha" ] && [ "$remote_source_sha" != "$SOURCE_SHA" ]; then
-            echo "Skipping stale queued translation for ${SOURCE_SHA}; origin/main mirrors ${remote_source_sha}."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Checkout source repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ Publish mirror for `docs.openclaw.ai`. Source repo: `openclaw/openclaw`.
 
 - Source sync starts in `openclaw/openclaw/.github/workflows/docs-sync-publish.yml`.
 - Sync mirrors `openclaw/openclaw/docs/**` into this repo and updates `.openclaw-sync/source.json`.
-- `translate-all.yml` runs from this repo after debounced docs changes, weekly schedule, release dispatch, or manual dispatch.
+- `translate-incremental.yml` runs normal debounced docs changes.
+- `translate-all.yml` runs full reconciliation from glossary changes, weekly schedule, release dispatch, or manual dispatch.
 - Translation pending logic compares source file SHA-256 with each page's `x-i18n.source_hash`.
-- Locale workers upload artifacts; the finalizer pushes one aggregate i18n commit.
+- Locale workers upload artifacts; the shared finalizer pushes one aggregate i18n commit.
 - If translated MDX fails, the repair step may touch only `docs/<locale>/**` and `docs/.i18n/<locale>.tm.jsonl`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Source of truth lives in [`openclaw/openclaw`](https://github.com/openclaw/openc
 1. English docs are authored in `openclaw/openclaw`.
 2. `openclaw/openclaw/.github/workflows/docs-sync-publish.yml` mirrors the docs tree into this repo.
 3. This repo stores the published docs tree plus generated locale output.
-4. `openclaw/docs/.github/workflows/translate-all.yml` debounces docs changes, runs locale translation in parallel, and commits one aggregate locale refresh.
+4. `openclaw/docs/.github/workflows/translate-incremental.yml` debounces normal docs changes, while `translate-all.yml` handles full reconciliation for glossary changes, weekly schedule, release dispatch, or manual dispatch.
 5. `.github/workflows/r2-pages.yml` builds the full unpruned static site and uploads changed objects to Cloudflare R2.
 6. `.github/workflows/pages.yml` deploys the small Cloudflare Worker router that preserves clean URLs and markdown negotiation while reading docs from R2.
 
@@ -24,6 +24,7 @@ Source of truth lives in [`openclaw/openclaw`](https://github.com/openclaw/openc
 - If files changed, only the pending files are translated.
 - The workflow retries transient model-format failures.
 - Locale outputs are uploaded as artifacts first, then committed together by the finalizer.
+- Incremental and full translation use separate concurrency lanes, so small docs edits do not cancel weekly or glossary-triggered full reconciliation.
 - The weekly scheduled run uses full reconciliation mode to repair missed or flaky locale updates.
 
 ## Editing rules

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -7,6 +7,7 @@ Internal note for the docs publish pipeline. This file is under `docs/.i18n`, wh
 - English docs deploy quickly after every source docs sync.
 - Locale translation does not run for every hot `main` commit.
 - Translation work is debounced so a burst of docs commits becomes one translation wave.
+- Incremental translation and full reconciliation use separate concurrency lanes.
 - Locale jobs translate only pages whose source hash changed since the last successful locale output.
 - Successful locale outputs are committed together, even if one or more locale jobs fail.
 - A weekly reconciliation reruns every locale/page path to repair missed or flaky translations.
@@ -15,25 +16,34 @@ Internal note for the docs publish pipeline. This file is under `docs/.i18n`, wh
 
 1. `openclaw/openclaw` syncs English docs into `openclaw/docs`.
 2. GitHub Pages deploys English/source changes immediately from the sync commit.
-3. `Translate All` is triggered by the sync commit, release dispatch, manual dispatch, or weekly schedule.
-4. The coordinator waits a cooldown window before starting translation.
-5. After the cooldown, the coordinator reads the current `origin/main` source metadata.
-6. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
-7. Per-locale translation jobs run in parallel with `fail-fast: false`.
-8. Each locale job uploads an artifact for the requested source SHA.
-9. The finalizer downloads available artifacts, ignores stale or failed payloads, and pushes one aggregate i18n commit.
-10. After the aggregate commit lands, the finalizer dispatches the Pages deploy once.
-11. The Pages workflow dispatches live smoke after deployment.
+3. `Translate Incremental` is triggered by normal source docs changes.
+4. `Translate Full` is triggered by glossary changes, release dispatch, manual dispatch, or weekly schedule.
+5. The selected coordinator waits a cooldown window before starting translation.
+6. After the cooldown, the coordinator reads the current `origin/main` source metadata.
+7. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
+8. Per-locale translation jobs run in parallel with `fail-fast: false`.
+9. Each locale job uploads an artifact for the requested source SHA.
+10. The shared finalizer downloads available artifacts and pushes one aggregate i18n commit.
+11. After the aggregate commit lands, the finalizer dispatches the Pages deploy once.
+12. The Pages workflow dispatches live smoke after deployment.
 
 ## Debounce policy
 
-The coordinator waits 1 hour after a docs sync or release dispatch, then re-reads `origin/main`.
+The active coordinator waits 1 hour after a docs sync or release dispatch, then re-reads `origin/main`.
 
 The default cooldown is controlled by the publish repo variable `OPENCLAW_DOCS_TRANSLATION_COOLDOWN_SECONDS`, which defaults to `3600`. Repository dispatch callers may override it with `client_payload.cooldown_seconds`, and manual runs may set `cooldown_seconds`.
 
 If `.openclaw-sync/source.json` changed during the wait, it waits again from the newer state. If `main` keeps moving, the wait is capped by `OPENCLAW_DOCS_TRANSLATION_MAX_WAIT_SECONDS`, which defaults to the cooldown value. The newest observed state is translated after the cap.
 
 Manual and weekly runs do not wait by default.
+
+## Concurrency lanes
+
+Full reconciliation uses the `docs-i18n-full` concurrency group and cancels older full runs. Full mode covers weekly reconciliation, glossary changes, release dispatch, and manual full runs.
+
+Incremental translation uses the `docs-i18n-incremental` concurrency group and cancels older incremental runs. It does not cancel full reconciliation.
+
+The finalizer uses the shared `docs-i18n-finalize` concurrency group with `cancel-in-progress: false`, so aggregate pushes are serialized across both lanes.
 
 ## Incremental translation
 
@@ -48,6 +58,8 @@ Normal runs translate only:
 Internal files under `docs/.i18n/**` are not translation inputs. Push-triggered runs that only change internal i18n files skip before the locale matrix.
 
 If a locale job fails, its artifact is marked failed and carries no payload. The finalizer still commits successful locales. The failed locale remains stale and is picked up by the next incremental run because its source hashes still do not match.
+
+If a run finishes after the source SHA has moved, the finalizer no longer drops the whole artifact set. It applies localized pages whose `x-i18n.source_hash` still matches the current English source file, skips stale pages, applies deletes only when the current English source is also gone, and skips translation memory updates from stale runs.
 
 ## Artifact contract
 
@@ -67,7 +79,7 @@ payload/docs/<locale>/**
 payload/docs/.i18n/<locale>.tm.jsonl
 ```
 
-`metadata.json` includes the locale, locale slug, source SHA, pending count, changed count, and any failure reason. The finalizer rejects artifacts whose `source_sha` does not match the current `.openclaw-sync/source.json`.
+`metadata.json` includes the locale, locale slug, source SHA, pending count, changed count, and any failure reason. The finalizer rejects artifacts with the wrong requested `source_sha`; if the requested source is no longer current, it falls back to per-page freshness checks.
 
 The source repo release workflow dispatches one `translate-all-release` event. The coordinator still accepts old per-locale release events for compatibility, but those are only a fallback.
 
@@ -81,7 +93,7 @@ Commit message:
 chore(i18n): refresh translations
 ```
 
-The commit may contain a partial locale set. The job summary lists applied locales, locales with no changes, missing or failed locales, stale artifacts, and invalid artifacts.
+The commit may contain a partial locale set. The job summary lists applied locales, locales with no changes, missing or failed locales, stale artifacts, skipped stale pages, skipped stale deletes, skipped stale translation memory, and invalid artifacts.
 
 ## Weekly reconciliation
 


### PR DESCRIPTION
## Summary

This PR splits docs translation scheduling into two lanes:

- `Translate Full` handles weekly reconciliation, glossary changes, release dispatch, and manual full runs.
- `Translate Incremental` handles normal source docs `.md` / `.mdx` changes.
- Both lanes share a serialized `Translate Finalize Reusable` job so aggregate i18n commits do not race each other.
- The finalizer now handles stale full artifacts per page instead of dropping the whole run: it applies localized pages whose `x-i18n.source_hash` still matches the current English source, skips stale pages/deletes, and skips translation memory from stale-source runs.

## Why

The current `Translate All` workflow puts incremental syncs, scheduled full reconciliation, glossary-triggered full reconciliation, and release-triggered full reconciliation in one `translate-all` concurrency group with `cancel-in-progress: true`.

That causes small main pushes to cancel long-running full reconciliation runs. Recent examples:

- scheduled full run cancelled after a later push: https://github.com/openclaw/docs/actions/runs/27488760322
- release full run cancelled after later sync activity: https://github.com/openclaw/docs/actions/runs/27480122561
- push-triggered runs repeatedly cancelling prior runs on June 13-14: https://github.com/openclaw/docs/actions/runs/27490959146 and https://github.com/openclaw/docs/actions/runs/27494117525

The goal is not to make locale docs perfectly synchronous with English docs. The goal is to prevent full reconciliation from being starved while still keeping incremental updates debounced and cheap.

## Implementation

- `translate-all.yml` is now the full lane with concurrency group `docs-i18n-full`.
- `translate-incremental.yml` is the incremental lane with concurrency group `docs-i18n-incremental`.
- The shared finalizer uses concurrency group `docs-i18n-finalize` with `cancel-in-progress: false` to serialize aggregate pushes from both lanes.
- Locale workers no longer abandon a requested source just because publish `main` moved later; the finalizer is responsible for freshness.
- If artifact `source_sha` is current, the finalizer applies the batch normally.
- If artifact `source_sha` is stale, the finalizer checks each localized page against the current English source hash:
  - matching page hash: apply it
  - mismatched page hash: skip it
  - delete payload: apply only when the current English source is also absent
  - translation memory: skip for stale-source runs
- Workflow docs now describe the dual-lane model and finalizer freshness rules.

## Verification

- `actionlint`
- `git diff --check`
- `git diff --check --no-index /dev/null .github/workflows/translate-incremental.yml`
- `git diff --check --no-index /dev/null .github/workflows/translate-finalize-reusable.yml`
- local finalizer fixture: stale full artifact applies only hash-matching pages, skips stale pages, skips stale translation memory, and applies deletes only when the current English source is absent
- local finalizer fixture: current-source artifact applies page and translation memory changes
- local finalizer fixture: failed locale artifact is counted as incomplete while valid locale payload is partially applied
- `.agents/skills/autoreview/scripts/autoreview --mode local`
