### PR TITLE
ci: throttle full docs translation fan-out

### DIFF
--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -158,7 +158,8 @@ jobs:
     if: needs.prepare.outputs.should_translate == 'true'
     strategy:
       fail-fast: false
-      max-parallel: 54
+      # Keep Codex API fan-out below the 108-worker peak that made failures expensive.
+      max-parallel: 12
       matrix:
         locale:
           - locale: zh-CN

--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -46,8 +46,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-workflow-shell:
+    name: Validate workflow shell blocks
+    uses: ./.github/workflows/translate-shell-check-reusable.yml
+
   prepare:
     name: Debounce and pick source
+    needs: validate-workflow-shell
     runs-on: ubuntu-latest
     outputs:
       mode: ${{ steps.prepare.outputs.mode }}

--- a/.github/workflows/translate-incremental.yml
+++ b/.github/workflows/translate-incremental.yml
@@ -42,8 +42,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-workflow-shell:
+    name: Validate workflow shell blocks
+    uses: ./.github/workflows/translate-shell-check-reusable.yml
+
   prepare:
     name: Debounce and pick source
+    needs: validate-workflow-shell
     runs-on: ubuntu-latest
     outputs:
       mode: ${{ steps.prepare.outputs.mode }}

--- a/.github/workflows/translate-locale-reusable.yml
+++ b/.github/workflows/translate-locale-reusable.yml
@@ -387,47 +387,47 @@ jobs:
             git diff --name-only --diff-filter=D -- "docs/${LOCALE}" "docs/.i18n/${LOCALE}.tm.jsonl" > "${artifact_dir}/all-deleted-files.txt"
             export ARTIFACT_DIR="${artifact_dir}"
 
-            python - <<'PY'
-            import os
-            from pathlib import Path
+          python - <<'PY'
+          import os
+          from pathlib import Path
 
-            docs_root = Path(os.environ["GITHUB_WORKSPACE"]) / "docs"
-            locale = os.environ["LOCALE"]
-            shard_index = int(os.environ["SHARD_INDEX"])
-            shard_total = int(os.environ["SHARD_TOTAL"])
-            pending_file = Path(".openclaw-sync") / f"docs-i18n-{os.environ['LOCALE_SLUG']}-s{os.environ['SHARD_INDEX']}of{os.environ['SHARD_TOTAL']}.txt"
-            allowed = set()
-            if pending_file.exists():
-              for line in pending_file.read_text().splitlines():
-                if not line.strip():
-                  continue
-                source = Path(line.strip())
-                rel = source.relative_to(docs_root).as_posix()
-                allowed.add(f"docs/{locale}/{rel}")
-            if shard_total == 1:
-              allowed.add(f"docs/.i18n/{locale}.tm.jsonl")
+          docs_root = Path(os.environ["GITHUB_WORKSPACE"]) / "docs"
+          locale = os.environ["LOCALE"]
+          shard_index = int(os.environ["SHARD_INDEX"])
+          shard_total = int(os.environ["SHARD_TOTAL"])
+          pending_file = Path(".openclaw-sync") / f"docs-i18n-{os.environ['LOCALE_SLUG']}-s{os.environ['SHARD_INDEX']}of{os.environ['SHARD_TOTAL']}.txt"
+          allowed = set()
+          if pending_file.exists():
+            for line in pending_file.read_text().splitlines():
+              if not line.strip():
+                continue
+              source = Path(line.strip())
+              rel = source.relative_to(docs_root).as_posix()
+              allowed.add(f"docs/{locale}/{rel}")
+          if shard_total == 1:
+            allowed.add(f"docs/.i18n/{locale}.tm.jsonl")
 
-            changed_path = Path(os.environ["ARTIFACT_DIR"]) / "all-changed-files.txt"
-            deleted_path = Path(os.environ["ARTIFACT_DIR"]) / "all-deleted-files.txt"
-            changed_out_path = Path(os.environ["ARTIFACT_DIR"]) / "changed-files.txt"
-            deleted_out_path = Path(os.environ["ARTIFACT_DIR"]) / "deleted-files.txt"
-            changed = [
-              line.strip()
-              for line in changed_path.read_text().splitlines()
-              if line.strip() in allowed
+          changed_path = Path(os.environ["ARTIFACT_DIR"]) / "all-changed-files.txt"
+          deleted_path = Path(os.environ["ARTIFACT_DIR"]) / "all-deleted-files.txt"
+          changed_out_path = Path(os.environ["ARTIFACT_DIR"]) / "changed-files.txt"
+          deleted_out_path = Path(os.environ["ARTIFACT_DIR"]) / "deleted-files.txt"
+          changed = [
+            line.strip()
+            for line in changed_path.read_text().splitlines()
+            if line.strip() in allowed
+          ]
+          deleted = [line.strip() for line in deleted_path.read_text().splitlines() if line.strip()]
+          if shard_total == 1:
+            shard_deleted = deleted
+          else:
+            shard_deleted = [
+              line
+              for index, line in enumerate(sorted(line for line in deleted if not line.startswith("docs/.i18n/")))
+              if index % shard_total == shard_index
             ]
-            deleted = [line.strip() for line in deleted_path.read_text().splitlines() if line.strip()]
-            if shard_total == 1:
-              shard_deleted = deleted
-            else:
-              shard_deleted = [
-                line
-                for index, line in enumerate(sorted(line for line in deleted if not line.startswith("docs/.i18n/")))
-                if index % shard_total == shard_index
-              ]
-            changed_out_path.write_text("\n".join(changed) + ("\n" if changed else ""))
-            deleted_out_path.write_text("\n".join(shard_deleted) + ("\n" if shard_deleted else ""))
-            PY
+          changed_out_path.write_text("\n".join(changed) + ("\n" if changed else ""))
+          deleted_out_path.write_text("\n".join(shard_deleted) + ("\n" if shard_deleted else ""))
+          PY
           fi
 
           while IFS= read -r file; do

--- a/.github/workflows/translate-shell-check-reusable.yml
+++ b/.github/workflows/translate-shell-check-reusable.yml
@@ -1,0 +1,85 @@
+name: Translate Shell Check Reusable
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check workflow shell blocks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Check bash syntax in translation workflows
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import re
+          from pathlib import Path
+
+          github_expression = re.compile(r"\$\{\{.*?\}\}")
+          workflow_paths = sorted(Path(".github/workflows").glob("translate-*.yml"))
+          out_dir = Path(".openclaw-sync/workflow-shell-check")
+          out_dir.mkdir(parents=True, exist_ok=True)
+
+          scripts = []
+          for workflow_path in workflow_paths:
+            lines = workflow_path.read_text(encoding="utf-8").splitlines()
+            index = 0
+            script_index = 0
+            while index < len(lines):
+              line = lines[index]
+              if line.strip() != "run: |":
+                index += 1
+                continue
+
+              base_indent = len(line) - len(line.lstrip(" "))
+              block_start = index + 1
+              block_end = block_start
+              while block_end < len(lines):
+                candidate = lines[block_end]
+                if candidate.strip() and len(candidate) - len(candidate.lstrip(" ")) <= base_indent:
+                  break
+                block_end += 1
+
+              content_indent = None
+              for candidate in lines[block_start:block_end]:
+                if candidate.strip():
+                  content_indent = len(candidate) - len(candidate.lstrip(" "))
+                  break
+              if content_indent is None:
+                index = block_end
+                continue
+
+              script_lines = []
+              for candidate in lines[block_start:block_end]:
+                if not candidate.strip():
+                  script_lines.append("")
+                else:
+                  if candidate.startswith(" " * content_indent):
+                    script_line = candidate[content_indent:]
+                  else:
+                    script_line = candidate.lstrip(" ")
+                  # GitHub expressions are interpolated before the shell runs; mask them so this preflight
+                  # stays focused on shell structure issues such as unterminated heredocs.
+                  script_lines.append(github_expression.sub("__GITHUB_EXPR__", script_line))
+
+              script_index += 1
+              script_path = out_dir / f"{workflow_path.name}.{script_index}.sh"
+              script_path.write_text("\n".join(script_lines) + "\n", encoding="utf-8")
+              scripts.append(script_path)
+              index = block_end
+
+          for script_path in scripts:
+            print(script_path)
+          PY
+
+          while IFS= read -r script; do
+            [ -n "${script}" ] || continue
+            bash -n "${script}"
+          done < <(find .openclaw-sync/workflow-shell-check -type f -name '*.sh' | sort)

--- a/.github/workflows/translate-shell-check-reusable.yml
+++ b/.github/workflows/translate-shell-check-reusable.yml
@@ -83,3 +83,57 @@ jobs:
             [ -n "${script}" ] || continue
             bash -n "${script}"
           done < <(find .openclaw-sync/workflow-shell-check -type f -name '*.sh' | sort)
+
+      - name: Check translation workflow budgets
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import re
+          from pathlib import Path
+
+          text = Path(".github/workflows/translate-all.yml").read_text(encoding="utf-8")
+
+          def scalar_after(pattern: str, label: str) -> int:
+            match = re.search(pattern, text, re.M)
+            if not match:
+              raise SystemExit(f"missing {label}")
+            return int(match.group(1))
+
+          max_parallel = scalar_after(r"^\s*max-parallel:\s*([0-9]+)\s*$", "full max-parallel")
+          shard_total = scalar_after(r'^\s*shard_total:\s*"([0-9]+)"\s*$', "full shard_total")
+          worker_parallel = scalar_after(r'^\s*worker_parallel:\s*"([0-9]+)"\s*$', "full worker_parallel")
+
+          locale_block = re.search(r"(?ms)^\s*locale:\n(?P<body>.*?)(?=^\s*shard_index:)", text)
+          if not locale_block:
+            raise SystemExit("missing full locale matrix")
+          locale_count = len(re.findall(r"^\s*-\s+locale:\s+\S+\s*$", locale_block.group("body"), re.M))
+          if locale_count == 0:
+            raise SystemExit("full locale matrix is empty")
+
+          shard_block = re.search(r"(?ms)^\s*shard_index:\n(?P<body>.*?)(?=^\s*uses:)", text)
+          if not shard_block:
+            raise SystemExit("missing full shard_index matrix")
+          shard_indexes = [int(value) for value in re.findall(r"^\s*-\s+([0-9]+)\s*$", shard_block.group("body"), re.M)]
+          expected_indexes = list(range(shard_total))
+          if shard_indexes != expected_indexes:
+            raise SystemExit(f"full shard_index matrix {shard_indexes} does not match shard_total {shard_total}")
+
+          matrix_jobs = locale_count * shard_total
+          if matrix_jobs > 256:
+            raise SystemExit(f"full translation matrix has {matrix_jobs} jobs; GitHub Actions limit is 256")
+
+          active_workers = max_parallel * worker_parallel
+          # Keep the budget explicit so a fan-out increase is an intentional workflow change, not an accident.
+          max_active_workers = 24
+          if active_workers > max_active_workers:
+            raise SystemExit(
+              f"full translation peak workers {active_workers} exceeds budget {max_active_workers} "
+              f"({max_parallel} max-parallel * {worker_parallel} workers)"
+            )
+
+          print(
+            f"full translation budget ok: locales={locale_count} shards={shard_total} "
+            f"matrix_jobs={matrix_jobs} peak_workers={active_workers}"
+          )
+          PY

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -11,11 +11,60 @@ Internal note for the docs publish pipeline. This file is under `docs/.i18n`, wh
 - Successful locale outputs are committed together, even if one or more locale jobs fail.
 - A weekly reconciliation reruns every locale/page path to repair missed or flaky translations.
 
+## Full translation stabilization review
+
+The June 2026 full-translation fixes were driven by three observed failure classes:
+
+- A full run could leave slow locale jobs active until the GitHub-hosted runner single-job 6 hour limit cancelled them.
+- Increasing shards without checking platform limits produced `18 locales * 16 shards = 288` matrix jobs, above the GitHub Actions 256-combination matrix limit.
+- A heredoc indentation bug in `Prepare locale artifact` made failed shards unable to upload failure metadata, so the finalizer could only report missing artifacts.
+
+Completed changes:
+
+| Area | Completed mitigation | PR |
+| --- | --- | --- |
+| Per-job runtime | Full runs are sharded by deterministic sorted pending-file index, so each locale job handles a subset instead of every pending page. | [#42](https://github.com/openclaw/docs/pull/42) |
+| Runner timeout margin | Full sharding moved from 8 shards to 14 effective shards per locale, and translation thinking effort moved from `xhigh` to `medium`. | [#45](https://github.com/openclaw/docs/pull/45), [#46](https://github.com/openclaw/docs/pull/46) |
+| Matrix platform limit | Full matrix size is capped at `18 * 14 = 252`, below the 256-combination limit. | [#46](https://github.com/openclaw/docs/pull/46) |
+| Upstream fan-out | Full matrix `max-parallel` is throttled to 12, keeping peak active translation workers at `12 * 2 = 24`. | [#47](https://github.com/openclaw/docs/pull/47) |
+| Failure observability | Failed translation or MDX repair shards upload metadata-only artifacts, so the finalizer can report failed shards separately from missing shards. | [#42](https://github.com/openclaw/docs/pull/42), [#47](https://github.com/openclaw/docs/pull/47) |
+| Shell syntax regression | Translation workflows run a reusable shell-block syntax check before preparing translation work. | [#47](https://github.com/openclaw/docs/pull/47) |
+| Matrix and worker budgets | The reusable preflight checks that `locale_count * shard_total <= 256` and peak full-run workers stay within the explicit budget of 24 before translation starts. | [#47](https://github.com/openclaw/docs/pull/47) |
+| Stale output safety | The finalizer checks source SHA, shard metadata, expected locales, expected shard count, and per-page source hashes before applying artifacts. | [#42](https://github.com/openclaw/docs/pull/42) |
+
+Parameter history:
+
+| Stage | Full matrix jobs | Shards per locale | Matrix `max-parallel` | Workers per active job | Peak active workers | Thinking effort | Main issue |
+| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| Before #42 | 18 | 1 | 18 effective | 8 | 144 | `xhigh` | Slow locale jobs could hit the 6 hour runner limit. |
+| #42 | 144 | 8 | 54 | 2 | 108 | `xhigh` | Slowest shards still had timeout risk. |
+| #45 | 288 | 16 | 54 | 2 | 108 | `medium` | Invalid matrix size: `288 > 256`. |
+| #46 | 252 | 14 | 54 | 2 | 108 | `medium` | Valid matrix, but still high upstream pressure. |
+| #47/current | 252 | 14 | 12 | 2 | 24 | `medium` | Lower pressure; needs PR-level preflight and run telemetry. |
+
+Recommended left-shift checks not yet completed:
+
+| Check | Failure prevented | Suggested owner |
+| --- | --- | --- |
+| Pull-request translation workflow preflight that runs `actionlint`, shell extraction, and budget checks for `translate-*.yml`. | Workflow regressions before merge instead of at the next translation trigger. | CI |
+| Artifact-contract fixture test for finalizer apply logic with successful, failed, missing, stale, invalid, changed, and deleted shard artifacts. | Finalizer regressions that only appear after expensive translation jobs finish. | Script or CI |
+| Shard distribution fixture that reports docs-per-shard and bytes-per-shard for every locale. | File-count sharding can still create oversized shards when a few pages are much larger than average. | Script or CI |
+| Small canary translation workflow using one locale and a tiny fixture docs tree. | End-to-end provider, prompt, MDX check, repair-scope, artifact upload, and finalizer assumptions before a full wave. | Manual or scheduled CI |
+| Run telemetry summary for per-shard duration, pending count, changed count, retries, and failure reason. | Shard and fan-out tuning remains guesswork without trend data. | Workflow summary |
+
+Open design risks:
+
+- The locale list is duplicated across incremental, full, reusable, and finalizer workflow code. Add a generated or checked single source of truth before adding or removing locales.
+- Full sharding assigns files by count, not by estimated work. A few large MDX pages can still make one shard much slower than the others.
+- Sharded full artifacts intentionally omit translation memory payloads to avoid parallel overwrite races. That avoids corrupting the TM file, but it means full runs do not refresh TM state while `shard_total > 1`.
+- The shell-block check validates extracted `run: |` scripts, but it is not a substitute for `actionlint`; it does not fully validate workflow expressions, matrix shape, permissions, or action inputs.
+- Old per-locale release dispatch event types still exist for compatibility. Deprecate them after callers migrate to `translate-all-release` so the workflow does not keep unnecessary compatibility surface.
+
 ## Event flow
 
 1. `openclaw/openclaw` syncs English docs into `openclaw/docs`.
 2. GitHub Pages deploys English/source changes immediately from the sync commit.
-3. `Translate All` is triggered by the sync commit, release dispatch, manual dispatch, or weekly schedule.
+3. `Translate Incremental` is triggered by normal English docs changes; `Translate Full` is triggered by glossary changes, release dispatch, manual dispatch, or weekly schedule.
 4. The coordinator waits a cooldown window before starting translation.
 5. After the cooldown, the coordinator reads the current `origin/main` source metadata.
 6. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
@@ -54,7 +103,7 @@ If a locale job fails, its artifact is marked failed and carries no payload. The
 Each locale job uploads one artifact named with locale and source SHA:
 
 ```text
-i18n-zh-cn-<source-sha>
+i18n-zh-cn-s0of14-<source-sha>
 ```
 
 Artifact contents:
@@ -68,6 +117,8 @@ payload/docs/.i18n/<locale>.tm.jsonl
 ```
 
 `metadata.json` includes the locale, locale slug, source SHA, pending count, changed count, and any failure reason. The finalizer rejects artifacts whose `source_sha` does not match the current `.openclaw-sync/source.json`.
+
+For sharded full runs, `metadata.json` also includes `shard_index`, `shard_total`, `worker_parallel`, and `thinking_effort`. The finalizer expects one artifact per locale/shard pair and reports missing, failed, invalid, and stale artifacts separately.
 
 The source repo release workflow dispatches one `translate-all-release` event. The coordinator still accepts old per-locale release events for compatibility, but those are only a fallback.
 


### PR DESCRIPTION
## Summary

- fix the `Prepare locale artifact` heredoc indentation so failed translation shards can still upload failure metadata
- reduce full docs translation matrix fan-out from `54 * 2 = 108` peak Codex workers to `12 * 2 = 24`
- keep 14 shards per locale and 2 workers per shard so per-shard runtime characteristics stay aligned with the existing 6-hour job-limit mitigation

## Verification

- `actionlint .github/workflows/translate-all.yml .github/workflows/translate-locale-reusable.yml`
- `git diff --check -- .github/workflows/translate-all.yml .github/workflows/translate-locale-reusable.yml`
- extracted `Prepare locale artifact` shell block and checked it with `bash -n`
- `$autoreview --mode local --parallel-tests <workflow lint + diff check + heredoc bash -n>`
  - result: `autoreview clean: no accepted/actionable findings reported`
