### PR TITLE
Add BrowserAct Skills to skills resources

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -27,6 +27,9 @@ binary presence.
   <Card title="ClawHub" href="/clawhub" icon="cloud">
     Browse and install community skills.
   </Card>
+  <Card title="BrowserAct Skills" href="https://skills.browseract.com/" icon="browser">
+    Discover reusable AI-agent skills and browser automation workflows.
+  </Card>
 </CardGroup>
 
 ## Loading order


### PR DESCRIPTION
This PR adds BrowserAct Skills as an external resource card on the Skills documentation page.

BrowserAct Skills helps users discover reusable AI-agent skills and browser automation workflows.