### PR TITLE
ci: recover full docs translation workflow

### DIFF
--- a/.github/scripts/i18n/budget_check.py
+++ b/.github/scripts/i18n/budget_check.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
-"""Validate Translate Full matrix and worker fan-out budgets.
+"""Validate Translate Full trigger and worker fan-out budgets.
 
 Definition:
   This script mirrors the budget preflight that previously lived in
-  translate-shell-check-reusable.yml. It intentionally uses the same explicit
-  scalar and block checks instead of a YAML dependency, so local and CI behavior
-  stay aligned without adding package installation.
+  translate-shell-check-reusable.yml. It intentionally uses explicit scalar and
+  block checks instead of a YAML dependency, so local and CI behavior stay
+  aligned without adding package installation.
 
 Parameters:
   --workflow: Path to translate-all.yml.
-  --max-matrix-jobs: GitHub Actions matrix job limit. Default: 256.
-  --max-active-workers: Maximum allowed max-parallel * worker_parallel. Default: 24.
+  --max-batch-size: Maximum locales per full follow-up batch. Default: 3.
+  --max-active-workers: Maximum allowed max-parallel * worker_parallel. Default: 12.
 
 Outputs:
-  Prints the validated locale, shard, matrix, and active worker counts.
-  Exits non-zero when the workflow exceeds a budget or the matrix is malformed.
+  Prints the validated batch, worker, trigger, and concurrency settings.
+  Exits non-zero when the workflow restores forbidden triggers, cancels running
+  full runs, exceeds fan-out, or omits manual locale rerun support.
 
 Examples:
   python .github/scripts/i18n/budget_check.py
-  python .github/scripts/i18n/budget_check.py --workflow /tmp/translate-all.yml --max-active-workers 24
+  python .github/scripts/i18n/budget_check.py --workflow /tmp/translate-all.yml --max-active-workers 12
 """
 
 from __future__ import annotations
@@ -31,61 +32,69 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class Budget:
-    locale_count: int
-    shard_total: int
-    matrix_jobs: int
-    max_parallel: int
+    batch_count: int
+    max_batch_parallel: int
     worker_parallel: int
     active_workers: int
+    cancel_in_progress: bool
 
 
-def scalar_after(text: str, pattern: str, label: str) -> int:
+def scalar_after(text: str, pattern: str, label: str) -> str:
     match = re.search(pattern, text, re.M)
     if not match:
         raise SystemExit(f"missing {label}")
-    return int(match.group(1))
+    return match.group(1)
 
 
-def validate_budget(workflow_path: Path, max_matrix_jobs: int = 256, max_active_workers: int = 24) -> Budget:
+def validate_budget(workflow_path: Path, max_batch_size: int = 3, max_active_workers: int = 12) -> Budget:
     text = workflow_path.read_text(encoding="utf-8")
-    max_parallel = scalar_after(text, r"^\s*max-parallel:\s*([0-9]+)\s*$", "full max-parallel")
-    shard_total = scalar_after(text, r'^\s*shard_total:\s*"([0-9]+)"\s*$', "full shard_total")
-    worker_parallel = scalar_after(text, r'^\s*worker_parallel:\s*"([0-9]+)"\s*$', "full worker_parallel")
 
-    locale_block = re.search(r"(?ms)^\s*locale:\n(?P<body>.*?)(?=^\s*shard_index:)", text)
-    if not locale_block:
-        raise SystemExit("missing full locale matrix")
-    locale_count = len(re.findall(r"^\s*-\s+locale:\s+\S+\s*$", locale_block.group("body"), re.M))
-    if locale_count == 0:
-        raise SystemExit("full locale matrix is empty")
+    if re.search(r"^\s*repository_dispatch:\s*$", text, re.M):
+        raise SystemExit("Translate Full must not be triggered by release repository_dispatch events")
+    if re.search(r'docs/\.i18n/glossary\.\*\.json', text):
+        raise SystemExit("Translate Full must not be triggered by glossary pushes")
+    if not re.search(r"^\s*schedule:\s*$", text, re.M):
+        raise SystemExit("Translate Full must keep weekly schedule")
+    if not re.search(r"^\s*workflow_dispatch:\s*$", text, re.M):
+        raise SystemExit("Translate Full must keep manual dispatch")
+    if not re.search(r"^\s*target_locale:\s*$", text, re.M):
+        raise SystemExit("Translate Full manual dispatch must support target_locale")
 
-    shard_block = re.search(r"(?ms)^\s*shard_index:\n(?P<body>.*?)(?=^\s*uses:)", text)
-    if not shard_block:
-        raise SystemExit("missing full shard_index matrix")
-    shard_indexes = [int(value) for value in re.findall(r"^\s*-\s+([0-9]+)\s*$", shard_block.group("body"), re.M)]
-    expected_indexes = list(range(shard_total))
-    if shard_indexes != expected_indexes:
-        raise SystemExit(f"full shard_index matrix {shard_indexes} does not match shard_total {shard_total}")
+    cancel_in_progress = scalar_after(text, r"^\s*cancel-in-progress:\s*(true|false)\s*$", "full cancel-in-progress") == "true"
+    if cancel_in_progress:
+        raise SystemExit("Translate Full must serialize without cancelling a running full run")
 
-    matrix_jobs = locale_count * shard_total
-    if matrix_jobs > max_matrix_jobs:
-        raise SystemExit(f"full translation matrix has {matrix_jobs} jobs; GitHub Actions limit is {max_matrix_jobs}")
+    max_parallel_values = [int(value) for value in re.findall(r"^\s*max-parallel:\s*([0-9]+)\s*$", text, re.M)]
+    if not max_parallel_values:
+        raise SystemExit("missing full batch max-parallel")
+    max_batch_parallel = max(max_parallel_values)
+    if max_batch_parallel > max_batch_size:
+        raise SystemExit(f"full locale batch parallelism {max_batch_parallel} exceeds budget {max_batch_size}")
 
-    active_workers = max_parallel * worker_parallel
+    worker_values = sorted(set(int(value) for value in re.findall(r'^\s*worker_parallel:\s*"([0-9]+)"\s*$', text, re.M)))
+    if not worker_values:
+        raise SystemExit("missing full worker_parallel")
+    if len(worker_values) != 1:
+        raise SystemExit(f"full workflow has mixed worker_parallel values: {worker_values}")
+    worker_parallel = worker_values[0]
+    active_workers = max_batch_parallel * worker_parallel
+    batch_count = len(re.findall(r"^\s*translate-batch-[0-9]+:\s*$", text, re.M))
+    if batch_count != 6:
+        raise SystemExit(f"expected 6 follow-up batch jobs, found {batch_count}")
+
     # This budget is intentionally explicit so fan-out increases remain reviewable.
     if active_workers > max_active_workers:
         raise SystemExit(
             f"full translation peak workers {active_workers} exceeds budget {max_active_workers} "
-            f"({max_parallel} max-parallel * {worker_parallel} workers)"
+            f"({max_batch_parallel} max-parallel * {worker_parallel} workers)"
         )
 
     return Budget(
-        locale_count=locale_count,
-        shard_total=shard_total,
-        matrix_jobs=matrix_jobs,
-        max_parallel=max_parallel,
+        batch_count=batch_count,
+        max_batch_parallel=max_batch_parallel,
         worker_parallel=worker_parallel,
         active_workers=active_workers,
+        cancel_in_progress=cancel_in_progress,
     )
 
 
@@ -98,21 +107,21 @@ def parse_args() -> argparse.Namespace:
 
 Examples:
   python .github/scripts/i18n/budget_check.py
-  python .github/scripts/i18n/budget_check.py --workflow .github/workflows/translate-all.yml --max-matrix-jobs 256
+  python .github/scripts/i18n/budget_check.py --workflow .github/workflows/translate-all.yml --max-active-workers 12
 """,
     )
     parser.add_argument("--workflow", default=".github/workflows/translate-all.yml", type=Path)
-    parser.add_argument("--max-matrix-jobs", default=256, type=int)
-    parser.add_argument("--max-active-workers", default=24, type=int)
+    parser.add_argument("--max-batch-size", default=3, type=int)
+    parser.add_argument("--max-active-workers", default=12, type=int)
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    budget = validate_budget(args.workflow, args.max_matrix_jobs, args.max_active_workers)
+    budget = validate_budget(args.workflow, args.max_batch_size, args.max_active_workers)
     print(
-        f"full translation budget ok: locales={budget.locale_count} shards={budget.shard_total} "
-        f"matrix_jobs={budget.matrix_jobs} peak_workers={budget.active_workers}"
+        f"full translation budget ok: batches={budget.batch_count} max_parallel={budget.max_batch_parallel} "
+        f"worker_parallel={budget.worker_parallel} peak_workers={budget.active_workers}"
     )
 
 

--- a/.github/scripts/i18n/build_pending_manifest.py
+++ b/.github/scripts/i18n/build_pending_manifest.py
@@ -12,7 +12,8 @@ Parameters:
   --openclaw-sync-dir: State/output directory. Default: .openclaw-sync.
 
 Environment:
-  LOCALE, LOCALE_SLUG, MODE, SHARD_INDEX, SHARD_TOTAL, and GITHUB_OUTPUT.
+  LOCALE, LOCALE_SLUG, MODE, SHARD_INDEX, SHARD_TOTAL, optional
+  PENDING_LIMIT, and GITHUB_OUTPUT.
 
 Outputs:
   Writes docs-i18n-<locale_slug>-s<index>of<total>.txt under --openclaw-sync-dir.
@@ -73,6 +74,16 @@ def validate_shard(index_value: str, total_value: str) -> tuple[int, int]:
     return shard_index, shard_total
 
 
+def validate_pending_limit(value: str) -> int:
+    try:
+        limit = int(value or "0")
+    except ValueError as exc:
+        raise SystemExit(f"invalid PENDING_LIMIT: {value}") from exc
+    if limit < 0:
+        raise SystemExit(f"invalid PENDING_LIMIT: {limit}")
+    return limit
+
+
 def build_pending_manifest(
     docs_root: Path,
     openclaw_sync_dir: Path,
@@ -81,6 +92,7 @@ def build_pending_manifest(
     mode: str,
     shard_index: int,
     shard_total: int,
+    pending_limit: int = 0,
 ) -> PendingResult:
     locale_dirs = {path.name for path in docs_root.iterdir() if is_locale_dir(path)}
     pending_path = openclaw_sync_dir / f"docs-i18n-{locale_slug}-s{shard_index}of{shard_total}.txt"
@@ -105,6 +117,10 @@ def build_pending_manifest(
 
     pending_files = sorted(pending_files)
     shard_files = [file for index, file in enumerate(pending_files) if index % shard_total == shard_index]
+    if pending_limit:
+        # Full canary intentionally translates a tiny deterministic sample; the
+        # follow-up locale batch still runs the complete manifest after the gate.
+        shard_files = shard_files[:pending_limit]
 
     pending_path.parent.mkdir(parents=True, exist_ok=True)
     pending_path.write_text("\n".join(str(file) for file in shard_files) + ("\n" if shard_files else ""), encoding="utf-8")
@@ -140,7 +156,7 @@ def parse_args() -> argparse.Namespace:
 
 Examples:
   LOCALE=fr LOCALE_SLUG=fr MODE=incremental SHARD_INDEX=0 SHARD_TOTAL=1 python .github/scripts/i18n/build_pending_manifest.py
-  LOCALE=zh-CN LOCALE_SLUG=zh-cn MODE=full SHARD_INDEX=1 SHARD_TOTAL=4 python .github/scripts/i18n/build_pending_manifest.py
+  LOCALE=zh-CN LOCALE_SLUG=zh-cn MODE=full SHARD_INDEX=1 SHARD_TOTAL=4 PENDING_LIMIT=1 python .github/scripts/i18n/build_pending_manifest.py
 """,
     )
     parser.add_argument("--docs-root", default="docs", type=Path)
@@ -151,6 +167,7 @@ Examples:
 def main() -> None:
     args = parse_args()
     shard_index, shard_total = validate_shard(os.environ["SHARD_INDEX"], os.environ["SHARD_TOTAL"])
+    pending_limit = validate_pending_limit(os.environ.get("PENDING_LIMIT", "0"))
     result = build_pending_manifest(
         docs_root=args.docs_root,
         openclaw_sync_dir=args.openclaw_sync_dir,
@@ -159,6 +176,7 @@ def main() -> None:
         mode=os.environ["MODE"],
         shard_index=shard_index,
         shard_total=shard_total,
+        pending_limit=pending_limit,
     )
     append_output(result)
 

--- a/.github/scripts/i18n/commit_locale_artifact.py
+++ b/.github/scripts/i18n/commit_locale_artifact.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Commit and publish one applied locale artifact.
+
+Definition:
+  This script owns the per-locale commit/push control plane for full
+  translation recovery. It expects locale files to have already been applied
+  and validated, then commits only docs/<locale> and that locale's translation
+  memory. It retries rebase/push conflicts while guarding against source
+  metadata moving after artifact application.
+
+Parameters:
+  --locale: Locale directory to commit. Default: LOCALE environment variable.
+  --base-source-sha: Source SHA observed after artifact application. Default:
+    BASE_SOURCE_SHA environment variable.
+  --attempts: Push/rebase retry count. Default: 5.
+
+Outputs:
+  GITHUB_OUTPUT receives committed=true or committed=false. The script exits
+  zero when there is nothing to commit or when source metadata moved after
+  apply; it exits non-zero only when a commit should have landed but push/retry
+  failed.
+
+Examples:
+  LOCALE=fr BASE_SOURCE_SHA=abc python .github/scripts/i18n/commit_locale_artifact.py
+  python .github/scripts/i18n/commit_locale_artifact.py --locale zh-CN --base-source-sha abc --attempts 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+
+def run(args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(args, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if check and result.returncode != 0:
+        raise SystemExit(result.stderr.strip() or f"{' '.join(args)} failed")
+    return result
+
+
+def git_stdout(args: list[str], check: bool = True) -> str:
+    return run(["git", *args], check=check).stdout
+
+
+def write_output(key: str, value: str) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    with Path(output).open("a", encoding="utf-8") as fh:
+        fh.write(f"{key}={value}\n")
+
+
+def remote_source_sha() -> str:
+    result = run(["git", "show", "refs/remotes/origin/main:.openclaw-sync/source.json"], check=False)
+    if result.returncode != 0:
+        return ""
+    try:
+        return json.loads(result.stdout).get("sha") or ""
+    except json.JSONDecodeError:
+        return ""
+
+
+def ensure_base_current(base_source_sha: str, locale: str) -> bool:
+    current_source_sha = remote_source_sha()
+    if current_source_sha and current_source_sha != base_source_sha:
+        # Artifact application already did stale-page filtering against latest
+        # main. If main moves again during validation/push, rerun this locale
+        # rather than commit against an unvalidated source base.
+        print(f"Source moved from {base_source_sha} to {current_source_sha}; skipping {locale} translation commit.")
+        write_output("committed", "false")
+        return False
+    return True
+
+
+def has_locale_changes(locale: str) -> bool:
+    result = run(
+        ["git", "status", "--porcelain", "--untracked-files=all", "--", f"docs/{locale}", f"docs/.i18n/{locale}.tm.jsonl"],
+        check=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def commit_locale(locale: str, base_source_sha: str, attempts: int) -> bool:
+    if not has_locale_changes(locale):
+        print(f"No {locale} translation changes.")
+        write_output("committed", "false")
+        return False
+
+    git_stdout(["config", "user.name", "openclaw-docs-i18n[bot]"])
+    git_stdout(["config", "user.email", "openclaw-docs-i18n[bot]@users.noreply.github.com"])
+    git_stdout(["add", f"docs/{locale}", f"docs/.i18n/{locale}.tm.jsonl"])
+    git_stdout(["commit", "-m", f"chore(i18n): refresh {locale} translations"])
+
+    for attempt in range(1, attempts + 1):
+        if run(["git", "fetch", "origin", "main:refs/remotes/origin/main"], check=False).returncode == 0:
+            if not ensure_base_current(base_source_sha, locale):
+                return False
+            if run(["git", "rebase", "origin/main"], check=False).returncode == 0:
+                if not ensure_base_current(base_source_sha, locale):
+                    return False
+                if run(["git", "push", "origin", "HEAD:main"], check=False).returncode == 0:
+                    write_output("committed", "true")
+                    return True
+            run(["git", "rebase", "--abort"], check=False)
+        print(f"{locale} translation push attempt {attempt} failed; retrying.")
+        time.sleep(attempt * 2)
+
+    raise SystemExit(f"Failed to push {locale} translations after retries.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Commit and publish one applied locale artifact.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Outputs:
+  Writes committed=true/false to GITHUB_OUTPUT and pushes docs/<locale> plus locale TM when changed.
+
+Examples:
+  LOCALE=fr BASE_SOURCE_SHA=abc python .github/scripts/i18n/commit_locale_artifact.py
+  python .github/scripts/i18n/commit_locale_artifact.py --locale zh-CN --base-source-sha abc --attempts 3
+""",
+    )
+    parser.add_argument("--locale", default=os.environ.get("LOCALE", ""))
+    parser.add_argument("--base-source-sha", default=os.environ.get("BASE_SOURCE_SHA", ""))
+    parser.add_argument("--attempts", default=5, type=int)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.locale:
+        raise SystemExit("missing locale: pass --locale or set LOCALE")
+    if not args.base_source_sha:
+        raise SystemExit("missing base source sha: pass --base-source-sha or set BASE_SOURCE_SHA")
+    if args.attempts < 1:
+        raise SystemExit("attempts must be >= 1")
+    commit_locale(args.locale, args.base_source_sha, args.attempts)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/i18n/package_artifact.py
+++ b/.github/scripts/i18n/package_artifact.py
@@ -14,12 +14,14 @@ Parameters:
 Environment:
   LOCALE, LOCALE_SLUG, SOURCE_SHA, MODE, SHARD_INDEX, SHARD_TOTAL,
   WORKER_PARALLEL, THINKING_EFFORT, PENDING_COUNT, TOTAL_PENDING_COUNT,
-  ALL_COUNT, TRANSLATE_OUTCOME, MDX_CHECK_OUTCOME, MDX_REPAIR_OUTCOME,
-  MDX_SCOPE_OUTCOME, and MDX_RECHECK_OUTCOME.
+  ALL_COUNT, optional ARTIFACT_ROLE, TRANSLATE_OUTCOME, MDX_CHECK_OUTCOME,
+  MDX_REPAIR_OUTCOME, MDX_SCOPE_OUTCOME, and MDX_RECHECK_OUTCOME.
 
 Outputs:
   Writes .openclaw-sync/artifacts/<locale_slug>-s<index>of<total>/ with
   changed-files.txt, deleted-files.txt, payload/, and metadata.json.
+  GITHUB_OUTPUT receives failed, failed_reason, changed_count, and deleted_count.
+  GITHUB_STEP_SUMMARY receives a concise per-locale artifact status.
 
 Examples:
   LOCALE=fr LOCALE_SLUG=fr SOURCE_SHA=abc MODE=incremental SHARD_INDEX=0 SHARD_TOTAL=1 python .github/scripts/i18n/package_artifact.py
@@ -87,6 +89,35 @@ def write_lines(path: Path, lines: list[str]) -> None:
     path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
 
 
+def append_outputs(metadata: dict[str, object]) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    failed_reason = str(metadata.get("failed_reason") or "")
+    with Path(output).open("a", encoding="utf-8") as fh:
+        fh.write(f"failed={'true' if failed_reason else 'false'}\n")
+        fh.write(f"failed_reason={failed_reason}\n")
+        fh.write(f"changed_count={metadata.get('changed_count', 0)}\n")
+        fh.write(f"deleted_count={metadata.get('deleted_count', 0)}\n")
+
+
+def append_summary(metadata: dict[str, object]) -> None:
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary:
+        return
+    with Path(summary).open("a", encoding="utf-8") as fh:
+        fh.write("### Locale artifact\n\n")
+        fh.write(f"- locale: `{metadata['locale']}`\n")
+        fh.write(f"- mode: `{metadata['mode']}`\n")
+        fh.write(f"- shard: `{metadata['shard_index']}/{metadata['shard_total']}`\n")
+        fh.write(f"- pending docs: `{metadata['pending_count']}`\n")
+        fh.write(f"- changed files: `{metadata['changed_count']}`\n")
+        fh.write(f"- deleted files: `{metadata['deleted_count']}`\n")
+        failed_reason = str(metadata.get("failed_reason") or "")
+        if failed_reason:
+            fh.write(f"- failure: `{failed_reason}`\n")
+
+
 def package_artifact(workspace: Path, openclaw_sync_dir: Path) -> dict[str, object]:
     locale = os.environ["LOCALE"]
     locale_slug = os.environ["LOCALE_SLUG"]
@@ -139,6 +170,7 @@ def package_artifact(workspace: Path, openclaw_sync_dir: Path) -> dict[str, obje
         "locale_slug": locale_slug,
         "source_sha": os.environ["SOURCE_SHA"],
         "mode": os.environ["MODE"],
+        "artifact_role": os.environ.get("ARTIFACT_ROLE", "locale"),
         "shard_index": shard_index,
         "shard_total": shard_total,
         "worker_parallel": env_int("WORKER_PARALLEL"),
@@ -156,6 +188,8 @@ def package_artifact(workspace: Path, openclaw_sync_dir: Path) -> dict[str, obje
         "failed_reason": failed_reason,
     }
     (artifact_dir / "metadata.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    append_outputs(metadata)
+    append_summary(metadata)
     print(json.dumps(metadata, indent=2, sort_keys=True))
     return metadata
 
@@ -165,7 +199,7 @@ def parse_args() -> argparse.Namespace:
         description="Package one locale shard artifact for the translation finalizer.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""Outputs:
-  Writes changed/deleted lists, payload files, and metadata.json under .openclaw-sync/artifacts.
+  Writes changed/deleted lists, payload files, metadata.json, and GitHub output status.
 
 Examples:
   LOCALE=fr LOCALE_SLUG=fr SOURCE_SHA=abc MODE=incremental SHARD_INDEX=0 SHARD_TOTAL=1 python .github/scripts/i18n/package_artifact.py

--- a/.github/scripts/i18n/plan_full.py
+++ b/.github/scripts/i18n/plan_full.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Plan Translate Full locale canary and bounded batches.
+
+Definition:
+  This script owns the full-translation locale selection policy. It turns a
+  manual target locale or an all-locale run into one canary locale plus bounded
+  follow-up batches. GitHub Actions consumes the emitted JSON matrices.
+
+Parameters:
+  --target-locale: Locale slug/name to rerun, or all. Default: TARGET_LOCALE/all.
+  --batch-size: Maximum locales per follow-up batch. Default: 3.
+
+Outputs:
+  GITHUB_OUTPUT receives locale_count, canary_locale, canary_locale_slug,
+  selected_locales, and batch_1 through batch_6 JSON matrices. The step summary
+  records the selected canary and batch count. Exits non-zero for unknown
+  locales or oversized batch requests.
+
+Examples:
+  python .github/scripts/i18n/plan_full.py --target-locale all
+  python .github/scripts/i18n/plan_full.py --target-locale fr --batch-size 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+MAX_BATCHES = 6
+DEFAULT_BATCH_SIZE = 3
+LOCALES: tuple[tuple[str, str], ...] = (
+    ("zh-CN", "zh-cn"),
+    ("zh-TW", "zh-tw"),
+    ("ja-JP", "ja-jp"),
+    ("es", "es"),
+    ("pt-BR", "pt-br"),
+    ("ko", "ko"),
+    ("de", "de"),
+    ("fr", "fr"),
+    ("ar", "ar"),
+    ("it", "it"),
+    ("vi", "vi"),
+    ("nl", "nl"),
+    ("fa", "fa"),
+    ("tr", "tr"),
+    ("uk", "uk"),
+    ("id", "id"),
+    ("pl", "pl"),
+    ("th", "th"),
+)
+
+
+@dataclass(frozen=True)
+class Locale:
+    locale: str
+    locale_slug: str
+
+    def matrix_item(self) -> dict[str, str]:
+        return {"locale": self.locale, "locale_slug": self.locale_slug}
+
+
+def all_locales() -> list[Locale]:
+    return [Locale(locale, slug) for locale, slug in LOCALES]
+
+
+def normalize_target(value: str) -> str:
+    return (value or "all").strip()
+
+
+def select_locales(target_locale: str) -> list[Locale]:
+    target = normalize_target(target_locale)
+    locales = all_locales()
+    if target.lower() == "all":
+        return locales
+    for locale in locales:
+        if target in {locale.locale, locale.locale_slug}:
+            return [locale]
+    allowed = ", ".join(["all", *(locale.locale_slug for locale in locales)])
+    raise SystemExit(f"unknown target locale {target!r}; expected one of: {allowed}")
+
+
+def build_batches(selected: list[Locale], batch_size: int) -> list[list[Locale]]:
+    if batch_size < 1 or batch_size > DEFAULT_BATCH_SIZE:
+        raise SystemExit(f"invalid batch size {batch_size}; expected 1..{DEFAULT_BATCH_SIZE}")
+    batches = [selected[index : index + batch_size] for index in range(0, len(selected), batch_size)]
+    if len(batches) > MAX_BATCHES:
+        raise SystemExit(f"full translation needs {len(batches)} batches; max supported is {MAX_BATCHES}")
+    return batches
+
+
+def matrix_json(locales: list[Locale]) -> str:
+    return json.dumps({"include": [locale.matrix_item() for locale in locales]}, separators=(",", ":"))
+
+
+def append_outputs(selected: list[Locale], batches: list[list[Locale]]) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    canary = selected[0]
+    with Path(output).open("a", encoding="utf-8") as fh:
+        fh.write(f"locale_count={len(selected)}\n")
+        fh.write(f"canary_locale={canary.locale}\n")
+        fh.write(f"canary_locale_slug={canary.locale_slug}\n")
+        fh.write(f"selected_locales={','.join(locale.locale for locale in selected)}\n")
+        for index in range(MAX_BATCHES):
+            batch = batches[index] if index < len(batches) else []
+            fh.write(f"batch_{index + 1}_count={len(batch)}\n")
+            fh.write(f"batch_{index + 1}={matrix_json(batch)}\n")
+
+
+def append_summary(target_locale: str, selected: list[Locale], batches: list[list[Locale]]) -> None:
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary:
+        return
+    with Path(summary).open("a", encoding="utf-8") as fh:
+        fh.write("### Translate Full locale plan\n\n")
+        fh.write(f"- requested target: `{normalize_target(target_locale)}`\n")
+        fh.write(f"- selected locales: `{', '.join(locale.locale for locale in selected)}`\n")
+        fh.write(f"- canary locale: `{selected[0].locale}`\n")
+        for index, batch in enumerate(batches, start=1):
+            fh.write(f"- batch {index}: `{', '.join(locale.locale for locale in batch)}`\n")
+
+
+def plan_full(target_locale: str, batch_size: int) -> dict[str, object]:
+    selected = select_locales(target_locale)
+    batches = build_batches(selected, batch_size)
+    append_outputs(selected, batches)
+    append_summary(target_locale, selected, batches)
+    return {
+        "selected": [locale.matrix_item() for locale in selected],
+        "canary": selected[0].matrix_item(),
+        "batches": [[locale.matrix_item() for locale in batch] for batch in batches],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Plan Translate Full locale canary and bounded follow-up batches.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Outputs:
+  Writes canary locale fields and batch_1..batch_6 JSON matrices to GITHUB_OUTPUT.
+
+Examples:
+  python .github/scripts/i18n/plan_full.py --target-locale all
+  TARGET_LOCALE=fr python .github/scripts/i18n/plan_full.py --batch-size 2
+""",
+    )
+    parser.add_argument("--target-locale", default=os.environ.get("TARGET_LOCALE", "all"))
+    parser.add_argument("--batch-size", default=DEFAULT_BATCH_SIZE, type=int)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    plan = plan_full(args.target_locale, args.batch_size)
+    print(json.dumps(plan, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/i18n/prepare.py
+++ b/.github/scripts/i18n/prepare.py
@@ -22,7 +22,7 @@ Outputs:
 
 Examples:
   EVENT_NAME=workflow_dispatch python .github/scripts/i18n/prepare.py --mode incremental --title "Translate Incremental"
-  EVENT_NAME=repository_dispatch python .github/scripts/i18n/prepare.py --mode full --title "Translate Full"
+  EVENT_NAME=workflow_dispatch python .github/scripts/i18n/prepare.py --mode full --title "Translate Full"
 """
 
 from __future__ import annotations
@@ -106,6 +106,18 @@ def is_translatable_doc_path(path: str) -> bool:
     return rel.lower().endswith((".md", ".mdx"))
 
 
+def incremental_should_translate_paths(changed_paths: list[str]) -> bool:
+    has_glossary_change = any(re.match(r"^docs/\.i18n/glossary\..*\.json$", path) for path in changed_paths)
+    has_translatable_docs = any(is_translatable_doc_path(path) for path in changed_paths)
+    if not has_translatable_docs:
+        if has_glossary_change:
+            print("Glossary-only change; weekly or manual full reconciliation will pick it up.")
+            return False
+        print("No translatable docs changed after cooldown; skipping translation matrix.")
+        return False
+    return True
+
+
 def incremental_should_translate(before_sha: str, publish_ref: str) -> bool:
     diff = subprocess.run(
         ["git", "diff", "--name-only", before_sha, publish_ref],
@@ -114,13 +126,7 @@ def incremental_should_translate(before_sha: str, publish_ref: str) -> bool:
         stderr=subprocess.DEVNULL,
     )
     changed_paths = [line.strip() for line in diff.stdout.splitlines() if line.strip()]
-    if any(re.match(r"^docs/\.i18n/glossary\..*\.json$", path) for path in changed_paths):
-        print("Glossary changed; full lane owns this translation.")
-        return False
-    if not any(is_translatable_doc_path(path) for path in changed_paths):
-        print("No translatable docs changed after cooldown; skipping translation matrix.")
-        return False
-    return True
+    return incremental_should_translate_paths(changed_paths)
 
 
 def append_github_output(values: dict[str, str]) -> None:
@@ -149,8 +155,6 @@ def default_cooldown(mode: str, event_name: str, requested: str, default: str) -
     if requested:
         return requested
     if mode == "incremental" and event_name == "push":
-        return default
-    if mode == "full" and event_name in {"push", "repository_dispatch"}:
         return default
     return "0"
 
@@ -228,7 +232,7 @@ def parse_args() -> argparse.Namespace:
 
 Examples:
   EVENT_NAME=workflow_dispatch python .github/scripts/i18n/prepare.py --mode incremental --title "Translate Incremental"
-  EVENT_NAME=repository_dispatch python .github/scripts/i18n/prepare.py --mode full --title "Translate Full"
+  EVENT_NAME=workflow_dispatch python .github/scripts/i18n/prepare.py --mode full --title "Translate Full"
 """,
     )
     parser.add_argument("--mode", choices=["incremental", "full"], required=True)

--- a/.github/scripts/i18n/provider_preflight.py
+++ b/.github/scripts/i18n/provider_preflight.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Validate the shared translation provider credentials before locale fan-out.
+
+Definition:
+  This script performs the translation workflow provider/key gate. It supports
+  the OpenAI provider used by docs-i18n, runs a minimal Responses API probe,
+  classifies common credential/model/quota failures, and fails before expensive
+  locale matrices are scheduled.
+
+Parameters:
+  --provider: Translation provider. Default: OPENCLAW_DOCS_I18N_PROVIDER/openai.
+  --model: Model name to validate. Default: OPENCLAW_DOCS_I18N_MODEL.
+  --timeout-seconds: HTTP timeout. Default: 30.
+  --status-code and --response-file: Test-only inputs for local classification.
+
+Outputs:
+  Prints a short success line or failure classification. GITHUB_OUTPUT receives
+  provider_preflight=ok and failure_class when available. Exit code is non-zero
+  for missing keys, unsupported providers, denied model access, quota/rate-limit
+  responses, or unknown API failures.
+
+Examples:
+  OPENAI_API_KEY=sk-... OPENCLAW_DOCS_I18N_MODEL=gpt-5.5 python .github/scripts/i18n/provider_preflight.py
+  python .github/scripts/i18n/provider_preflight.py --status-code 401 --response-file /tmp/openai-error.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
+
+
+@dataclass(frozen=True)
+class ApiResponse:
+    status_code: int
+    body: str
+
+
+def append_output(values: dict[str, str]) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    with Path(output).open("a", encoding="utf-8") as fh:
+        for key, value in values.items():
+            fh.write(f"{key}={value}\n")
+
+
+def parse_error_code(body: str) -> str:
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return ""
+    error = data.get("error")
+    if isinstance(error, dict):
+        code = error.get("code") or error.get("type") or ""
+        return str(code)
+    return ""
+
+
+def classify_response(status_code: int, body: str) -> tuple[bool, str, str]:
+    code = parse_error_code(body)
+    if 200 <= status_code < 300:
+        return True, "ok", "provider preflight ok"
+    if code == "insufficient_quota":
+        return False, "quota_exhausted", "OpenAI reported insufficient quota for the translation key"
+    if status_code == 401:
+        return False, "invalid_key", "OpenAI rejected the translation API key"
+    if status_code == 403:
+        return False, "model_access_denied", "OpenAI denied access to the requested translation model"
+    if status_code == 404:
+        return False, "model_not_found", "OpenAI could not find the requested translation model"
+    if status_code == 429:
+        return False, "rate_limited", "OpenAI rate-limited the translation preflight"
+    if "model" in code and "not" in code:
+        return False, "model_not_found", "OpenAI could not find the requested translation model"
+    return False, "provider_error", f"OpenAI preflight failed with HTTP {status_code}"
+
+
+def openai_probe_request(model: str, api_key: str, timeout_seconds: int) -> ApiResponse:
+    payload = json.dumps(
+        {
+            "model": model,
+            "input": "Reply with ok.",
+            "max_output_tokens": 8,
+            "store": False,
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        OPENAI_RESPONSES_URL,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310 - fixed OpenAI API URL.
+            body = response.read().decode("utf-8", errors="replace")
+            return ApiResponse(status_code=response.status, body=body)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return ApiResponse(status_code=exc.code, body=body)
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"provider_error: OpenAI preflight network failure: {exc}") from exc
+
+
+def load_test_response(status_code: int | None, response_file: Path | None) -> ApiResponse | None:
+    if status_code is None:
+        return None
+    body = response_file.read_text(encoding="utf-8") if response_file else ""
+    return ApiResponse(status_code=status_code, body=body)
+
+
+def provider_preflight(
+    provider: str,
+    model: str,
+    timeout_seconds: int,
+    test_response: ApiResponse | None = None,
+) -> str:
+    if provider != "openai":
+        append_output({"provider_preflight": "failed", "failure_class": "unsupported_provider"})
+        raise SystemExit(f"unsupported_provider: {provider}")
+    if not model:
+        append_output({"provider_preflight": "failed", "failure_class": "missing_model"})
+        raise SystemExit("missing_model: OPENCLAW_DOCS_I18N_MODEL is required")
+
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if test_response is None and not api_key:
+        append_output({"provider_preflight": "failed", "failure_class": "missing_key"})
+        raise SystemExit("missing_key: OPENAI_API_KEY is required for translation")
+
+    response = test_response or openai_probe_request(model, api_key, timeout_seconds)
+    ok, failure_class, message = classify_response(response.status_code, response.body)
+    append_output({"provider_preflight": "ok" if ok else "failed", "failure_class": "" if ok else failure_class})
+    if not ok:
+        raise SystemExit(f"{failure_class}: {message}")
+    print(f"provider preflight ok: provider={provider} model={model}")
+    return failure_class
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate translation provider credentials before locale fan-out.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Outputs:
+  Prints a concise provider/key result and writes provider_preflight/failure_class to GITHUB_OUTPUT.
+
+Examples:
+  OPENAI_API_KEY=sk-... OPENCLAW_DOCS_I18N_MODEL=gpt-5.5 python .github/scripts/i18n/provider_preflight.py
+  python .github/scripts/i18n/provider_preflight.py --status-code 429 --response-file /tmp/error.json
+""",
+    )
+    parser.add_argument("--provider", default=os.environ.get("OPENCLAW_DOCS_I18N_PROVIDER", "openai"))
+    parser.add_argument("--model", default=os.environ.get("OPENCLAW_DOCS_I18N_MODEL", ""))
+    parser.add_argument("--timeout-seconds", default=30, type=int)
+    parser.add_argument("--status-code", type=int, help="Test-only HTTP status to classify instead of calling the provider.")
+    parser.add_argument("--response-file", type=Path, help="Test-only provider response body for --status-code.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    test_response = load_test_response(args.status_code, args.response_file)
+    provider_preflight(args.provider, args.model, args.timeout_seconds, test_response)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/i18n/summarize_full.py
+++ b/.github/scripts/i18n/summarize_full.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Summarize a Translate Full run by locale artifact status.
+
+Definition:
+  This script reads downloaded full translation artifacts and writes a
+  locale-oriented GitHub summary. It is intentionally report-only: workflow job
+  results remain the source of truth for pass/fail, while this summary explains
+  which locales succeeded, failed, or were skipped before artifact creation.
+
+Parameters:
+  --selected-locales: Comma-separated locale names selected by plan_full.py.
+  --artifacts-root: Downloaded artifact directory. Default:
+    .openclaw-sync/i18n-artifacts.
+  --canary-result: GitHub job result for the canary job.
+  --provider-result: GitHub job result for provider preflight.
+
+Outputs:
+  GITHUB_STEP_SUMMARY receives successful locales, failed locales, skipped
+  locales, and artifact counts. The script also prints the summary JSON.
+
+Examples:
+  python .github/scripts/i18n/summarize_full.py --selected-locales zh-CN,fr
+  python .github/scripts/i18n/summarize_full.py --selected-locales fr --canary-result failure
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class FullSummary:
+    successful: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    invalid: list[str] = field(default_factory=list)
+    artifact_count: int = 0
+    metadata_only_count: int = 0
+
+
+def parse_selected(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def read_artifacts(artifacts_root: Path) -> tuple[dict[str, dict[str, object]], list[str], int, int]:
+    artifacts: dict[str, dict[str, object]] = {}
+    invalid: list[str] = []
+    artifact_count = 0
+    metadata_only_count = 0
+    if not artifacts_root.exists():
+        return artifacts, invalid, artifact_count, metadata_only_count
+
+    for artifact in sorted(path for path in artifacts_root.rglob("*") if path.is_dir() and (path / "metadata.json").exists()):
+        artifact_count += 1
+        try:
+            metadata = json.loads((artifact / "metadata.json").read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            invalid.append(f"{artifact.name}: invalid metadata ({exc})")
+            continue
+        locale = str(metadata.get("locale") or "")
+        if not locale:
+            invalid.append(f"{artifact.name}: missing locale")
+            continue
+        changed_count = int(metadata.get("changed_count") or 0)
+        deleted_count = int(metadata.get("deleted_count") or 0)
+        failed_reason = str(metadata.get("failed_reason") or "")
+        artifact_role = str(metadata.get("artifact_role") or "locale")
+        if failed_reason and changed_count == 0 and deleted_count == 0:
+            metadata_only_count += 1
+        if artifact_role == "canary":
+            continue
+        existing = artifacts.get(locale)
+        if existing is None or (not existing.get("failed_reason") and failed_reason):
+            artifacts[locale] = metadata
+    return artifacts, invalid, artifact_count, metadata_only_count
+
+
+def summarize_full(selected_locales: list[str], artifacts_root: Path, provider_result: str, canary_result: str) -> FullSummary:
+    artifacts, invalid, artifact_count, metadata_only_count = read_artifacts(artifacts_root)
+    summary = FullSummary(invalid=invalid, artifact_count=artifact_count, metadata_only_count=metadata_only_count)
+
+    for locale in selected_locales:
+        metadata = artifacts.get(locale)
+        if metadata is None:
+            if provider_result != "success":
+                summary.skipped.append(f"{locale}: provider preflight {provider_result}")
+            elif canary_result != "success":
+                summary.skipped.append(f"{locale}: canary {canary_result}")
+            else:
+                summary.skipped.append(f"{locale}: no artifact")
+            continue
+        failed_reason = str(metadata.get("failed_reason") or "")
+        if failed_reason:
+            summary.failed.append(f"{locale}: {failed_reason}")
+        else:
+            changed = metadata.get("changed_count", 0)
+            deleted = metadata.get("deleted_count", 0)
+            summary.successful.append(f"{locale}: changed={changed} deleted={deleted}")
+    return summary
+
+
+def append_summary(summary: FullSummary) -> None:
+    output = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not output:
+        return
+    with Path(output).open("a", encoding="utf-8") as fh:
+        fh.write("### Translate Full locale artifacts\n\n")
+        fh.write(f"- artifact count: `{summary.artifact_count}`\n")
+        fh.write(f"- metadata-only failure artifacts: `{summary.metadata_only_count}`\n")
+        fh.write(f"- successful locales: `{', '.join(summary.successful) if summary.successful else 'none'}`\n")
+        fh.write(f"- failed locales: `{', '.join(summary.failed) if summary.failed else 'none'}`\n")
+        fh.write(f"- skipped locales: `{', '.join(summary.skipped) if summary.skipped else 'none'}`\n")
+        if summary.invalid:
+            fh.write(f"- invalid artifacts: `{' ; '.join(summary.invalid)}`\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Summarize Translate Full locale artifact status.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Outputs:
+  Writes a locale-level artifact summary to GITHUB_STEP_SUMMARY and prints JSON.
+
+Examples:
+  python .github/scripts/i18n/summarize_full.py --selected-locales zh-CN,fr
+  python .github/scripts/i18n/summarize_full.py --selected-locales fr --canary-result failure
+""",
+    )
+    parser.add_argument("--selected-locales", required=True)
+    parser.add_argument("--artifacts-root", default=".openclaw-sync/i18n-artifacts", type=Path)
+    parser.add_argument("--provider-result", default=os.environ.get("PROVIDER_RESULT", "unknown"))
+    parser.add_argument("--canary-result", default=os.environ.get("CANARY_RESULT", "unknown"))
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    summary = summarize_full(parse_selected(args.selected_locales), args.artifacts_root, args.provider_result, args.canary_result)
+    append_summary(summary)
+    print(json.dumps(summary.__dict__, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/i18n/tests/test_i18n_scripts.py
+++ b/.github/scripts/i18n/tests/test_i18n_scripts.py
@@ -36,6 +36,9 @@ package_artifact = load_module("package_artifact")
 apply_artifacts = load_module("apply_artifacts")
 read_source_metadata = load_module("read_source_metadata")
 prune_stale_locale_pages = load_module("prune_stale_locale_pages")
+plan_full = load_module("plan_full")
+provider_preflight = load_module("provider_preflight")
+summarize_full = load_module("summarize_full")
 
 
 @contextmanager
@@ -120,10 +123,11 @@ class I18NScriptTests(unittest.TestCase):
             stdout=subprocess.PIPE,
         ).stdout.splitlines()
         changed_paths = changed + untracked
+        allowed_docs_paths = {"docs/.i18n/translation-workflow.md"}
         generated_docs = [
             path
             for path in changed_paths
-            if path.startswith("docs/")
+            if (path.startswith("docs/") and path not in allowed_docs_paths)
             or path == "docs/docs.json"
             or (
                 path.startswith(".openclaw-sync/")
@@ -144,19 +148,37 @@ class I18NScriptTests(unittest.TestCase):
             self.assertIn('echo "__GITHUB_EXPR__"', scripts[0].read_text(encoding="utf-8"))
             workflow_shell_check.check_bash_syntax(scripts)
 
-    def test_budget_check_accepts_current_full_matrix_and_rejects_worker_over_budget(self) -> None:
+    def test_budget_check_accepts_current_full_batches_and_rejects_worker_over_budget(self) -> None:
         budget = budget_check.validate_budget(REPO_ROOT / ".github/workflows/translate-all.yml")
-        self.assertEqual(18, budget.locale_count)
-        self.assertEqual(14, budget.shard_total)
-        self.assertEqual(252, budget.matrix_jobs)
-        self.assertEqual(24, budget.active_workers)
+        self.assertEqual(6, budget.batch_count)
+        self.assertEqual(3, budget.max_batch_parallel)
+        self.assertEqual(3, budget.worker_parallel)
+        self.assertEqual(9, budget.active_workers)
+        self.assertFalse(budget.cancel_in_progress)
 
         with tempfile.TemporaryDirectory() as tmp:
             workflow = Path(tmp) / "translate-all.yml"
             text = (REPO_ROOT / ".github/workflows/translate-all.yml").read_text(encoding="utf-8")
-            workflow.write_text(text.replace("max-parallel: 12", "max-parallel: 13"), encoding="utf-8")
+            workflow.write_text(text.replace('worker_parallel: "3"', 'worker_parallel: "5"'), encoding="utf-8")
             with self.assertRaises(SystemExit):
                 budget_check.validate_budget(workflow)
+
+    def test_full_workflow_keeps_only_weekly_and_manual_triggers(self) -> None:
+        text = (REPO_ROOT / ".github/workflows/translate-all.yml").read_text(encoding="utf-8")
+        self.assertNotIn("repository_dispatch:", text)
+        self.assertNotIn('"docs/.i18n/glossary.*.json"', text)
+        self.assertIn("schedule:", text)
+        self.assertIn("workflow_dispatch:", text)
+        self.assertIn("target_locale:", text)
+        self.assertIn("cancel-in-progress: false", text)
+
+    def test_full_workflow_gates_batches_after_canary(self) -> None:
+        text = (REPO_ROOT / ".github/workflows/translate-all.yml").read_text(encoding="utf-8")
+        for index in range(1, 7):
+            self.assertIn(f"translate-batch-{index}:", text)
+            self.assertIn("needs.translate-canary.result == 'success'", text)
+        self.assertIn("provider-preflight:", text)
+        self.assertIn("Translate Full completed with failed or cancelled work", text)
 
     def test_prepare_path_selection_matches_incremental_rules(self) -> None:
         self.assertTrue(prepare.is_translatable_doc_path("docs/guide/setup.mdx"))
@@ -166,7 +188,35 @@ class I18NScriptTests(unittest.TestCase):
         self.assertFalse(prepare.is_translatable_doc_path("docs/.generated/api.md"))
         self.assertEqual("3600", prepare.default_cooldown("incremental", "push", "", "3600"))
         self.assertEqual("0", prepare.default_cooldown("incremental", "workflow_dispatch", "", "3600"))
-        self.assertEqual("3600", prepare.default_cooldown("full", "repository_dispatch", "", "3600"))
+        self.assertEqual("0", prepare.default_cooldown("full", "schedule", "", "3600"))
+        self.assertFalse(prepare.incremental_should_translate_paths(["docs/.i18n/glossary.fr.json"]))
+        self.assertTrue(prepare.incremental_should_translate_paths(["docs/.i18n/glossary.fr.json", "docs/guide/setup.mdx"]))
+
+    def test_full_plan_all_uses_canary_and_small_batches(self) -> None:
+        result = plan_full.plan_full("all", 3)
+        self.assertEqual("zh-CN", result["canary"]["locale"])
+        self.assertEqual(6, len(result["batches"]))
+        self.assertLessEqual(max(len(batch) for batch in result["batches"]), 3)
+        self.assertEqual(18, sum(len(batch) for batch in result["batches"]))
+
+    def test_full_plan_manual_single_locale_only_selects_target(self) -> None:
+        result = plan_full.plan_full("fr", 3)
+        self.assertEqual({"locale": "fr", "locale_slug": "fr"}, result["canary"])
+        self.assertEqual([[{"locale": "fr", "locale_slug": "fr"}]], result["batches"])
+        with self.assertRaises(SystemExit):
+            plan_full.plan_full("xx", 3)
+
+    def test_provider_preflight_classifies_key_model_and_quota_failures(self) -> None:
+        self.assertEqual((False, "invalid_key", "OpenAI rejected the translation API key"), provider_preflight.classify_response(401, "{}"))
+        self.assertEqual(
+            (False, "model_access_denied", "OpenAI denied access to the requested translation model"),
+            provider_preflight.classify_response(403, "{}"),
+        )
+        self.assertEqual(
+            (False, "quota_exhausted", "OpenAI reported insufficient quota for the translation key"),
+            provider_preflight.classify_response(429, '{"error":{"code":"insufficient_quota"}}'),
+        )
+        self.assertEqual((True, "ok", "provider preflight ok"), provider_preflight.classify_response(200, "{}"))
 
     def test_read_source_metadata_validates_requested_sha_and_outputs_fields(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -238,6 +288,25 @@ class I18NScriptTests(unittest.TestCase):
             self.assertEqual(2, result.all_count)
             self.assertEqual(1, result.total_pending_count)
             self.assertTrue(result.shard_files[0].as_posix().endswith("/docs/guide/setup.mdx"))
+
+    def test_pending_manifest_canary_limit_keeps_total_count_but_limits_sample(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            shutil.copytree(FIXTURES / "pending-docs" / "docs", tmp_path / "docs")
+
+            result = pending.build_pending_manifest(
+                docs_root=tmp_path / "docs",
+                openclaw_sync_dir=tmp_path / ".openclaw-sync",
+                locale="fr",
+                locale_slug="fr",
+                mode="full",
+                shard_index=0,
+                shard_total=1,
+                pending_limit=1,
+            )
+
+            self.assertEqual(2, result.total_pending_count)
+            self.assertEqual(1, result.pending_count)
 
     def test_package_artifact_keeps_only_allowed_changed_paths_and_payload(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -321,6 +390,69 @@ class I18NScriptTests(unittest.TestCase):
             self.assertEqual("translation failed", metadata["failed_reason"])
             self.assertEqual("", (artifact / "changed-files.txt").read_text(encoding="utf-8"))
             self.assertEqual("", (artifact / "deleted-files.txt").read_text(encoding="utf-8"))
+
+    def test_package_artifact_failure_writes_visible_github_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            (repo / ".openclaw-sync").mkdir()
+            (repo / "docs").mkdir()
+            (repo / "docs/index.md").write_text("# Index\n", encoding="utf-8")
+            run_git(repo, "add", ".")
+            run_git(repo, "commit", "-m", "initial")
+            output = repo / "github-output.txt"
+
+            with chdir(repo), env(
+                {
+                    "GITHUB_WORKSPACE": str(repo),
+                    "GITHUB_OUTPUT": str(output),
+                    "LOCALE": "fr",
+                    "LOCALE_SLUG": "fr",
+                    "SOURCE_SHA": "source-a",
+                    "MODE": "incremental",
+                    "SHARD_INDEX": "0",
+                    "SHARD_TOTAL": "1",
+                    "WORKER_PARALLEL": "8",
+                    "THINKING_EFFORT": "medium",
+                    "PENDING_COUNT": "1",
+                    "TOTAL_PENDING_COUNT": "1",
+                    "ALL_COUNT": "1",
+                    "TRANSLATE_OUTCOME": "failure",
+                    "MDX_CHECK_OUTCOME": "skipped",
+                    "MDX_REPAIR_OUTCOME": "skipped",
+                    "MDX_SCOPE_OUTCOME": "skipped",
+                    "MDX_RECHECK_OUTCOME": "skipped",
+                }
+            ):
+                package_artifact.package_artifact(repo, Path(".openclaw-sync"))
+
+            self.assertIn("failed=true", output.read_text(encoding="utf-8"))
+            self.assertIn("failed_reason=translation failed", output.read_text(encoding="utf-8"))
+
+    def test_full_summary_ignores_canary_as_locale_success_and_reports_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = Path(tmp)
+            self._write_artifact(
+                artifacts,
+                "canary",
+                metadata={
+                    "artifact_role": "canary",
+                    "failed_reason": "",
+                    "locale": "fr",
+                    "locale_slug": "fr",
+                    "mode": "full",
+                    "shard_index": 0,
+                    "shard_total": 1,
+                    "source_sha": "source-a",
+                    "changed_count": 1,
+                    "deleted_count": 0,
+                },
+            )
+
+            summary = summarize_full.summarize_full(["fr"], artifacts, "success", "success")
+
+            self.assertEqual([], summary.successful)
+            self.assertEqual(["fr: no artifact"], summary.skipped)
 
     def test_apply_artifacts_applies_normal_fixture(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -1,32 +1,6 @@
 name: Translate Full
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "docs/.i18n/glossary.*.json"
-  repository_dispatch:
-    types:
-      - translate-all-release
-      - translate-ar-release
-      - translate-de-release
-      - translate-es-release
-      - translate-fa-release
-      - translate-fr-release
-      - translate-id-release
-      - translate-it-release
-      - translate-ja-jp-release
-      - translate-ko-release
-      - translate-nl-release
-      - translate-pl-release
-      - translate-pt-br-release
-      - translate-th-release
-      - translate-tr-release
-      - translate-uk-release
-      - translate-vi-release
-      - translate-zh-cn-release
-      - translate-zh-tw-release
   schedule:
     - cron: "17 3 * * 0"
   workflow_dispatch:
@@ -36,6 +10,31 @@ on:
         required: true
         default: "0"
         type: string
+      target_locale:
+        description: Locale slug to rerun, or all.
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - zh-cn
+          - zh-tw
+          - ja-jp
+          - es
+          - pt-br
+          - ko
+          - de
+          - fr
+          - ar
+          - it
+          - vi
+          - nl
+          - fa
+          - tr
+          - uk
+          - id
+          - pl
+          - th
 
 permissions:
   actions: write
@@ -43,7 +42,7 @@ permissions:
 
 concurrency:
   group: docs-i18n-full
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   validate-workflow-shell:
@@ -70,7 +69,7 @@ jobs:
         id: prepare
         env:
           EVENT_NAME: ${{ github.event_name }}
-          REQUESTED_COOLDOWN_SECONDS: ${{ inputs.cooldown_seconds || github.event.client_payload.cooldown_seconds || '' }}
+          REQUESTED_COOLDOWN_SECONDS: ${{ inputs.cooldown_seconds || '' }}
           DEFAULT_COOLDOWN_SECONDS: ${{ vars.OPENCLAW_DOCS_TRANSLATION_COOLDOWN_SECONDS || '3600' }}
           DEFAULT_MAX_WAIT_SECONDS: ${{ vars.OPENCLAW_DOCS_TRANSLATION_MAX_WAIT_SECONDS || vars.OPENCLAW_DOCS_TRANSLATION_COOLDOWN_SECONDS || '3600' }}
         run: |
@@ -78,88 +77,327 @@ jobs:
 
           python .github/scripts/i18n/prepare.py --mode full --title "Translate Full"
 
-  translate:
-    name: Translate ${{ matrix.locale.locale }} shard ${{ matrix.shard_index }}/14
+  plan:
+    name: Plan full locale batches
     needs: prepare
     if: needs.prepare.outputs.should_translate == 'true'
-    strategy:
-      fail-fast: false
-      # Keep Codex API fan-out below the 108-worker peak that made failures expensive.
-      max-parallel: 12
-      matrix:
-        locale:
-          - locale: zh-CN
-            locale_slug: zh-cn
-          - locale: zh-TW
-            locale_slug: zh-tw
-          - locale: ja-JP
-            locale_slug: ja-jp
-          - locale: es
-            locale_slug: es
-          - locale: pt-BR
-            locale_slug: pt-br
-          - locale: ko
-            locale_slug: ko
-          - locale: de
-            locale_slug: de
-          - locale: fr
-            locale_slug: fr
-          - locale: ar
-            locale_slug: ar
-          - locale: it
-            locale_slug: it
-          - locale: vi
-            locale_slug: vi
-          - locale: nl
-            locale_slug: nl
-          - locale: fa
-            locale_slug: fa
-          - locale: tr
-            locale_slug: tr
-          - locale: uk
-            locale_slug: uk
-          - locale: id
-            locale_slug: id
-          - locale: pl
-            locale_slug: pl
-          - locale: th
-            locale_slug: th
-        shard_index:
-          - 0
-          - 1
-          - 2
-          - 3
-          - 4
-          - 5
-          - 6
-          - 7
-          - 8
-          - 9
-          - 10
-          - 11
-          - 12
-          - 13
+    runs-on: ubuntu-latest
+    outputs:
+      locale_count: ${{ steps.plan.outputs.locale_count }}
+      canary_locale: ${{ steps.plan.outputs.canary_locale }}
+      canary_locale_slug: ${{ steps.plan.outputs.canary_locale_slug }}
+      selected_locales: ${{ steps.plan.outputs.selected_locales }}
+      batch_1_count: ${{ steps.plan.outputs.batch_1_count }}
+      batch_1: ${{ steps.plan.outputs.batch_1 }}
+      batch_2_count: ${{ steps.plan.outputs.batch_2_count }}
+      batch_2: ${{ steps.plan.outputs.batch_2 }}
+      batch_3_count: ${{ steps.plan.outputs.batch_3_count }}
+      batch_3: ${{ steps.plan.outputs.batch_3 }}
+      batch_4_count: ${{ steps.plan.outputs.batch_4_count }}
+      batch_4: ${{ steps.plan.outputs.batch_4 }}
+      batch_5_count: ${{ steps.plan.outputs.batch_5_count }}
+      batch_5: ${{ steps.plan.outputs.batch_5 }}
+      batch_6_count: ${{ steps.plan.outputs.batch_6_count }}
+      batch_6: ${{ steps.plan.outputs.batch_6 }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Build full locale plan
+        id: plan
+        env:
+          TARGET_LOCALE: ${{ inputs.target_locale || 'all' }}
+        run: |
+          set -euo pipefail
+
+          python .github/scripts/i18n/plan_full.py --batch-size 3
+
+  provider-preflight:
+    name: Check translation provider
+    needs:
+      - prepare
+      - plan
+    if: needs.prepare.outputs.should_translate == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Validate OpenAI key and model
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
+          OPENCLAW_DOCS_I18N_PROVIDER: openai
+          OPENCLAW_DOCS_I18N_MODEL: gpt-5.5
+        run: |
+          set -euo pipefail
+
+          python .github/scripts/i18n/provider_preflight.py
+
+  translate-canary:
+    name: Canary ${{ needs.plan.outputs.canary_locale }}
+    needs:
+      - prepare
+      - plan
+      - provider-preflight
+    if: needs.prepare.outputs.should_translate == 'true'
     uses: ./.github/workflows/translate-locale-reusable.yml
     with:
-      locale: ${{ matrix.locale.locale }}
-      locale_slug: ${{ matrix.locale.locale_slug }}
+      locale: ${{ needs.plan.outputs.canary_locale }}
+      locale_slug: ${{ needs.plan.outputs.canary_locale_slug }}
       publish_ref: ${{ needs.prepare.outputs.publish_ref }}
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
-      shard_index: ${{ matrix.shard_index }}
-      shard_total: "14"
-      worker_parallel: "2"
+      shard_index: "0"
+      shard_total: "1"
+      worker_parallel: "3"
       thinking_effort: "medium"
+      pending_limit: "1"
+      artifact_prefix: i18n-canary
+      artifact_role: canary
+      commit_locale: false
     secrets: inherit
 
-  finalize:
-    name: Commit successful locale artifacts
+  translate-batch-1:
+    name: Full batch 1
     needs:
       - prepare
-      - translate
-    if: always() && needs.prepare.result == 'success' && needs.prepare.outputs.should_translate == 'true'
-    uses: ./.github/workflows/translate-finalize-reusable.yml
+      - plan
+      - translate-canary
+    if: always() && needs.prepare.outputs.should_translate == 'true' && needs.translate-canary.result == 'success' && needs.plan.outputs.batch_1_count != '0'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.plan.outputs.batch_1) }}
+    uses: ./.github/workflows/translate-locale-reusable.yml
     with:
+      locale: ${{ matrix.locale }}
+      locale_slug: ${{ matrix.locale_slug }}
+      publish_ref: ${{ needs.prepare.outputs.publish_ref }}
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
-      shard_total: "14"
+      shard_index: "0"
+      shard_total: "1"
+      worker_parallel: "3"
+      thinking_effort: "medium"
+      pending_limit: "0"
+      artifact_prefix: i18n
+      artifact_role: locale
+      commit_locale: true
+    secrets: inherit
+
+  translate-batch-2:
+    name: Full batch 2
+    needs:
+      - prepare
+      - plan
+      - translate-canary
+      - translate-batch-1
+    if: always() && needs.prepare.outputs.should_translate == 'true' && needs.translate-canary.result == 'success' && needs.plan.outputs.batch_2_count != '0'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.plan.outputs.batch_2) }}
+    uses: ./.github/workflows/translate-locale-reusable.yml
+    with:
+      locale: ${{ matrix.locale }}
+      locale_slug: ${{ matrix.locale_slug }}
+      publish_ref: ${{ needs.prepare.outputs.publish_ref }}
+      source_sha: ${{ needs.prepare.outputs.source_sha }}
+      mode: ${{ needs.prepare.outputs.mode }}
+      shard_index: "0"
+      shard_total: "1"
+      worker_parallel: "3"
+      thinking_effort: "medium"
+      pending_limit: "0"
+      artifact_prefix: i18n
+      artifact_role: locale
+      commit_locale: true
+    secrets: inherit
+
+  translate-batch-3:
+    name: Full batch 3
+    needs:
+      - prepare
+      - plan
+      - translate-canary
+      - translate-batch-2
+    if: always() && needs.prepare.outputs.should_translate == 'true' && needs.translate-canary.result == 'success' && needs.plan.outputs.batch_3_count != '0'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.plan.outputs.batch_3) }}
+    uses: ./.github/workflows/translate-locale-reusable.yml
+    with:
+      locale: ${{ matrix.locale }}
+      locale_slug: ${{ matrix.locale_slug }}
+      publish_ref: ${{ needs.prepare.outputs.publish_ref }}
+      source_sha: ${{ needs.prepare.outputs.source_sha }}
+      mode: ${{ needs.prepare.outputs.mode }}
+      shard_index: "0"
+      shard_total: "1"
+      worker_parallel: "3"
+      thinking_effort: "medium"
+      pending_limit: "0"
+      artifact_prefix: i18n
+      artifact_role: locale
+      commit_locale: true
+    secrets: inherit
+
+  translate-batch-4:
+    name: Full batch 4
+    needs:
+      - prepare
+      - plan
+      - translate-canary
+      - translate-batch-3
+    if: always() && needs.prepare.outputs.should_translate == 'true' && needs.translate-canary.result == 'success' && needs.plan.outputs.batch_4_count != '0'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.plan.outputs.batch_4) }}
+    uses: ./.github/workflows/translate-locale-reusable.yml
+    with:
+      locale: ${{ matrix.locale }}
+      locale_slug: ${{ matrix.locale_slug }}
+      publish_ref: ${{ needs.prepare.outputs.publish_ref }}
+      source_sha: ${{ needs.prepare.outputs.source_sha }}
+      mode: ${{ needs.prepare.outputs.mode }}
+      shard_index: "0"
+      shard_total: "1"
+      worker_parallel: "3"
+      thinking_effort: "medium"
+      pending_limit: "0"
+      artifact_prefix: i18n
+      artifact_role: locale
+      commit_locale: true
+    secrets: inherit
+
+  translate-batch-5:
+    name: Full batch 5
+    needs:
+      - prepare
+      - plan
+      - translate-canary
+      - translate-batch-4
+    if: always() && needs.prepare.outputs.should_translate == 'true' && needs.translate-canary.result == 'success' && needs.plan.outputs.batch_5_count != '0'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.plan.outputs.batch_5) }}
+    uses: ./.github/workflows/translate-locale-reusable.yml
+    with:
+      locale: ${{ matrix.locale }}
+      locale_slug: ${{ matrix.locale_slug }}
+      publish_ref: ${{ needs.prepare.outputs.publish_ref }}
+      source_sha: ${{ needs.prepare.outputs.source_sha }}
+      mode: ${{ needs.prepare.outputs.mode }}
+      shard_index: "0"
+      shard_total: "1"
+      worker_parallel: "3"
+      thinking_effort: "medium"
+      pending_limit: "0"
+      artifact_prefix: i18n
+      artifact_role: locale
+      commit_locale: true
+    secrets: inherit
+
+  translate-batch-6:
+    name: Full batch 6
+    needs:
+      - prepare
+      - plan
+      - translate-canary
+      - translate-batch-5
+    if: always() && needs.prepare.outputs.should_translate == 'true' && needs.translate-canary.result == 'success' && needs.plan.outputs.batch_6_count != '0'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.plan.outputs.batch_6) }}
+    uses: ./.github/workflows/translate-locale-reusable.yml
+    with:
+      locale: ${{ matrix.locale }}
+      locale_slug: ${{ matrix.locale_slug }}
+      publish_ref: ${{ needs.prepare.outputs.publish_ref }}
+      source_sha: ${{ needs.prepare.outputs.source_sha }}
+      mode: ${{ needs.prepare.outputs.mode }}
+      shard_index: "0"
+      shard_total: "1"
+      worker_parallel: "3"
+      thinking_effort: "medium"
+      pending_limit: "0"
+      artifact_prefix: i18n
+      artifact_role: locale
+      commit_locale: true
+    secrets: inherit
+
+  full-status:
+    name: Report full translation status
+    needs:
+      - prepare
+      - plan
+      - provider-preflight
+      - translate-canary
+      - translate-batch-1
+      - translate-batch-2
+      - translate-batch-3
+      - translate-batch-4
+      - translate-batch-5
+      - translate-batch-6
+    if: always() && needs.prepare.outputs.should_translate == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Download full locale artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: i18n-*-${{ needs.prepare.outputs.source_sha }}
+          path: .openclaw-sync/i18n-artifacts
+
+      - name: Summarize full run
+        env:
+          SELECTED_LOCALES: ${{ needs.plan.outputs.selected_locales }}
+          LOCALE_COUNT: ${{ needs.plan.outputs.locale_count }}
+          PROVIDER_RESULT: ${{ needs.provider-preflight.result }}
+          CANARY_RESULT: ${{ needs.translate-canary.result }}
+          BATCH_1_RESULT: ${{ needs.translate-batch-1.result }}
+          BATCH_2_RESULT: ${{ needs.translate-batch-2.result }}
+          BATCH_3_RESULT: ${{ needs.translate-batch-3.result }}
+          BATCH_4_RESULT: ${{ needs.translate-batch-4.result }}
+          BATCH_5_RESULT: ${{ needs.translate-batch-5.result }}
+          BATCH_6_RESULT: ${{ needs.translate-batch-6.result }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "### Translate Full status"
+            echo
+            echo "- selected locales: \`${SELECTED_LOCALES}\`"
+            echo "- locale count: \`${LOCALE_COUNT}\`"
+            echo "- provider preflight: \`${PROVIDER_RESULT}\`"
+            echo "- canary: \`${CANARY_RESULT}\`"
+            echo "- batch 1: \`${BATCH_1_RESULT}\`"
+            echo "- batch 2: \`${BATCH_2_RESULT}\`"
+            echo "- batch 3: \`${BATCH_3_RESULT}\`"
+            echo "- batch 4: \`${BATCH_4_RESULT}\`"
+            echo "- batch 5: \`${BATCH_5_RESULT}\`"
+            echo "- batch 6: \`${BATCH_6_RESULT}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          python .github/scripts/i18n/summarize_full.py \
+            --selected-locales "${SELECTED_LOCALES}" \
+            --provider-result "${PROVIDER_RESULT}" \
+            --canary-result "${CANARY_RESULT}"
+
+          for result in "${PROVIDER_RESULT}" "${CANARY_RESULT}" "${BATCH_1_RESULT}" "${BATCH_2_RESULT}" "${BATCH_3_RESULT}" "${BATCH_4_RESULT}" "${BATCH_5_RESULT}" "${BATCH_6_RESULT}"; do
+            case "${result}" in
+              success|skipped)
+                ;;
+              *)
+                echo "Translate Full completed with failed or cancelled work: ${result}" >&2
+                exit 1
+                ;;
+            esac
+          done

--- a/.github/workflows/translate-incremental.yml
+++ b/.github/workflows/translate-incremental.yml
@@ -77,7 +77,9 @@ jobs:
 
   translate:
     name: Translate ${{ matrix.locale }}
-    needs: prepare
+    needs:
+      - prepare
+      - provider-preflight
     if: needs.prepare.outputs.should_translate == 'true'
     strategy:
       fail-fast: false
@@ -130,14 +132,38 @@ jobs:
       shard_total: "1"
       worker_parallel: "8"
       thinking_effort: "medium"
+      pending_limit: "0"
+      artifact_prefix: i18n
+      artifact_role: locale
+      commit_locale: false
     secrets: inherit
+
+  provider-preflight:
+    name: Check translation provider
+    needs: prepare
+    if: needs.prepare.outputs.should_translate == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Validate OpenAI key and model
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
+          OPENCLAW_DOCS_I18N_PROVIDER: openai
+          OPENCLAW_DOCS_I18N_MODEL: gpt-5.5
+        run: |
+          set -euo pipefail
+
+          python .github/scripts/i18n/provider_preflight.py
 
   finalize:
     name: Commit successful locale artifacts
     needs:
       - prepare
+      - provider-preflight
       - translate
-    if: always() && needs.prepare.result == 'success' && needs.prepare.outputs.should_translate == 'true'
+    if: always() && needs.prepare.result == 'success' && needs.provider-preflight.result == 'success' && needs.prepare.outputs.should_translate == 'true'
     uses: ./.github/workflows/translate-finalize-reusable.yml
     with:
       source_sha: ${{ needs.prepare.outputs.source_sha }}

--- a/.github/workflows/translate-locale-reusable.yml
+++ b/.github/workflows/translate-locale-reusable.yml
@@ -30,14 +30,29 @@ on:
       thinking_effort:
         required: true
         type: string
-
-permissions:
-  contents: read
+      pending_limit:
+        required: false
+        default: "0"
+        type: string
+      artifact_prefix:
+        required: false
+        default: i18n
+        type: string
+      artifact_role:
+        required: false
+        default: locale
+        type: string
+      commit_locale:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   translate:
     name: Translate ${{ inputs.locale }} shard ${{ inputs.shard_index }}/${{ inputs.shard_total }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     concurrency:
       group: translate-${{ inputs.locale_slug }}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}
       cancel-in-progress: false
@@ -47,6 +62,7 @@ jobs:
         with:
           ref: ${{ inputs.publish_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Read source metadata
         id: meta
@@ -101,6 +117,7 @@ jobs:
           MODE: ${{ inputs.mode }}
           SHARD_INDEX: ${{ inputs.shard_index }}
           SHARD_TOTAL: ${{ inputs.shard_total }}
+          PENDING_LIMIT: ${{ inputs.pending_limit }}
         run: |
           python .github/scripts/i18n/build_pending_manifest.py
 
@@ -224,6 +241,7 @@ jobs:
             --json-out ".openclaw-sync/mdx/${LOCALE}.json"
 
       - name: Prepare locale artifact
+        id: package
         if: steps.stale.outputs.skip != 'true'
         env:
           LOCALE: ${{ inputs.locale }}
@@ -242,6 +260,7 @@ jobs:
           MDX_REPAIR_OUTCOME: ${{ steps.mdx_repair.outcome || 'skipped' }}
           MDX_SCOPE_OUTCOME: ${{ steps.mdx_scope.outcome || 'skipped' }}
           MDX_RECHECK_OUTCOME: ${{ steps.mdx_recheck.outcome || 'skipped' }}
+          ARTIFACT_ROLE: ${{ inputs.artifact_role }}
         run: |
           set -euo pipefail
 
@@ -251,6 +270,105 @@ jobs:
         if: steps.stale.outputs.skip != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: i18n-${{ inputs.locale_slug }}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}-${{ inputs.source_sha }}
+          name: ${{ inputs.artifact_prefix }}-${{ inputs.locale_slug }}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}-${{ inputs.source_sha }}
           path: .openclaw-sync/artifacts/${{ inputs.locale_slug }}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}
           retention-days: 7
+
+      - name: Fail failed locale artifact
+        if: steps.stale.outputs.skip != 'true' && steps.package.outputs.failed == 'true'
+        env:
+          FAILED_REASON: ${{ steps.package.outputs.failed_reason }}
+        run: |
+          {
+            echo "Locale artifact records a failed translation."
+            echo "Failure: ${FAILED_REASON}"
+            echo "The artifact was uploaded before failing this job so the status and artifact contract stay aligned."
+          } >&2
+          exit 1
+
+  commit-locale:
+    name: Commit ${{ inputs.locale }} artifact
+    needs: translate
+    if: inputs.commit_locale && needs.translate.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+    concurrency:
+      group: docs-i18n-finalize
+      cancel-in-progress: false
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download locale artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact_prefix }}-${{ inputs.locale_slug }}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}-${{ inputs.source_sha }}
+          path: .openclaw-sync/i18n-artifacts/${{ inputs.locale_slug }}-s${{ inputs.shard_index }}of${{ inputs.shard_total }}
+
+      - name: Apply locale artifact
+        id: apply
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          MODE: ${{ inputs.mode }}
+          SHARD_TOTAL: ${{ inputs.shard_total }}
+          EXPECTED_LOCALES: ${{ inputs.locale_slug }}=${{ inputs.locale }}
+        run: |
+          set -euo pipefail
+
+          python .github/scripts/i18n/apply_artifacts.py \
+            --source-sha "${SOURCE_SHA}" \
+            --mode "${MODE}" \
+            --shard-total "${SHARD_TOTAL}" \
+            --expected-locales "${EXPECTED_LOCALES}"
+
+      - name: Set up Node for locale validation
+        if: steps.apply.outputs.changed_count != '0'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install docs dependencies
+        if: steps.apply.outputs.changed_count != '0'
+        run: npm ci
+
+      - name: Install validation system dependencies
+        if: steps.apply.outputs.changed_count != '0'
+        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
+
+      - name: Check docs before locale commit
+        if: steps.apply.outputs.changed_count != '0'
+        run: npm run docs:check
+
+      - name: Commit locale refresh
+        id: locale_commit
+        if: steps.apply.outputs.changed_count != '0'
+        env:
+          BASE_SOURCE_SHA: ${{ steps.apply.outputs.base_source_sha }}
+          LOCALE: ${{ inputs.locale }}
+        run: |
+          set -euo pipefail
+
+          python .github/scripts/i18n/commit_locale_artifact.py
+
+      - name: Dispatch locale docs deploy
+        if: steps.locale_commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh workflow run pages.yml --ref main
+
+      - name: Fail incomplete locale artifact
+        if: steps.apply.outputs.incomplete_count != '0'
+        run: |
+          {
+            echo "Locale finalizer found missing or failed artifact data."
+            cat .openclaw-sync/i18n-incomplete-locales.txt
+          } >&2
+          exit 1

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -5,41 +5,47 @@ Internal note for the docs publish pipeline. This file is under `docs/.i18n`, wh
 ## Goals
 
 - English docs deploy quickly after every source docs sync.
-- Locale translation does not run for every hot `main` commit.
-- Translation work is debounced so a burst of docs commits becomes one translation wave.
-- Locale jobs translate only pages whose source hash changed since the last successful locale output.
-- Successful locale outputs are committed together, even if one or more locale jobs fail.
-- A weekly reconciliation reruns every locale/page path to repair missed or flaky translations.
+- Incremental translation does not run for every hot `main` commit.
+- Full reconciliation is a recovery path, not a release path.
+- Full reconciliation runs automatically only on the weekly schedule, or manually when an operator starts it.
+- A failed full run can be retried for one locale without rerunning every locale.
+- Provider/key failures stop before locale fan-out.
+- A tiny canary sample must succeed before follow-up full batches start.
+- Locale translation failures are visible as failed GitHub jobs, even when diagnostic artifacts were uploaded.
 
-## Event flow
+## Event Flow
 
 1. `openclaw/openclaw` syncs English docs into `openclaw/docs`.
 2. GitHub Pages deploys English/source changes immediately from the sync commit.
-3. `Translate All` is triggered by the sync commit, release dispatch, manual dispatch, or weekly schedule.
-4. The coordinator waits a cooldown window before starting translation.
-5. After the cooldown, the coordinator reads the current `origin/main` source metadata.
-6. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.
-7. Per-locale translation jobs run in parallel with `fail-fast: false`.
-8. Each locale job uploads an artifact for the requested source SHA.
-9. The finalizer downloads available artifacts, ignores stale or failed payloads, and pushes one aggregate i18n commit.
-10. After the aggregate commit lands, the finalizer dispatches the Pages deploy once.
-11. The Pages workflow dispatches live smoke after deployment.
+3. `Translate Incremental` debounces source-doc pushes and translates stale locale pages.
+4. `Translate Full` runs only from the weekly schedule or `workflow_dispatch`.
+5. Both workflows read the current `origin/main` source metadata after debounce.
+6. Both workflows run the shared OpenAI provider/key preflight before any locale job.
+7. Full translation plans one canary locale sample and bounded follow-up batches of up to three locales.
+8. If the canary fails, follow-up full batches do not start.
+9. Full locale jobs validate, commit, and dispatch deploy independently after that locale succeeds.
+10. Incremental locale jobs still upload artifacts for the aggregate finalizer.
+11. Failed locale jobs upload failure metadata before failing the job, so artifacts and CI status agree.
 
-## Debounce policy
+## Trigger Policy
 
-The coordinator waits 1 hour after a docs sync or release dispatch, then re-reads `origin/main`.
+`Translate Full` deliberately does not listen to release dispatches or glossary pushes. Release and glossary changes converge through the weekly full run. For urgent recovery, manually run `Translate Full` with `target_locale=all` or a single locale slug.
 
-The default cooldown is controlled by the publish repo variable `OPENCLAW_DOCS_TRANSLATION_COOLDOWN_SECONDS`, which defaults to `3600`. Repository dispatch callers may override it with `client_payload.cooldown_seconds`, and manual runs may set `cooldown_seconds`.
+Top-level full workflow concurrency is serialized with `cancel-in-progress: false`. A new full run waits for a running full run instead of cancelling it.
 
-If `.openclaw-sync/source.json` changed during the wait, it waits again from the newer state. If `main` keeps moving, the wait is capped by `OPENCLAW_DOCS_TRANSLATION_MAX_WAIT_SECONDS`, which defaults to the cooldown value. The newest observed state is translated after the cap.
+Manual `target_locale` accepts `all` or one locale slug such as `fr`, `ja-jp`, or `zh-cn`. A single-locale rerun uses that locale for the canary sample, then schedules only that locale in the first full batch.
 
-Manual and weekly runs do not wait by default.
+## Debounce Policy
 
-## Incremental translation
+The coordinator waits after push-triggered incremental runs. The default cooldown is controlled by `OPENCLAW_DOCS_TRANSLATION_COOLDOWN_SECONDS`, which defaults to `3600`. Manual and weekly runs do not wait by default unless the manual input sets `cooldown_seconds`.
+
+If `.openclaw-sync/source.json` changed during a wait, the workflow waits again from the newer state. If `main` keeps moving, the wait is capped by `OPENCLAW_DOCS_TRANSLATION_MAX_WAIT_SECONDS`, which defaults to the cooldown value.
+
+## Incremental Translation
 
 Each translated page stores `x-i18n.source_hash`. Locale jobs compare the current English page hash with the stored locale hash.
 
-Normal runs translate only:
+Normal incremental runs translate only:
 
 - missing locale pages
 - locale pages with stale `x-i18n.source_hash`
@@ -47,14 +53,32 @@ Normal runs translate only:
 
 Internal files under `docs/.i18n/**` are not translation inputs. Push-triggered runs that only change internal i18n files skip before the locale matrix.
 
-If a locale job fails, its artifact is marked failed and carries no payload. The finalizer still commits successful locales. The failed locale remains stale and is picked up by the next incremental run because its source hashes still do not match.
+Incremental translation uses the provider/key preflight before expanding the locale matrix. If the key is invalid, model access is denied, or quota is exhausted, the preflight job fails and locale jobs are not scheduled.
 
-## Artifact contract
+## Full Translation
 
-Each locale job uploads one artifact named with locale and source SHA:
+Full mode forces every source page for the selected locale into the pending manifest instead of relying on changed source hashes.
+
+The weekly all-locale plan is:
 
 ```text
-i18n-zh-cn-<source-sha>
+provider/key preflight
+  -> canary locale sample
+  -> batch 1, up to 3 locales
+  -> batch 2, up to 3 locales
+  -> ...
+  -> status summary
+```
+
+The canary is a deterministic one-document sample from the first selected locale. It uploads a `canary` artifact for diagnostics but does not commit or publish. If it fails, later batches are skipped. If it succeeds, the selected locales, including the canary locale, run in normal full batches. If a later locale fails, already successful locales remain committed and published, and the failed locale can be rerun manually.
+
+## Artifact Contract
+
+Each locale job uploads one artifact named with role, locale, shard, and source SHA:
+
+```text
+i18n-zh-cn-s0of1-<source-sha>
+i18n-canary-zh-cn-s0of1-<source-sha>
 ```
 
 Artifact contents:
@@ -67,45 +91,51 @@ payload/docs/<locale>/**
 payload/docs/.i18n/<locale>.tm.jsonl
 ```
 
-`metadata.json` includes the locale, locale slug, source SHA, pending count, changed count, and any failure reason. The finalizer rejects artifacts whose `source_sha` does not match the current `.openclaw-sync/source.json`.
+`metadata.json` includes the artifact role, locale, locale slug, source SHA, pending count, changed count, deleted count, step outcomes, and failure reason. A failed translation writes an empty payload contract, uploads the artifact, then fails the job. Full status summaries count canary artifacts separately and do not treat a canary artifact as a successful locale refresh.
 
-The source repo release workflow dispatches one `translate-all-release` event. The coordinator still accepts old per-locale release events for compatibility, but those are only a fallback.
+## Commit And Deploy Policy
 
-## Aggregate commit
+Full locale jobs are the commit and publish unit. After a locale succeeds, a separate write-permission commit job downloads that locale artifact, applies it to latest `main`, runs `npm run docs:check`, commits only `docs/<locale>/**` and `docs/.i18n/<locale>.tm.jsonl`, pushes with rebase/retry under the shared locale finalizer concurrency, and dispatches `pages.yml`.
 
-The finalizer owns the only locale push in the normal path.
+Artifact application is intentionally conservative when source metadata has moved. The apply step uses latest `main`, copies only payload pages whose embedded `x-i18n.source_hash` still matches the current source page, and skips stale translation memory. If `main` moves again between apply/validation and push, the commit script skips that locale commit so the next manual or weekly run can re-evaluate from the new base.
 
-Commit message:
+Incremental translation keeps the aggregate finalizer. The finalizer downloads available artifacts, applies valid successful payloads, rejects stale or failed artifacts, runs `npm run docs:check`, pushes one aggregate i18n commit, dispatches `pages.yml`, and fails when required locale artifacts are missing or failed.
 
-```text
-chore(i18n): refresh translations
+## Automatic Verification
+
+The script test suite validates the recovery controls:
+
+- `Translate Full` has no release dispatch trigger.
+- glossary pushes do not trigger `Translate Full`.
+- weekly and manual triggers remain present.
+- manual single-locale planning selects only that locale.
+- full canary manifests keep the total pending count but translate only a bounded sample.
+- provider/key preflight classifies invalid key, model access, and quota failures.
+- canary success gates follow-up full batches.
+- full worker fan-out stays within the small-batch budget.
+- full status summaries report locale success, failure, skip reason, and artifact counts from metadata.
+- failed artifact metadata produces visible GitHub output status.
+- locale artifact application still rejects missing, failed, stale, and invalid artifacts.
+
+Run locally:
+
+```bash
+python -m unittest .github/scripts/i18n/tests/test_i18n_scripts.py
+python .github/scripts/i18n/workflow_shell_check.py --check-bash
+python .github/scripts/i18n/budget_check.py
 ```
 
-The commit may contain a partial locale set. The job summary lists applied locales, locales with no changes, missing or failed locales, stale artifacts, and invalid artifacts.
+## Manual Verification
 
-## Weekly reconciliation
+Before merging workflow recovery changes:
 
-The weekly run uses `full` mode. It forces a full reconciliation across every locale and every source page instead of relying only on changed source hashes.
-
-Glossary changes also force full reconciliation because glossary guidance can affect pages whose source hashes did not change.
-
-Expected behavior:
-
-- regenerate or verify every locale page
-- prune stale locale pages
-- refresh translation memory as needed
-- still use parallel locale jobs
-- still commit one aggregate result
-- still tolerate individual locale failures
-
-The weekly run is the repair mechanism for LLM flakiness, partial failures, and missed incremental updates.
-
-## Deployment policy
-
-English deploys from source sync commits.
-
-Translations deploy after the aggregate i18n commit. The finalizer dispatches GitHub Pages once because GitHub suppresses normal push-triggered workflow runs from `GITHUB_TOKEN` commits. The Pages workflow dispatches live smoke after deployment so the smoke test checks the deployed site instead of racing the deploy.
-
-A hot docs day should produce many fast English deploys, but only a small number of locale deploys.
-
-If external deploy providers such as Mintlify watch every push, the aggregate i18n commit is the load reducer. Avoid restoring per-locale pushes to `main`.
+1. Trigger `Translate Full` with a deliberately invalid translation key in a test context and confirm the provider preflight fails before locale jobs start.
+2. Trigger or simulate a canary failure and confirm follow-up full batches are skipped.
+3. Trigger `Translate Full` with `target_locale=fr` and confirm only `fr` runs.
+4. Trigger a small manual full run and confirm a successful locale commits independently and dispatches `pages.yml`.
+5. Observe or simulate a later locale failure and confirm earlier successful locale commits remain published.
+6. Rerun only the failed locale with `target_locale=<slug>` and confirm it commits independently.
+7. Confirm release events do not start `Translate Full`.
+8. Confirm glossary-only changes do not start `Translate Full`.
+9. Check GitHub Actions summaries for selected locales, canary/batch status, artifact counts, and explicit failures.
+10. Confirm the final diff from any locale commit contains only `docs/<locale>/**` and `docs/.i18n/<locale>.tm.jsonl`.


### PR DESCRIPTION
## Summary

This PR implements PR2 from `I18N_FULL_TRANSLATION_REPAIR_PLAN_2026-06-26.md`: recover the full docs translation workflow as a stable, observable recovery path.

Core changes:

- Restrict `Translate Full` to weekly schedule + manual dispatch only.
- Do not restore release-triggered or glossary-triggered full translation.
- Add manual `target_locale` so one failed locale can be rerun without restarting all locales.
- Serialize full runs at the workflow level with `cancel-in-progress: false`.
- Add shared OpenAI provider/key preflight for both full and incremental before locale fan-out.
- Add a small canary sample gate before full batches.
- Run full locales in bounded batches of up to three locales.
- Commit and publish each successful full locale independently.
- Make failed/metadata-only artifacts visible as failed jobs instead of hiding failures behind green workflow status.
- Add locale/artifact-level full summaries and document automatic/manual verification.

## Recovery Flow

```mermaid
flowchart TD
    A["Weekly / Manual Full"] --> B["Prepare source state"]
    B --> C["Provider / key preflight"]
    C -->|fail| X["Stop before locale fan-out<br/>clear failure class"]
    C -->|pass| D["Canary locale sample"]
    D -->|fail| Y["Stop<br/>do not expand locale batches"]
    D -->|pass| E["Locale batch 1<br/>up to 3 locales"]

    E --> F1["translate zh-CN"]
    E --> F2["translate zh-TW"]
    E --> F3["translate ja-JP"]

    F1 --> G1["validate + commit + publish zh-CN"]
    F2 --> G2["validate + commit + publish zh-TW"]
    F3 --> G3["validate + commit + publish ja-JP"]

    G1 --> H["Next locale batch"]
    G2 --> H
    G3 --> H

    H --> I["translate + validate + commit + publish each successful locale"]
    I --> J["Full summary<br/>success / failed / skipped / artifact counts"]
```

## Behavior Notes

- The canary is intentionally a tiny deterministic sample from the first selected locale. It uploads `i18n-canary-*` diagnostics but does not commit or publish.
- After the canary passes, the selected locales, including the canary locale, run in normal full batches.
- Full locale commits happen in a separate write-permission job. The translation job remains read-only and uses `persist-credentials: false` while executing translator code from the source checkout.
- Locale commit/push logic is in `.github/scripts/i18n/commit_locale_artifact.py`, with rebase/retry under `docs-i18n-finalize` concurrency.
- If source metadata moves after artifact application but before push, the locale commit is skipped conservatively and can be picked up by a later manual/weekly run.
- Incremental finalization is gated on provider preflight success, so invalid credentials fail in preflight instead of producing a misleading missing-artifacts finalizer failure.

## What This Does Not Do

- Does not re-enable release-triggered full translation.
- Does not re-enable glossary-triggered full translation.
- Does not introduce a campaign database or multi-layer scheduler.
- Does not hand-edit generated docs, locale pages, or translation memory.


## Auto Review

Repository `autoreview` was run with the default Codex reviewer:

```bash
.agents/skills/autoreview/scripts/autoreview --mode local
```

Review/fix loop results:

- First run found a P1 permission regression: the reusable locale workflow had been elevated to write permissions while translator code still ran in the same job. Fixed by keeping the translate job read-only with `persist-credentials: false` and moving commit/publish into a separate write-permission job.
- Second run found a P2 trigger regression: glossary + source-doc pushes would skip incremental translation after glossary-triggered full was removed. Fixed by skipping only glossary-only pushes while allowing mixed glossary/docs pushes to run incremental translation.
- Final run was clean: `autoreview clean: no accepted/actionable findings reported`.

## Verification

Automated/local checks run:

- `python .github/scripts/i18n/tests/test_i18n_scripts.py`
- `python .github/scripts/i18n/workflow_shell_check.py --check-bash`
- `python .github/scripts/i18n/budget_check.py`
- `python -m py_compile .github/scripts/i18n/*.py`
- `actionlint .github/workflows/translate-all.yml .github/workflows/translate-incremental.yml .github/workflows/translate-locale-reusable.yml .github/workflows/translate-finalize-reusable.yml .github/workflows/translate-shell-check-reusable.yml`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, no accepted/actionable findings

Manual verification checklist documented in `docs/.i18n/translation-workflow.md` includes:

- invalid key preflight path for full/incremental
- canary failure stopping later full batches
- `target_locale=<slug>` single-locale rerun
- successful locale independent commit + `pages.yml` dispatch
- later locale failure not blocking already committed locales
- release/glossary events not starting full translation
- Actions summary exposing failures directly instead of hiding them in artifacts
