### PR TITLE
Compact language picker preview

### DIFF
--- a/scripts/docs-site/assets.mjs
+++ b/scripts/docs-site/assets.mjs
@@ -44,6 +44,13 @@ export function siteCss() {
 .oc-mermaid-overlay-canvas svg{display:block;width:max-content;min-width:min(1040px,100%);max-width:none;height:auto;margin:auto}
 .oc-mermaid-overlay-canvas pre{margin:0;white-space:pre;min-width:max-content}
 .has-mermaid-overlay{overflow:hidden}
+.language-menu{top:calc(100% + 8px);width:min(270px,calc(100vw - 32px));max-height:min(62vh,430px);padding:6px;border-radius:16px;scrollbar-width:thin;scrollbar-color:color-mix(in srgb,var(--brand) 58%,transparent) transparent;box-shadow:0 22px 70px rgba(0,0,0,.48),inset 0 1px 0 rgba(255,255,255,.03)}
+.language-menu::-webkit-scrollbar{width:8px}
+.language-menu::-webkit-scrollbar-track{background:transparent}
+.language-menu::-webkit-scrollbar-thumb{background:color-mix(in srgb,var(--brand) 58%,transparent);border:2px solid transparent;border-radius:999px;background-clip:content-box}
+.language-option{grid-template-columns:24px minmax(0,1fr) 18px;gap:8px;padding:8px 10px;border-radius:10px;font-size:15px;line-height:1.15}
+.language-check{font-size:16px}
+@media(max-width:820px){.language-menu{width:min(300px,calc(100vw - 28px));max-height:min(62vh,430px)}}
 `;
 }
 

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -95,34 +95,6 @@ const localeFlags = {
 const localePickerLabels = {
   "pt-BR": "Português (BR)"
 };
-const previewLocalePickerCodes = [
-  "en",
-  "pt-BR",
-  "es",
-  "fr",
-  "de",
-  "ja-JP",
-  "ko",
-  "zh-CN",
-  "it",
-  "ar",
-  "zh-TW",
-  "vi",
-  "nl",
-  "tr",
-  "uk",
-  "id",
-  "pl",
-  "fa",
-  "th",
-  "es-MX"
-];
-const previewLocalePickerLabels = {
-  "es-MX": "Español (MX)"
-};
-const previewLocalePickerFlags = {
-  "es-MX": "🇲🇽"
-};
 
 copyPublicFiles();
 if (!previewMode) await renderPageOgCards();
@@ -402,7 +374,9 @@ function languagePicker(page) {
   const current = locales.find((locale) => locale.code === page.locale) ?? locales[0];
   const currentLabel = localeDisplayName(current.code);
   const currentFlag = localeFlag(current.code);
-  const pickerLocales = languagePickerLocales(page);
+  const pickerLocales = previewMode
+    ? locales.filter((locale) => locale.code === page.locale || pageByKey.has(pageKey(locale.code, page.slug)))
+    : locales;
   const options = pickerLocales.map((locale) => {
     const active = locale.code === page.locale;
     return `<a class="language-option${active ? " active" : ""}" role="option" aria-selected="${active ? "true" : "false"}" href="${escapeAttr(localeUrlForSlug(locale.code, page.slug))}" data-locale-option><span class="locale-flag" aria-hidden="true">${escapeHtml(localeFlag(locale.code))}</span><span class="language-name">${escapeHtml(localeDisplayName(locale.code))}</span><span class="language-check" aria-hidden="true">✓</span></a>`;
@@ -410,19 +384,12 @@ function languagePicker(page) {
   return `<div class="language-picker" data-language-picker><button class="language-trigger" type="button" data-language-trigger aria-haspopup="listbox" aria-expanded="false"><span class="locale-flag" aria-hidden="true">${escapeHtml(currentFlag)}</span><span class="language-current">${escapeHtml(currentLabel)}</span><span class="language-chevron" aria-hidden="true">${icon("chevron-down")}</span></button><div class="language-menu" role="listbox" aria-label="Language">${options}</div></div>`;
 }
 
-function languagePickerLocales(page) {
-  if (!previewMode) return locales;
-  const byCode = new Map(locales.map((locale) => [locale.code, locale]));
-  const codes = [...new Set([page.locale, ...previewLocalePickerCodes])].slice(0, previewLocalePickerCodes.length);
-  return codes.map((code) => byCode.get(code) ?? { code, source: locales[0]?.source, root: code === "en" });
-}
-
 function localeFlag(code) {
-  return previewLocalePickerFlags[code] ?? localeFlags[code] ?? "🌐";
+  return localeFlags[code] ?? "🌐";
 }
 
 function localeDisplayName(code) {
-  return previewLocalePickerLabels[code] ?? localePickerLabels[code] ?? localeLabels[code] ?? code;
+  return localePickerLabels[code] ?? localeLabels[code] ?? code;
 }
 
 function topLink(label, href, iconName) {

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -95,6 +95,34 @@ const localeFlags = {
 const localePickerLabels = {
   "pt-BR": "Português (BR)"
 };
+const previewLocalePickerCodes = [
+  "en",
+  "pt-BR",
+  "es",
+  "fr",
+  "de",
+  "ja-JP",
+  "ko",
+  "zh-CN",
+  "it",
+  "ar",
+  "zh-TW",
+  "vi",
+  "nl",
+  "tr",
+  "uk",
+  "id",
+  "pl",
+  "fa",
+  "th",
+  "es-MX"
+];
+const previewLocalePickerLabels = {
+  "es-MX": "Español (MX)"
+};
+const previewLocalePickerFlags = {
+  "es-MX": "🇲🇽"
+};
 
 copyPublicFiles();
 if (!previewMode) await renderPageOgCards();
@@ -374,9 +402,7 @@ function languagePicker(page) {
   const current = locales.find((locale) => locale.code === page.locale) ?? locales[0];
   const currentLabel = localeDisplayName(current.code);
   const currentFlag = localeFlag(current.code);
-  const pickerLocales = previewMode
-    ? locales.filter((locale) => locale.code === page.locale || pageByKey.has(pageKey(locale.code, page.slug)))
-    : locales;
+  const pickerLocales = languagePickerLocales(page);
   const options = pickerLocales.map((locale) => {
     const active = locale.code === page.locale;
     return `<a class="language-option${active ? " active" : ""}" role="option" aria-selected="${active ? "true" : "false"}" href="${escapeAttr(localeUrlForSlug(locale.code, page.slug))}" data-locale-option><span class="locale-flag" aria-hidden="true">${escapeHtml(localeFlag(locale.code))}</span><span class="language-name">${escapeHtml(localeDisplayName(locale.code))}</span><span class="language-check" aria-hidden="true">✓</span></a>`;
@@ -384,12 +410,19 @@ function languagePicker(page) {
   return `<div class="language-picker" data-language-picker><button class="language-trigger" type="button" data-language-trigger aria-haspopup="listbox" aria-expanded="false"><span class="locale-flag" aria-hidden="true">${escapeHtml(currentFlag)}</span><span class="language-current">${escapeHtml(currentLabel)}</span><span class="language-chevron" aria-hidden="true">${icon("chevron-down")}</span></button><div class="language-menu" role="listbox" aria-label="Language">${options}</div></div>`;
 }
 
+function languagePickerLocales(page) {
+  if (!previewMode) return locales;
+  const byCode = new Map(locales.map((locale) => [locale.code, locale]));
+  const codes = [...new Set([page.locale, ...previewLocalePickerCodes])].slice(0, previewLocalePickerCodes.length);
+  return codes.map((code) => byCode.get(code) ?? { code, source: locales[0]?.source, root: code === "en" });
+}
+
 function localeFlag(code) {
-  return localeFlags[code] ?? "🌐";
+  return previewLocalePickerFlags[code] ?? localeFlags[code] ?? "🌐";
 }
 
 function localeDisplayName(code) {
-  return localePickerLabels[code] ?? localeLabels[code] ?? code;
+  return previewLocalePickerLabels[code] ?? localePickerLabels[code] ?? localeLabels[code] ?? code;
 }
 
 function topLink(label, href, iconName) {

--- a/scripts/docs-site/smoke.mjs
+++ b/scripts/docs-site/smoke.mjs
@@ -243,6 +243,10 @@ if (process.env.DOCS_SITE_CNAME) {
 }
 const siteJs = fs.readFileSync(path.join(site, "assets/docs-site.js"), "utf8");
 const siteCss = fs.readFileSync(path.join(site, "assets/docs-site.css"), "utf8");
+if (!/\.language-menu\{top:calc\(100% \+ 8px\);width:min\(270px,calc\(100vw - 32px\)\);max-height:min\(62vh,430px\)/.test(siteCss)
+  || !/\.language-menu::-webkit-scrollbar-track\{background:transparent\}/.test(siteCss)) {
+  throw new Error("assets: compact language picker is missing");
+}
 try {
   execFileSync(process.execPath, ["--check", path.join(site, "assets/docs-site.js")], { stdio: "pipe" });
 } catch (err) {


### PR DESCRIPTION
## Summary

Compacts the docs language picker while keeping the current visual treatment. The preview build now renders 20 mock locale entries so the scroll state is easy to evaluate before real translated pages are wired in.

The proposed language menu also removes the visible scrollbar track background, leaving only the thumb over the menu surface.

## Screenshots

Compact, after first adjustment:

![Compact language picker](https://verdant-aura-67qz.here.now/droppie-2026-06-16T20-46-12Z.png)

Previously oversized:

![Oversized language picker](https://zen-beacon-eja5.here.now/droppie-2026-06-16T20-46-36Z.png)

New scrollbar treatment proposed in this PR:

![New language picker scrollbar treatment](https://proud-mullet-8wv8.here.now/droppie-2026-06-16T20-52-25Z.png)

## Validation

- `git diff --check HEAD~1..HEAD`
- `DOCS_SITE_PREVIEW_INCLUDE_FIXTURE=1 npm run docs:build:preview`
- `DOCS_SITE_ARTIFACT_MODE=shell DOCS_SITE_PREVIEW_LOCALE=en DOCS_SITE_PREVIEW_PAGES_PER_GROUP=8 DOCS_SITE_PREVIEW_MAX_PAGES=220 DOCS_SITE_PREVIEW_INCLUDE_FIXTURE=1 node scripts/docs-site/build.mjs`
- `npm run docs:visual`
- direct generated HTML/CSS assertion for 20 language options and transparent scrollbar track
