### PR TITLE
ci: tune docs translation shard sizing

### DIFF
--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -153,7 +153,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
   translate:
-    name: Translate ${{ matrix.locale.locale }} shard ${{ matrix.shard_index }}/8
+    name: Translate ${{ matrix.locale.locale }} shard ${{ matrix.shard_index }}/16
     needs: prepare
     if: needs.prepare.outputs.should_translate == 'true'
     strategy:
@@ -206,6 +206,14 @@ jobs:
           - 5
           - 6
           - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+          - 15
     uses: ./.github/workflows/translate-locale-reusable.yml
     with:
       locale: ${{ matrix.locale.locale }}
@@ -214,8 +222,9 @@ jobs:
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
       shard_index: ${{ matrix.shard_index }}
-      shard_total: "8"
+      shard_total: "16"
       worker_parallel: "2"
+      thinking_effort: "medium"
     secrets: inherit
 
   finalize:
@@ -228,4 +237,4 @@ jobs:
     with:
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
-      shard_total: "8"
+      shard_total: "16"

--- a/.github/workflows/translate-incremental.yml
+++ b/.github/workflows/translate-incremental.yml
@@ -232,6 +232,7 @@ jobs:
       shard_index: "0"
       shard_total: "1"
       worker_parallel: "8"
+      thinking_effort: "medium"
     secrets: inherit
 
   finalize:

--- a/.github/workflows/translate-locale-reusable.yml
+++ b/.github/workflows/translate-locale-reusable.yml
@@ -27,6 +27,9 @@ on:
       worker_parallel:
         required: true
         type: string
+      thinking_effort:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -226,6 +229,7 @@ jobs:
           OPENCLAW_DOCS_I18N_MODEL: gpt-5.5
           OPENCLAW_DOCS_I18N_PROMPT_TIMEOUT: 10m
           WORKER_PARALLEL: ${{ inputs.worker_parallel }}
+          THINKING_EFFORT: ${{ inputs.thinking_effort }}
         run: |
           pending_file=".openclaw-sync/docs-i18n-${LOCALE_SLUG}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}.txt"
           if [ ! -s "${pending_file}" ]; then
@@ -245,7 +249,7 @@ jobs:
                 --lang "${LOCALE}" \
                 --src en \
                 --mode doc \
-                --thinking xhigh \
+                --thinking "${THINKING_EFFORT}" \
                 --allow-partial \
                 --parallel "${WORKER_PARALLEL}" \
                 "${DOC_FILES[@]}"
@@ -342,6 +346,7 @@ jobs:
           SHARD_INDEX: ${{ inputs.shard_index }}
           SHARD_TOTAL: ${{ inputs.shard_total }}
           WORKER_PARALLEL: ${{ inputs.worker_parallel }}
+          THINKING_EFFORT: ${{ inputs.thinking_effort }}
           PENDING_COUNT: ${{ steps.pending.outputs.pending_count || '0' }}
           TOTAL_PENDING_COUNT: ${{ steps.pending.outputs.total_pending_count || '0' }}
           ALL_COUNT: ${{ steps.pending.outputs.all_count || '0' }}
@@ -449,6 +454,7 @@ jobs:
               "shard_index": int(os.environ["SHARD_INDEX"]),
               "shard_total": int(os.environ["SHARD_TOTAL"]),
               "worker_parallel": int(os.environ["WORKER_PARALLEL"]),
+              "thinking_effort": os.environ["THINKING_EFFORT"],
               "pending_count": int(os.environ["PENDING_COUNT"]),
               "total_pending_count": int(os.environ["TOTAL_PENDING_COUNT"]),
               "all_count": int(os.environ["ALL_COUNT"]),

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -15,15 +15,17 @@ Internal note for the docs publish pipeline. This file is under `docs/.i18n`, wh
 
 1. `openclaw/openclaw` syncs English docs into `openclaw/docs`.
 2. GitHub Pages deploys English/source changes immediately from the sync commit.
-3. `Translate All` is triggered by the sync commit, release dispatch, manual dispatch, or weekly schedule.
-4. The coordinator waits a cooldown window before starting translation.
-5. After the cooldown, the coordinator reads the current `origin/main` source metadata.
-6. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
-7. Per-locale translation jobs run in parallel with `fail-fast: false`.
-8. Each locale job uploads an artifact for the requested source SHA.
-9. The finalizer downloads available artifacts, ignores stale or failed payloads, and pushes one aggregate i18n commit.
-10. After the aggregate commit lands, the finalizer dispatches the Pages deploy once.
-11. The Pages workflow dispatches live smoke after deployment.
+3. `Translate Incremental` is triggered by normal source docs changes.
+4. `Translate Full` is triggered by glossary changes, release dispatch, manual dispatch, or weekly schedule.
+5. The selected coordinator waits a cooldown window before starting translation.
+6. After the cooldown, the coordinator reads the current `origin/main` source metadata.
+7. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
+8. Incremental translation runs one job per locale with `fail-fast: false`.
+9. Full translation runs sixteen deterministic shards per locale with `fail-fast: false` and `max-parallel: 54`.
+10. Each locale job or locale shard uploads an artifact for the requested source SHA.
+11. The shared finalizer downloads available artifacts and pushes one aggregate i18n commit.
+12. After the aggregate commit lands, the finalizer dispatches the Pages deploy once.
+13. The Pages workflow dispatches live smoke after deployment.
 
 ## Debounce policy
 
@@ -34,6 +36,18 @@ The default cooldown is controlled by the publish repo variable `OPENCLAW_DOCS_T
 If `.openclaw-sync/source.json` changed during the wait, it waits again from the newer state. If `main` keeps moving, the wait is capped by `OPENCLAW_DOCS_TRANSLATION_MAX_WAIT_SECONDS`, which defaults to the cooldown value. The newest observed state is translated after the cap.
 
 Manual and weekly runs do not wait by default.
+
+## Concurrency lanes
+
+Full reconciliation uses the `docs-i18n-full` concurrency group and cancels older full runs. Full mode covers weekly reconciliation, glossary changes, release dispatch, and manual full runs.
+
+Incremental translation uses the `docs-i18n-incremental` concurrency group and cancels older incremental runs. It does not cancel full reconciliation.
+
+The finalizer uses the shared `docs-i18n-finalize` concurrency group with `cancel-in-progress: false`, so aggregate pushes are serialized across both lanes.
+
+Full translation shards use 16 locale shards with 2 in-job workers each. The matrix `max-parallel: 54` caps active shard jobs, for a maximum of 108 active translation workers. More shards reduce the per-job page count without increasing upstream translation pressure. Incremental translation stays unsharded with 8 in-job workers per locale.
+
+Docs translation uses `gpt-5.5` with medium thinking effort. The workload is constrained translation rather than deep reasoning; medium keeps prompt latency lower so full shard jobs stay farther from GitHub-hosted runner's 6 hour job limit.
 
 ## Incremental translation
 
@@ -49,13 +63,23 @@ Internal files under `docs/.i18n/**` are not translation inputs. Push-triggered 
 
 If a locale job fails, its artifact is marked failed and carries no payload. The finalizer still commits successful locales. The failed locale remains stale and is picked up by the next incremental run because its source hashes still do not match.
 
+If a run finishes after the source SHA has moved, the finalizer no longer drops the whole artifact set. It applies localized pages whose `x-i18n.source_hash` still matches the current English source file, skips stale pages, applies deletes only when the current English source is also gone, and skips translation memory updates from stale runs.
+
+## Full translation shards
+
+Full mode forces every source page into the pending list, then splits the sorted file list with `file_index % shard_total == shard_index`.
+
+Each full shard translates only its assigned files. Deleted locale pages are also deterministically split across shards by sorted deleted path. Sharded full artifacts exclude `docs/.i18n/<locale>.tm.jsonl` so parallel shards cannot overwrite one another's translation memory output. Locale pages are still aggregated and committed by the finalizer.
+
 ## Artifact contract
 
-Each locale job uploads one artifact named with locale and source SHA:
+Each locale job or shard uploads one artifact named with locale, shard, and source SHA:
 
 ```text
-i18n-zh-cn-<source-sha>
+i18n-zh-cn-s0of16-<source-sha>
 ```
+
+Incremental runs use `s0of1`.
 
 Artifact contents:
 
@@ -67,7 +91,9 @@ payload/docs/<locale>/**
 payload/docs/.i18n/<locale>.tm.jsonl
 ```
 
-`metadata.json` includes the locale, locale slug, source SHA, pending count, changed count, and any failure reason. The finalizer rejects artifacts whose `source_sha` does not match the current `.openclaw-sync/source.json`.
+The translation memory payload is present for unsharded incremental runs only. Sharded full runs omit it.
+
+`metadata.json` includes the locale, locale slug, source SHA, shard index, shard total, worker parallelism, thinking effort, total pending count, shard pending count, changed count, and any failure reason. The finalizer rejects artifacts with the wrong requested `source_sha` or unexpected shard metadata; if the requested source is no longer current, it falls back to per-page freshness checks.
 
 The source repo release workflow dispatches one `translate-all-release` event. The coordinator still accepts old per-locale release events for compatibility, but those are only a fallback.
 
@@ -81,7 +107,7 @@ Commit message:
 chore(i18n): refresh translations
 ```
 
-The commit may contain a partial locale set. The job summary lists applied locales, locales with no changes, missing or failed locales, stale artifacts, and invalid artifacts.
+The commit may contain a partial locale or shard set. The job summary lists applied artifacts, artifacts with no changes, missing or failed artifacts, stale artifacts, skipped stale pages, skipped stale deletes, skipped stale translation memory, and invalid artifacts.
 
 ## Weekly reconciliation
 
@@ -93,8 +119,8 @@ Expected behavior:
 
 - regenerate or verify every locale page
 - prune stale locale pages
-- refresh translation memory as needed
-- still use parallel locale jobs
+- refresh locale pages while skipping sharded translation memory output
+- still use parallel locale shard jobs
 - still commit one aggregate result
 - still tolerate individual locale failures
 


### PR DESCRIPTION
## Summary

This is a follow-up to the full translation sharding change after observing the first sharded full run still hit GitHub-hosted runner's single-job 6 hour limit.

Changes:
- Increase full translation from 8 shards per locale to 16 shards per locale.
- Keep each full shard at `--parallel 2`.
- Keep full matrix `max-parallel: 54`.
- Change docs translation thinking effort from hard-coded `xhigh` to caller-provided `thinking_effort`.
- Set both full and incremental translation to `medium` thinking effort.
- Record `thinking_effort` in artifact metadata.
- Update the internal translation workflow notes.

## Why

The previous full run showed active shard jobs getting cancelled at roughly 6 hours. One example was `Translate ko shard 3/8`, which ran for about `6h00m17s` and was still translating when GitHub cancelled it.

So the first sharding pass reduced overall job size, but not enough for the slowest shard under current Codex translation behavior. The logs also show many `codex exec failed` fallback/split/retry paths, which makes `xhigh` expensive because every retry pays higher per-call latency.

Translation is a constrained formatting and localization task, not deep reasoning. `medium` should reduce per-call latency while keeping the model and prompt unchanged.

## Concurrency / Engine Pressure

This does not increase instantaneous pressure on the translation engine:

- Previous sharded full: `54 max-parallel * 2 workers = 108` active workers.
- New full: `54 max-parallel * 2 workers = 108` active workers.

The shard count increases total matrix jobs, but `max-parallel` keeps only 54 shard jobs active at once. The goal is to cut each job's assigned page count roughly in half while keeping peak upstream worker pressure unchanged.

## Timeout Consideration

GitHub-hosted runners have a single-job 6 hour limit. Increasing shards from 8 to 16 reduces the expected per-shard work by about 50%. Combined with `medium` thinking effort, this should move slow shards farther away from the 6 hour ceiling without changing model, prompt timeout, or final aggregate commit behavior.

## Behavior Kept

- Full lane still uses `docs-i18n-full` concurrency and cancels older full runs.
- Incremental lane remains unsharded (`s0of1`) with `--parallel 8`.
- Finalizer still waits for the expected shard count and creates one aggregate i18n commit.
- Sharded full still omits translation memory payloads to avoid shard overwrite races.

## Validation

- `actionlint .github/workflows/translate-all.yml .github/workflows/translate-incremental.yml .github/workflows/translate-locale-reusable.yml .github/workflows/translate-finalize-reusable.yml`
- PyYAML parse for the edited workflow files
- Local Python shard distribution check for `shard_total=1` and `shard_total=16`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - `autoreview clean: no accepted/actionable findings reported`
