### PR TITLE
ci: shard full docs translations

### DIFF
--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -153,13 +153,14 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
   translate:
-    name: Translate ${{ matrix.locale }}
+    name: Translate ${{ matrix.locale.locale }} shard ${{ matrix.shard_index }}/8
     needs: prepare
     if: needs.prepare.outputs.should_translate == 'true'
     strategy:
       fail-fast: false
+      max-parallel: 54
       matrix:
-        include:
+        locale:
           - locale: zh-CN
             locale_slug: zh-cn
           - locale: zh-TW
@@ -196,13 +197,25 @@ jobs:
             locale_slug: pl
           - locale: th
             locale_slug: th
+        shard_index:
+          - 0
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
     uses: ./.github/workflows/translate-locale-reusable.yml
     with:
-      locale: ${{ matrix.locale }}
-      locale_slug: ${{ matrix.locale_slug }}
+      locale: ${{ matrix.locale.locale }}
+      locale_slug: ${{ matrix.locale.locale_slug }}
       publish_ref: ${{ needs.prepare.outputs.publish_ref }}
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
+      shard_index: ${{ matrix.shard_index }}
+      shard_total: "8"
+      worker_parallel: "2"
     secrets: inherit
 
   finalize:
@@ -215,3 +228,4 @@ jobs:
     with:
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
+      shard_total: "8"

--- a/.github/workflows/translate-finalize-reusable.yml
+++ b/.github/workflows/translate-finalize-reusable.yml
@@ -9,6 +9,9 @@ on:
       mode:
         required: true
         type: string
+      shard_total:
+        required: true
+        type: string
 
 permissions:
   actions: write
@@ -40,6 +43,7 @@ jobs:
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
           MODE: ${{ inputs.mode }}
+          SHARD_TOTAL: ${{ inputs.shard_total }}
           EXPECTED_LOCALES: zh-cn=zh-CN zh-tw=zh-TW ja-jp=ja-JP es=es pt-br=pt-BR ko=ko de=de fr=fr ar=ar it=it vi=vi nl=nl fa=fa tr=tr uk=uk id=id pl=pl th=th
         run: |
           set -euo pipefail
@@ -66,6 +70,9 @@ jobs:
           source_current = current_source_sha == source_sha
           expected_pairs = os.environ["EXPECTED_LOCALES"].split()
           expected = dict(pair.split("=", 1) for pair in expected_pairs)
+          expected_shard_total = int(os.environ["SHARD_TOTAL"])
+          if expected_shard_total < 1:
+            raise SystemExit(f"invalid shard_total: {expected_shard_total}")
           root = Path(".openclaw-sync/i18n-artifacts")
           source_hash_re = re.compile(r'^x-i18n:\n(?:[ \t]+.*\n)*?[ \t]+source_hash: ([0-9a-f]{64})$', re.M)
 
@@ -78,6 +85,11 @@ jobs:
           skipped_stale_deletes = []
           skipped_stale_tm = []
           seen = set()
+
+          def artifact_label(locale: str, shard_index: int) -> str:
+            if expected_shard_total == 1:
+              return locale
+            return f"{locale} shard {shard_index}/{expected_shard_total}"
 
           def read_lines(path: Path) -> list[str]:
             if not path.exists():
@@ -148,14 +160,26 @@ jobs:
               if slug not in expected or expected[slug] != locale:
                 invalid.append(f"{artifact.name}: unexpected locale {locale!r}/{slug!r}")
                 continue
+              try:
+                shard_index = int(metadata.get("shard_index", 0))
+                artifact_shard_total = int(metadata.get("shard_total", 1))
+              except (TypeError, ValueError):
+                invalid.append(f"{artifact.name}: invalid shard metadata")
+                continue
+              if artifact_shard_total != expected_shard_total:
+                invalid.append(f"{artifact.name}: shard_total {artifact_shard_total} did not match expected {expected_shard_total}")
+                continue
+              if shard_index < 0 or shard_index >= expected_shard_total:
+                invalid.append(f"{artifact.name}: invalid shard_index {shard_index}")
+                continue
               if metadata.get("source_sha") != source_sha:
-                stale.append(f"{locale}: {metadata.get('source_sha')}")
+                stale.append(f"{artifact_label(locale, shard_index)}: {metadata.get('source_sha')}")
                 continue
 
-              seen.add(slug)
+              seen.add((slug, shard_index))
               failed_reason = metadata.get("failed_reason") or ""
               if failed_reason:
-                failed.append(f"{locale}: {failed_reason}")
+                failed.append(f"{artifact_label(locale, shard_index)}: {failed_reason}")
                 continue
 
               changed = read_lines(artifact / "changed-files.txt")
@@ -191,14 +215,19 @@ jobs:
                 applied_any = True
 
               if applied_any:
-                applied.append(locale)
+                applied.append(artifact_label(locale, shard_index))
               elif changed or deleted:
-                no_changes.append(f"{locale} (all stale)")
+                no_changes.append(f"{artifact_label(locale, shard_index)} (all stale)")
               else:
-                no_changes.append(locale)
+                no_changes.append(artifact_label(locale, shard_index))
 
-          missing = [expected[slug] for slug in expected if slug not in seen]
-          missing_or_failed = missing + failed
+          missing = [
+            artifact_label(expected[slug], shard_index)
+            for slug in expected
+            for shard_index in range(expected_shard_total)
+            if (slug, shard_index) not in seen
+          ]
+          missing_or_failed = missing + failed + invalid
           status = subprocess.run(
               ["git", "status", "--porcelain", "--untracked-files=all", "--", "docs"],
               check=True,
@@ -221,15 +250,16 @@ jobs:
           with summary.open("a", encoding="utf-8") as fh:
             fh.write("### Translation finalizer\n\n")
             fh.write(f"- mode: `{os.environ['MODE']}`\n")
+            fh.write(f"- shard total: `{expected_shard_total}`\n")
             fh.write(f"- artifact source: `{source_sha}`\n")
             fh.write(f"- current source: `{current_source_sha}`\n")
             fh.write(f"- changed paths: `{len(status)}`\n")
             if applied:
-              fh.write(f"- applied locales: {', '.join(applied)}\n")
+              fh.write(f"- applied artifacts: {', '.join(applied)}\n")
             if no_changes:
-              fh.write(f"- locales with no changes: {', '.join(no_changes)}\n")
+              fh.write(f"- artifacts with no changes: {', '.join(no_changes)}\n")
             if missing_or_failed:
-              fh.write(f"- missing or failed locales: {', '.join(missing_or_failed)}\n")
+              fh.write(f"- missing or failed artifacts: {', '.join(missing_or_failed)}\n")
             if stale:
               fh.write(f"- stale artifacts ignored: {', '.join(stale)}\n")
             if skipped_stale_pages:
@@ -331,8 +361,8 @@ jobs:
         if: steps.apply.outputs.stale != 'true' && steps.apply.outputs.incomplete_count != '0'
         run: |
           {
-            echo "Translation finished with missing or failed locales."
-            echo "Successful locale artifacts were applied before this failure when available."
+            echo "Translation finished with missing or failed locale artifacts."
+            echo "Successful locale shard artifacts were applied before this failure when available."
             cat .openclaw-sync/i18n-incomplete-locales.txt
           } >&2
           exit 1

--- a/.github/workflows/translate-incremental.yml
+++ b/.github/workflows/translate-incremental.yml
@@ -229,6 +229,9 @@ jobs:
       publish_ref: ${{ needs.prepare.outputs.publish_ref }}
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
+      shard_index: "0"
+      shard_total: "1"
+      worker_parallel: "8"
     secrets: inherit
 
   finalize:
@@ -241,3 +244,4 @@ jobs:
     with:
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
+      shard_total: "1"

--- a/.github/workflows/translate-locale-reusable.yml
+++ b/.github/workflows/translate-locale-reusable.yml
@@ -18,16 +18,25 @@ on:
       mode:
         required: true
         type: string
+      shard_index:
+        required: true
+        type: string
+      shard_total:
+        required: true
+        type: string
+      worker_parallel:
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   translate:
-    name: Translate ${{ inputs.locale }}
+    name: Translate ${{ inputs.locale }} shard ${{ inputs.shard_index }}/${{ inputs.shard_total }}
     runs-on: ubuntu-latest
     concurrency:
-      group: translate-${{ inputs.locale_slug }}
+      group: translate-${{ inputs.locale_slug }}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}
       cancel-in-progress: false
     steps:
       - name: Checkout publish repo
@@ -119,6 +128,8 @@ jobs:
           LOCALE: ${{ inputs.locale }}
           LOCALE_SLUG: ${{ inputs.locale_slug }}
           MODE: ${{ inputs.mode }}
+          SHARD_INDEX: ${{ inputs.shard_index }}
+          SHARD_TOTAL: ${{ inputs.shard_total }}
         run: |
           python - <<'PY'
           import hashlib
@@ -143,7 +154,16 @@ jobs:
           }
           locale = os.environ["LOCALE"]
           mode = os.environ["MODE"]
-          pending_path = Path(".openclaw-sync") / f"docs-i18n-{os.environ['LOCALE_SLUG']}.txt"
+          try:
+            shard_index = int(os.environ["SHARD_INDEX"])
+            shard_total = int(os.environ["SHARD_TOTAL"])
+          except ValueError as exc:
+            raise SystemExit(f"invalid shard inputs: {exc}")
+          if shard_total < 1:
+            raise SystemExit(f"invalid shard_total: {shard_total}")
+          if shard_index < 0 or shard_index >= shard_total:
+            raise SystemExit(f"invalid shard_index {shard_index} for shard_total {shard_total}")
+          pending_path = Path(".openclaw-sync") / f"docs-i18n-{os.environ['LOCALE_SLUG']}-s{shard_index}of{shard_total}.txt"
 
           def stored_source_hash(path: Path) -> str:
             if not path.exists():
@@ -175,12 +195,23 @@ jobs:
             if mode == "full" or stored_source_hash(locale_path) != source_hash:
               pending_files.append(str(path.resolve()))
 
+          pending_files = sorted(pending_files)
+          shard_files = [
+            file
+            for index, file in enumerate(pending_files)
+            if index % shard_total == shard_index
+          ]
+
           pending_path.parent.mkdir(exist_ok=True)
-          pending_path.write_text("\n".join(pending_files) + ("\n" if pending_files else ""))
-          print(f"all_docs={len(all_files)} pending_docs={len(pending_files)}")
+          pending_path.write_text("\n".join(shard_files) + ("\n" if shard_files else ""))
+          print(
+            f"all_docs={len(all_files)} total_pending_docs={len(pending_files)} "
+            f"shard={shard_index}/{shard_total} shard_pending_docs={len(shard_files)}"
+          )
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
             fh.write(f"all_count={len(all_files)}\n")
-            fh.write(f"pending_count={len(pending_files)}\n")
+            fh.write(f"total_pending_count={len(pending_files)}\n")
+            fh.write(f"pending_count={len(shard_files)}\n")
           PY
 
       - name: Translate changed docs into locale
@@ -194,8 +225,9 @@ jobs:
           OPENCLAW_DOCS_I18N_PROVIDER: openai
           OPENCLAW_DOCS_I18N_MODEL: gpt-5.5
           OPENCLAW_DOCS_I18N_PROMPT_TIMEOUT: 10m
+          WORKER_PARALLEL: ${{ inputs.worker_parallel }}
         run: |
-          pending_file=".openclaw-sync/docs-i18n-${LOCALE_SLUG}.txt"
+          pending_file=".openclaw-sync/docs-i18n-${LOCALE_SLUG}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}.txt"
           if [ ! -s "${pending_file}" ]; then
             echo "No docs files found."
             exit 0
@@ -215,7 +247,7 @@ jobs:
                 --mode doc \
                 --thinking xhigh \
                 --allow-partial \
-                --parallel 8 \
+                --parallel "${WORKER_PARALLEL}" \
                 "${DOC_FILES[@]}"
             ); then
               exit 0
@@ -307,7 +339,11 @@ jobs:
           LOCALE_SLUG: ${{ inputs.locale_slug }}
           SOURCE_SHA: ${{ steps.meta.outputs.sha }}
           MODE: ${{ inputs.mode }}
+          SHARD_INDEX: ${{ inputs.shard_index }}
+          SHARD_TOTAL: ${{ inputs.shard_total }}
+          WORKER_PARALLEL: ${{ inputs.worker_parallel }}
           PENDING_COUNT: ${{ steps.pending.outputs.pending_count || '0' }}
+          TOTAL_PENDING_COUNT: ${{ steps.pending.outputs.total_pending_count || '0' }}
           ALL_COUNT: ${{ steps.pending.outputs.all_count || '0' }}
           TRANSLATE_OUTCOME: ${{ steps.translate_docs.outcome || 'skipped' }}
           MDX_CHECK_OUTCOME: ${{ steps.mdx_check.outcome || 'skipped' }}
@@ -317,7 +353,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          artifact_dir=".openclaw-sync/artifacts/${LOCALE_SLUG}"
+          shard_id="s${SHARD_INDEX}of${SHARD_TOTAL}"
+          artifact_dir=".openclaw-sync/artifacts/${LOCALE_SLUG}-${shard_id}"
           payload_dir="${artifact_dir}/payload"
           mkdir -p "${payload_dir}"
 
@@ -339,10 +376,53 @@ jobs:
             : > "${artifact_dir}/changed-files.txt"
             : > "${artifact_dir}/deleted-files.txt"
           else
-            git diff --name-only --diff-filter=ACMRT -- "docs/${LOCALE}" "docs/.i18n/${LOCALE}.tm.jsonl" > "${artifact_dir}/changed-files.txt"
-            git ls-files --others --exclude-standard -- "docs/${LOCALE}" "docs/.i18n/${LOCALE}.tm.jsonl" >> "${artifact_dir}/changed-files.txt"
-            sort -u "${artifact_dir}/changed-files.txt" -o "${artifact_dir}/changed-files.txt"
-            git diff --name-only --diff-filter=D -- "docs/${LOCALE}" "docs/.i18n/${LOCALE}.tm.jsonl" > "${artifact_dir}/deleted-files.txt"
+            git diff --name-only --diff-filter=ACMRT -- "docs/${LOCALE}" "docs/.i18n/${LOCALE}.tm.jsonl" > "${artifact_dir}/all-changed-files.txt"
+            git ls-files --others --exclude-standard -- "docs/${LOCALE}" "docs/.i18n/${LOCALE}.tm.jsonl" >> "${artifact_dir}/all-changed-files.txt"
+            sort -u "${artifact_dir}/all-changed-files.txt" -o "${artifact_dir}/all-changed-files.txt"
+            git diff --name-only --diff-filter=D -- "docs/${LOCALE}" "docs/.i18n/${LOCALE}.tm.jsonl" > "${artifact_dir}/all-deleted-files.txt"
+            export ARTIFACT_DIR="${artifact_dir}"
+
+            python - <<'PY'
+            import os
+            from pathlib import Path
+
+            docs_root = Path(os.environ["GITHUB_WORKSPACE"]) / "docs"
+            locale = os.environ["LOCALE"]
+            shard_index = int(os.environ["SHARD_INDEX"])
+            shard_total = int(os.environ["SHARD_TOTAL"])
+            pending_file = Path(".openclaw-sync") / f"docs-i18n-{os.environ['LOCALE_SLUG']}-s{os.environ['SHARD_INDEX']}of{os.environ['SHARD_TOTAL']}.txt"
+            allowed = set()
+            if pending_file.exists():
+              for line in pending_file.read_text().splitlines():
+                if not line.strip():
+                  continue
+                source = Path(line.strip())
+                rel = source.relative_to(docs_root).as_posix()
+                allowed.add(f"docs/{locale}/{rel}")
+            if shard_total == 1:
+              allowed.add(f"docs/.i18n/{locale}.tm.jsonl")
+
+            changed_path = Path(os.environ["ARTIFACT_DIR"]) / "all-changed-files.txt"
+            deleted_path = Path(os.environ["ARTIFACT_DIR"]) / "all-deleted-files.txt"
+            changed_out_path = Path(os.environ["ARTIFACT_DIR"]) / "changed-files.txt"
+            deleted_out_path = Path(os.environ["ARTIFACT_DIR"]) / "deleted-files.txt"
+            changed = [
+              line.strip()
+              for line in changed_path.read_text().splitlines()
+              if line.strip() in allowed
+            ]
+            deleted = [line.strip() for line in deleted_path.read_text().splitlines() if line.strip()]
+            if shard_total == 1:
+              shard_deleted = deleted
+            else:
+              shard_deleted = [
+                line
+                for index, line in enumerate(sorted(line for line in deleted if not line.startswith("docs/.i18n/")))
+                if index % shard_total == shard_index
+              ]
+            changed_out_path.write_text("\n".join(changed) + ("\n" if changed else ""))
+            deleted_out_path.write_text("\n".join(shard_deleted) + ("\n" if shard_deleted else ""))
+            PY
           fi
 
           while IFS= read -r file; do
@@ -357,7 +437,8 @@ jobs:
           import os
           from pathlib import Path
 
-          artifact_dir = Path(".openclaw-sync/artifacts") / os.environ["LOCALE_SLUG"]
+          shard_id = f"s{os.environ['SHARD_INDEX']}of{os.environ['SHARD_TOTAL']}"
+          artifact_dir = Path(".openclaw-sync/artifacts") / f"{os.environ['LOCALE_SLUG']}-{shard_id}"
           changed = [line for line in (artifact_dir / "changed-files.txt").read_text().splitlines() if line.strip()]
           deleted = [line for line in (artifact_dir / "deleted-files.txt").read_text().splitlines() if line.strip()]
           metadata = {
@@ -365,7 +446,11 @@ jobs:
               "locale_slug": os.environ["LOCALE_SLUG"],
               "source_sha": os.environ["SOURCE_SHA"],
               "mode": os.environ["MODE"],
+              "shard_index": int(os.environ["SHARD_INDEX"]),
+              "shard_total": int(os.environ["SHARD_TOTAL"]),
+              "worker_parallel": int(os.environ["WORKER_PARALLEL"]),
               "pending_count": int(os.environ["PENDING_COUNT"]),
+              "total_pending_count": int(os.environ["TOTAL_PENDING_COUNT"]),
               "all_count": int(os.environ["ALL_COUNT"]),
               "changed_count": len(changed),
               "deleted_count": len(deleted),
@@ -384,6 +469,6 @@ jobs:
         if: steps.stale.outputs.skip != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: i18n-${{ inputs.locale_slug }}-${{ inputs.source_sha }}
-          path: .openclaw-sync/artifacts/${{ inputs.locale_slug }}
+          name: i18n-${{ inputs.locale_slug }}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}-${{ inputs.source_sha }}
+          path: .openclaw-sync/artifacts/${{ inputs.locale_slug }}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}
           retention-days: 7

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -15,15 +15,17 @@ Internal note for the docs publish pipeline. This file is under `docs/.i18n`, wh
 
 1. `openclaw/openclaw` syncs English docs into `openclaw/docs`.
 2. GitHub Pages deploys English/source changes immediately from the sync commit.
-3. `Translate All` is triggered by the sync commit, release dispatch, manual dispatch, or weekly schedule.
-4. The coordinator waits a cooldown window before starting translation.
-5. After the cooldown, the coordinator reads the current `origin/main` source metadata.
-6. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
-7. Per-locale translation jobs run in parallel with `fail-fast: false`.
-8. Each locale job uploads an artifact for the requested source SHA.
-9. The finalizer downloads available artifacts, ignores stale or failed payloads, and pushes one aggregate i18n commit.
-10. After the aggregate commit lands, the finalizer dispatches the Pages deploy once.
-11. The Pages workflow dispatches live smoke after deployment.
+3. `Translate Incremental` is triggered by normal source docs changes.
+4. `Translate Full` is triggered by glossary changes, release dispatch, manual dispatch, or weekly schedule.
+5. The selected coordinator waits a cooldown window before starting translation.
+6. After the cooldown, the coordinator reads the current `origin/main` source metadata.
+7. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
+8. Incremental translation runs one job per locale with `fail-fast: false`.
+9. Full translation runs eight deterministic shards per locale with `fail-fast: false` and `max-parallel: 54`.
+10. Each locale job or locale shard uploads an artifact for the requested source SHA.
+11. The shared finalizer downloads available artifacts and pushes one aggregate i18n commit.
+12. After the aggregate commit lands, the finalizer dispatches the Pages deploy once.
+13. The Pages workflow dispatches live smoke after deployment.
 
 ## Debounce policy
 
@@ -34,6 +36,16 @@ The default cooldown is controlled by the publish repo variable `OPENCLAW_DOCS_T
 If `.openclaw-sync/source.json` changed during the wait, it waits again from the newer state. If `main` keeps moving, the wait is capped by `OPENCLAW_DOCS_TRANSLATION_MAX_WAIT_SECONDS`, which defaults to the cooldown value. The newest observed state is translated after the cap.
 
 Manual and weekly runs do not wait by default.
+
+## Concurrency lanes
+
+Full reconciliation uses the `docs-i18n-full` concurrency group and cancels older full runs. Full mode covers weekly reconciliation, glossary changes, release dispatch, and manual full runs.
+
+Incremental translation uses the `docs-i18n-incremental` concurrency group and cancels older incremental runs. It does not cancel full reconciliation.
+
+The finalizer uses the shared `docs-i18n-finalize` concurrency group with `cancel-in-progress: false`, so aggregate pushes are serialized across both lanes.
+
+Full translation shards use 8 locale shards with 2 in-job workers each. The matrix `max-parallel: 54` caps active shard jobs, for a maximum of 108 active translation workers. Incremental translation stays unsharded with 8 in-job workers per locale.
 
 ## Incremental translation
 
@@ -49,13 +61,23 @@ Internal files under `docs/.i18n/**` are not translation inputs. Push-triggered 
 
 If a locale job fails, its artifact is marked failed and carries no payload. The finalizer still commits successful locales. The failed locale remains stale and is picked up by the next incremental run because its source hashes still do not match.
 
+If a run finishes after the source SHA has moved, the finalizer no longer drops the whole artifact set. It applies localized pages whose `x-i18n.source_hash` still matches the current English source file, skips stale pages, applies deletes only when the current English source is also gone, and skips translation memory updates from stale runs.
+
+## Full translation shards
+
+Full mode forces every source page into the pending list, then splits the sorted file list with `file_index % shard_total == shard_index`.
+
+Each full shard translates only its assigned files. Deleted locale pages are also deterministically split across shards by sorted deleted path. Sharded full artifacts exclude `docs/.i18n/<locale>.tm.jsonl` so parallel shards cannot overwrite one another's translation memory output. Locale pages are still aggregated and committed by the finalizer.
+
 ## Artifact contract
 
-Each locale job uploads one artifact named with locale and source SHA:
+Each locale job or shard uploads one artifact named with locale, shard, and source SHA:
 
 ```text
-i18n-zh-cn-<source-sha>
+i18n-zh-cn-s0of8-<source-sha>
 ```
+
+Incremental runs use `s0of1`.
 
 Artifact contents:
 
@@ -67,7 +89,9 @@ payload/docs/<locale>/**
 payload/docs/.i18n/<locale>.tm.jsonl
 ```
 
-`metadata.json` includes the locale, locale slug, source SHA, pending count, changed count, and any failure reason. The finalizer rejects artifacts whose `source_sha` does not match the current `.openclaw-sync/source.json`.
+The translation memory payload is present for unsharded incremental runs only. Sharded full runs omit it.
+
+`metadata.json` includes the locale, locale slug, source SHA, shard index, shard total, total pending count, shard pending count, changed count, and any failure reason. The finalizer rejects artifacts with the wrong requested `source_sha` or unexpected shard metadata; if the requested source is no longer current, it falls back to per-page freshness checks.
 
 The source repo release workflow dispatches one `translate-all-release` event. The coordinator still accepts old per-locale release events for compatibility, but those are only a fallback.
 
@@ -81,7 +105,7 @@ Commit message:
 chore(i18n): refresh translations
 ```
 
-The commit may contain a partial locale set. The job summary lists applied locales, locales with no changes, missing or failed locales, stale artifacts, and invalid artifacts.
+The commit may contain a partial locale or shard set. The job summary lists applied artifacts, artifacts with no changes, missing or failed artifacts, stale artifacts, skipped stale pages, skipped stale deletes, skipped stale translation memory, and invalid artifacts.
 
 ## Weekly reconciliation
 
@@ -93,8 +117,8 @@ Expected behavior:
 
 - regenerate or verify every locale page
 - prune stale locale pages
-- refresh translation memory as needed
-- still use parallel locale jobs
+- refresh locale pages while skipping sharded translation memory output
+- still use parallel locale shard jobs
 - still commit one aggregate result
 - still tolerate individual locale failures
 


### PR DESCRIPTION
## Summary

This shards full docs translation so a manual/weekly full reconciliation no longer depends on one long-running locale job finishing all source pages within the GitHub-hosted runner job limit.

Before this change, each locale ran as one job with `--parallel 8`. A full run therefore had 18 locale jobs and up to `18 * 8 = 144` active translation workers. The recent manual full run reached the GitHub-hosted runner 6 hour job limit while individual locale jobs were still translating, so increasing workflow timeout is not a reliable fix.

This PR keeps the same translation model and final aggregate commit behavior, but splits full translation into deterministic per-locale shards:

- Full translation: `18 locales * 8 shards`
- Per-shard worker parallelism: `--parallel 2`
- Matrix cap: `max-parallel: 54`
- Maximum translation pressure: `54 * 2 = 108` active workers

That is about 75% of the previous maximum pressure on the upstream Codex/OpenAI translation engine (`108 / 144 = 75%`), while each shard has much less work than the old single locale job. The intent is to reduce per-job wall time enough to avoid the 6 hour runner limit without increasing load on the translation backend.

Incremental translation remains unsharded (`s0of1`) and keeps the existing `--parallel 8` behavior. The finalizer still downloads artifacts and produces one aggregate i18n commit.

## Implementation Notes

- Full runs use deterministic file sharding: sorted pending files are assigned by `file_index % shard_total == shard_index`.
- Reusable locale workflow now receives `shard_index`, `shard_total`, and `worker_parallel`.
- Shard artifacts are named like `i18n-zh-cn-s0of8-<source_sha>`.
- The finalizer validates completeness by locale + shard, so missing or failed shard artifacts are reported precisely.
- Sharded full artifacts omit locale translation memory files to avoid parallel shard overwrite.
- Deleted locale pages are deterministically split by sorted deleted path so shard artifacts do not export out-of-scope deletes.

## Validation

- `actionlint .github/workflows/translate-all.yml .github/workflows/translate-incremental.yml .github/workflows/translate-locale-reusable.yml .github/workflows/translate-finalize-reusable.yml`
- PyYAML parse for all modified workflow files
- shard distribution and deleted-path shard distribution Python checks
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "actionlint .github/workflows/translate-all.yml .github/workflows/translate-incremental.yml .github/workflows/translate-locale-reusable.yml .github/workflows/translate-finalize-reusable.yml"`

Autoreview result: clean, no accepted/actionable findings reported.