### PR TITLE
ci: bound docs translation workers

### DIFF
--- a/.github/workflows/translate-locale-reusable.yml
+++ b/.github/workflows/translate-locale-reusable.yml
@@ -63,6 +63,7 @@ jobs:
   translate:
     name: Translate ${{ inputs.locale }} shard ${{ inputs.shard_index }}/${{ inputs.shard_total }}
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: read
     concurrency:


### PR DESCRIPTION
## What Problem This Solves

`Translate Full` can currently hang indefinitely when one locale worker stalls inside the model/API translation step. Today’s run is blocked on the zh-TW shard with no run update after the first few minutes, which leaves the whole full-translation chain pinned.

## Why This Change Was Made

Add a 120 minute job timeout to the reusable locale translation worker. That preserves room for legitimate full-locale reconciliation while bounding stuck workers so the workflow can fail, rerun, and unblock later batches.

## User Impact

Docs translation automation stops getting wedged forever on a single locale shard. Failed long-running shards become visible CI failures instead of silent stuck runs.

## Evidence

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/translate-locale-reusable.yml"); puts "yaml ok"'`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, patch correct 0.93
- Live failure source: `Translate Full` run `28291238605`, zh-TW shard `83824657509` still in progress after more than two hours.
