### PR TITLE
fix(ci): pin Dependabot to public npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,16 @@
 version: 2
 
+registries:
+  npmjs:
+    type: npm-registry
+    url: https://registry.npmjs.org
+    replaces-base: true
+
 updates:
   - package-ecosystem: npm
     directory: /
+    registries:
+      - npmjs
     schedule:
       interval: daily
     cooldown:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+@types:registry=https://registry.npmjs.org/


### PR DESCRIPTION
What Problem This Solves

Dependabot npm updates in openclaw/docs were failing before file fetch with private_registry_config_not_found for npm.pkg.github.com even though this mirror only uses public npm packages.

Why This Change Was Made

The repo now declares the public npm registry in dependabot.yml and commits a root .npmrc that pins default and @types package resolution to registry.npmjs.org. This keeps org-level GitHub Packages registry state from being treated as the base package source.

User Impact

Daily Dependabot npm update runs should resume instead of failing before dependency discovery.

Evidence

- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "yaml ok"'
- npm config --userconfig .npmrc get @types:registry
- git diff --check