### PR TITLE
fix(security): remove vulnerable docs parser

### DIFF
--- a/.github/workflows/docs-code-ci.yml
+++ b/.github/workflows/docs-code-ci.yml
@@ -52,6 +52,9 @@ jobs:
           find scripts .openclaw-sync -name '*.mjs' -print0 \
             | xargs -0 -n 1 node --check
 
+      - name: Test docs helpers
+        run: npm test
+
       - name: Validate Worker bundle
         run: npx wrangler@4.88.0 deploy --dry-run --config wrangler.toml
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,13 @@
       "name": "openclaw-docs-site",
       "devDependencies": {
         "@resvg/resvg-js": "^2.6.2",
-        "gray-matter": "4.0.3",
         "highlight.js": "11.11.1",
         "markdown-it": "14.2.0",
         "markdown-it-anchor": "9.2.0",
         "mermaid": "11.15.0",
         "pagefind": "1.5.2",
-        "playwright": "^1.60.0"
+        "playwright": "^1.60.0",
+        "yaml": "2.9.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -749,16 +749,6 @@
         "d3-transition": "^3.0.1"
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -1338,9 +1328,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -1371,33 +1361,6 @@
         "benchmarks"
       ]
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1411,22 +1374,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/hachure-fill": {
@@ -1480,30 +1427,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/katex": {
       "version": "0.16.47",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
@@ -1536,16 +1459,6 @@
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
       "dev": true
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/layout-base": {
       "version": "1.0.2",
@@ -1804,37 +1717,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/section-matter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stylis": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
@@ -1881,6 +1763,22 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,16 +15,17 @@
     "docs:smoke": "node scripts/docs-site/smoke.mjs",
     "docs:smoke:shell": "DOCS_SITE_ARTIFACT_MODE=shell node scripts/docs-site/smoke.mjs",
     "docs:visual": "node scripts/docs-site/visual-smoke.mjs",
-    "docs:check": "npm run docs:build && npm run docs:smoke && npm run docs:visual && node --check scripts/docs-site/llms-full.mjs"
+    "docs:check": "npm run docs:build && npm run docs:smoke && npm run docs:visual && node --check scripts/docs-site/llms-full.mjs",
+    "test": "node --test scripts/docs-site/frontmatter.test.mjs"
   },
   "devDependencies": {
     "@resvg/resvg-js": "^2.6.2",
-    "gray-matter": "4.0.3",
     "highlight.js": "11.11.1",
     "markdown-it": "14.2.0",
     "markdown-it-anchor": "9.2.0",
     "mermaid": "11.15.0",
     "pagefind": "1.5.2",
-    "playwright": "^1.60.0"
+    "playwright": "^1.60.0",
+    "yaml": "2.9.0"
   }
 }

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -3,13 +3,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { Worker } from "node:worker_threads";
-import matter from "gray-matter";
 
 import { ignoredDocDirs, ignoredDocFiles, localeLabels, mintlifyLocaleToDir, rtlLocales } from "./config.mjs";
 import { siteCss, siteJs } from "./assets.mjs";
 import { createMarkdownRenderer, renderMdxish } from "./mdx-ish.mjs";
 import { editSourceUrlForPage, frontmatterSourcePath, readSourceMetadata } from "./edit-source.mjs";
 import { elementsFixture } from "./elements-fixture.mjs";
+import { parseFrontmatter } from "./frontmatter.mjs";
 import { renderPageOgSvg } from "./og-card-template.mjs";
 
 const root = process.cwd();
@@ -143,7 +143,7 @@ function collectPages(localeList) {
       const rel = path.relative(base, file).replaceAll(path.sep, "/");
       if (ignoredDocFiles.has(rel) || rel.endsWith("/AGENTS.md")) continue;
       const raw = fs.readFileSync(file, "utf8");
-      const parsed = matter(raw);
+      const parsed = parseFrontmatter(raw);
       const slug = fileSlug(rel);
       const title = parsed.data.title || firstHeading(parsed.content) || titleize(path.basename(slug));
       result.push({
@@ -173,7 +173,7 @@ function collectPages(localeList) {
 }
 
 function elementsFixturePage() {
-  const parsed = matter(elementsFixture);
+  const parsed = parseFrontmatter(elementsFixture);
   return {
     locale: "en",
     dir: "",
@@ -742,7 +742,7 @@ function expandSnippets(input, sourceFile, seen = new Set()) {
     if (!target.startsWith(root) || seen.has(target) || !fs.existsSync(target)) return "";
     const nextSeen = new Set(seen);
     nextSeen.add(target);
-    const parsed = matter(fs.readFileSync(target, "utf8"));
+    const parsed = parseFrontmatter(fs.readFileSync(target, "utf8"));
     return `\n${expandSnippets(parsed.content, target, nextSeen).trim()}\n`;
   });
 }

--- a/scripts/docs-site/frontmatter.mjs
+++ b/scripts/docs-site/frontmatter.mjs
@@ -1,0 +1,18 @@
+import { parse } from "yaml";
+
+const openingDelimiter = /^---[ \t]*\r?\n/u;
+const closingDelimiter = /\r?\n---[ \t]*(?:\r?\n|$)/u;
+
+export function parseFrontmatter(source) {
+  const input = String(source).replace(/^\uFEFF/u, "");
+  const opening = input.match(openingDelimiter);
+  if (!opening) return { data: {}, content: input };
+
+  const frontmatterStart = opening[0].length;
+  const closing = closingDelimiter.exec(input.slice(frontmatterStart));
+  if (!closing || closing.index === undefined) return { data: {}, content: input };
+
+  const data = parse(input.slice(frontmatterStart, frontmatterStart + closing.index)) ?? {};
+  const contentStart = frontmatterStart + closing.index + closing[0].length;
+  return { data, content: input.slice(contentStart) };
+}

--- a/scripts/docs-site/frontmatter.test.mjs
+++ b/scripts/docs-site/frontmatter.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseFrontmatter } from "./frontmatter.mjs";
+
+test("parses YAML frontmatter and strips its delimiters", () => {
+  assert.deepEqual(
+    parseFrontmatter("---\ntitle: Docs\nread_when:\n  - testing\n---\n# Body\n"),
+    {
+      data: { title: "Docs", read_when: ["testing"] },
+      content: "# Body\n",
+    },
+  );
+});
+
+test("returns unprefixed content without frontmatter", () => {
+  assert.deepEqual(parseFrontmatter("# Body\n"), { data: {}, content: "# Body\n" });
+});
+
+test("accepts a UTF-8 byte-order mark", () => {
+  assert.deepEqual(parseFrontmatter("\uFEFF---\ntitle: Docs\n---\n# Body\n"), {
+    data: { title: "Docs" },
+    content: "# Body\n",
+  });
+});

--- a/scripts/docs-site/smoke.mjs
+++ b/scripts/docs-site/smoke.mjs
@@ -2,10 +2,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import matter from "gray-matter";
 
 import { localeLabels } from "./config.mjs";
 import { editSourceUrlForPage, frontmatterSourcePath, readSourceMetadata } from "./edit-source.mjs";
+import { parseFrontmatter } from "./frontmatter.mjs";
 
 const root = process.cwd();
 const site = path.join(root, "dist", "docs-site");
@@ -733,7 +733,7 @@ function pageForRenderedHtml(htmlRel) {
   if (!sourceFile) return null;
 
   const raw = fs.readFileSync(sourceFile, "utf8");
-  const parsed = matter(raw);
+  const parsed = parseFrontmatter(raw);
   return {
     rel: path.relative(base, sourceFile).replaceAll(path.sep, "/"),
     sourcePath: frontmatterSourcePath(parsed.data),


### PR DESCRIPTION
## Summary
- replace gray-matter with yaml 2.9.0 for docs frontmatter parsing, removing vulnerable js-yaml 3.x from the dependency graph
- refresh the Mermaid DOMPurify lockfile entry to 3.4.10
- run the parser regression test in Docs Code CI

## Security
Resolves the open Dependabot alerts for js-yaml and dompurify.

## Verification
- npm ci
- npm test
- npm audit --package-lock-only --audit-level=low
- make docs-check
- npm run docs:visual
- actionlint .github/workflows/docs-code-ci.yml
- autoreview --mode local