### PR TITLE
ci: keep full translation matrix under limit

### DIFF
--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -153,7 +153,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
   translate:
-    name: Translate ${{ matrix.locale.locale }} shard ${{ matrix.shard_index }}/16
+    name: Translate ${{ matrix.locale.locale }} shard ${{ matrix.shard_index }}/14
     needs: prepare
     if: needs.prepare.outputs.should_translate == 'true'
     strategy:
@@ -212,8 +212,6 @@ jobs:
           - 11
           - 12
           - 13
-          - 14
-          - 15
     uses: ./.github/workflows/translate-locale-reusable.yml
     with:
       locale: ${{ matrix.locale.locale }}
@@ -222,7 +220,7 @@ jobs:
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
       shard_index: ${{ matrix.shard_index }}
-      shard_total: "16"
+      shard_total: "14"
       worker_parallel: "2"
       thinking_effort: "medium"
     secrets: inherit
@@ -237,4 +235,4 @@ jobs:
     with:
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
-      shard_total: "16"
+      shard_total: "14"

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -15,15 +15,16 @@ Internal note for the docs publish pipeline. This file is under `docs/.i18n`, wh
 
 1. `openclaw/openclaw` syncs English docs into `openclaw/docs`.
 2. GitHub Pages deploys English/source changes immediately from the sync commit.
-3. `Translate All` is triggered by the sync commit, release dispatch, manual dispatch, or weekly schedule.
-4. The coordinator waits a cooldown window before starting translation.
-5. After the cooldown, the coordinator reads the current `origin/main` source metadata.
-6. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
-7. Per-locale translation jobs run in parallel with `fail-fast: false`.
-8. Each locale job uploads an artifact for the requested source SHA.
-9. The finalizer downloads available artifacts, ignores stale or failed payloads, and pushes one aggregate i18n commit.
-10. After the aggregate commit lands, the finalizer dispatches the Pages deploy once.
-11. The Pages workflow dispatches live smoke after deployment.
+3. `Translate Incremental` is triggered by normal source docs changes.
+4. `Translate Full` is triggered by glossary changes, release dispatch, manual dispatch, or weekly schedule.
+5. The selected coordinator waits a cooldown window before starting translation.
+6. After the cooldown, the coordinator reads the current `origin/main` source metadata.
+7. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
+8. Incremental translation runs one job per locale; full translation runs 14 shards per locale.
+9. Each locale job or shard uploads an artifact for the requested source SHA.
+10. The finalizer downloads available artifacts, ignores stale or failed payloads, and pushes one aggregate i18n commit.
+11. After the aggregate commit lands, the finalizer dispatches the Pages deploy once.
+12. The Pages workflow dispatches live smoke after deployment.
 
 ## Debounce policy
 
@@ -49,13 +50,17 @@ Internal files under `docs/.i18n/**` are not translation inputs. Push-triggered 
 
 If a locale job fails, its artifact is marked failed and carries no payload. The finalizer still commits successful locales. The failed locale remains stale and is picked up by the next incremental run because its source hashes still do not match.
 
+Full translation forces every source page into the pending list and splits the sorted file list across 14 shards per locale. With 18 locales, the full matrix has 252 jobs and stays below GitHub Actions' 256 matrix-combination limit.
+
 ## Artifact contract
 
-Each locale job uploads one artifact named with locale and source SHA:
+Each locale job or shard uploads one artifact named with locale, shard, and source SHA:
 
 ```text
-i18n-zh-cn-<source-sha>
+i18n-zh-cn-s0of14-<source-sha>
 ```
+
+Incremental runs use `s0of1`.
 
 Artifact contents:
 
@@ -67,7 +72,7 @@ payload/docs/<locale>/**
 payload/docs/.i18n/<locale>.tm.jsonl
 ```
 
-`metadata.json` includes the locale, locale slug, source SHA, pending count, changed count, and any failure reason. The finalizer rejects artifacts whose `source_sha` does not match the current `.openclaw-sync/source.json`.
+`metadata.json` includes the locale, locale slug, source SHA, shard index, shard total, pending count, changed count, and any failure reason. The finalizer rejects artifacts whose `source_sha` does not match the current `.openclaw-sync/source.json`.
 
 The source repo release workflow dispatches one `translate-all-release` event. The coordinator still accepts old per-locale release events for compatibility, but those are only a fallback.
 


### PR DESCRIPTION
## Summary

Fix the immediate `Translate Full` failure after #45.

#45 increased full translation to `18 locales * 16 shards = 288` matrix combinations. GitHub Actions matrix jobs are limited to 256 combinations, so the translate matrix did not start and the finalizer immediately failed with every expected shard missing.

This PR changes full translation to:

- `14` shards per locale
- `18 * 14 = 252` matrix combinations, below the 256 limit
- unchanged `max-parallel: 54`
- unchanged per-shard `--parallel 2`
- unchanged `medium` thinking effort from #45

## Why 14

This is the smallest low-risk correction that keeps the current design:

- avoids splitting the workflow into multiple translate jobs
- keeps the finalizer contract unchanged
- keeps peak translation pressure at `54 * 2 = 108` workers
- still cuts per-shard work substantially compared with the original 8 shard setup

## Validation

- `actionlint .github/workflows/translate-all.yml .github/workflows/translate-incremental.yml .github/workflows/translate-locale-reusable.yml .github/workflows/translate-finalize-reusable.yml`
- PyYAML parse for workflow files
- Matrix size check: `18 locales * 14 shards = 252 <= 256`
- Local shard distribution check for `shard_total=1` and `shard_total=14`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --codex-bin <temporary wrapper>`
  - The wrapper only removed unsupported `--ignore-user-config` / `--ignore-rules` flags for the local Codex CLI invocation.
  - Result: `autoreview clean: no accepted/actionable findings reported`
