### PR TITLE
ci: bound docs translation finalizers

### DIFF
--- a/.github/workflows/translate-locale-reusable.yml
+++ b/.github/workflows/translate-locale-reusable.yml
@@ -312,6 +312,7 @@ jobs:
     needs: translate
     if: needs.translate.result == 'success' && (inputs.commit_locale || inputs.artifact_role == 'canary')
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
## What Problem This Solves

After bounding locale translation workers, the zh-TW proof run showed the next unbounded part of `Translate Full`: `Finalize zh-TW artifact` can sit in progress without updating the run. That still pins the full-translation chain.

## Why This Change Was Made

Add a 60 minute job timeout to the reusable locale finalizer. The finalizer can legitimately install dependencies, validate docs, commit locale output, dispatch deploys, and run canary smoke, so this is intentionally looser than a tiny gate while still preventing indefinite workflow wedging.

## User Impact

Docs translation finalization failures become visible bounded CI failures instead of silently blocking future full-translation runs.

## Evidence

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/translate-locale-reusable.yml"); puts "yaml ok"'`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, patch correct 0.93
- Live proof source: `Translate Full` run `28294966132`; zh-TW translation succeeded, then `Finalize zh-TW artifact` stayed in progress without updating.
