### PR TITLE
fix(r2): allow manifest-backed canary locales

### DIFF
--- a/.github/scripts/i18n/tests/test_i18n_scripts.py
+++ b/.github/scripts/i18n/tests/test_i18n_scripts.py
@@ -893,7 +893,61 @@ class I18NScriptTests(unittest.TestCase):
         self.assertNotIn("ja-JP/channels/line", result.stdout)
         self.assertNotIn("assets/docs-site.css", result.stdout)
 
-    def _run_r2_upload_scope(self, scope: str, locale: str, page_path: str = "") -> subprocess.CompletedProcess[str]:
+    def test_r2_upload_page_scope_allows_canary_locale_manifest_entries(self) -> None:
+        result = self._run_r2_upload_scope(
+            "page",
+            "hi",
+            "channels/line",
+            extra_keys=[
+                "hi/channels/line",
+                "hi/channels/line/index.html",
+                "hi/channels/line.md",
+            ],
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("r2 upload scope: page (3/10 manifest entries, partial=true)", result.stdout)
+        self.assertIn("r2 dry-run put: hi/channels/line\n", result.stdout)
+        self.assertIn("r2 dry-run put: hi/channels/line/index.html", result.stdout)
+        self.assertIn("r2 dry-run put: hi/channels/line.md", result.stdout)
+
+    def test_r2_upload_page_scope_rejects_unknown_locale_without_manifest_entries(self) -> None:
+        result = self._run_r2_upload_scope("page", "hi", "channels/line")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("R2_UPLOAD_SCOPE=page matched zero manifest entries", result.stderr)
+
+    def test_r2_upload_locale_scope_rejects_pagefind_only_unknown_locale(self) -> None:
+        result = self._run_r2_upload_scope("locale", "hi")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("R2_UPLOAD_SCOPE=locale matched no entries for locale hi", result.stderr)
+
+    def test_r2_upload_page_scope_rejects_unclean_locale_code(self) -> None:
+        result = self._run_r2_upload_scope("page", "../hi", "channels/line")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("R2_UPLOAD_LOCALE must be a clean locale code", result.stderr)
+
+    def test_r2_upload_page_scope_rejects_reserved_asset_prefix_locale(self) -> None:
+        result = self._run_r2_upload_scope("page", "assets", "docs-site.css")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("R2_UPLOAD_LOCALE cannot use reserved docs asset prefix: assets", result.stderr)
+
+    def test_r2_upload_locale_scope_rejects_reserved_pagefind_prefix_locale(self) -> None:
+        result = self._run_r2_upload_scope("locale", "pagefind")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("R2_UPLOAD_LOCALE cannot use reserved docs asset prefix: pagefind", result.stderr)
+
+    def _run_r2_upload_scope(
+        self,
+        scope: str,
+        locale: str,
+        page_path: str = "",
+        extra_keys: list[str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             dist = tmp_path / "dist"
@@ -909,6 +963,7 @@ class I18NScriptTests(unittest.TestCase):
                 "ja-JP/channels/line/index.html",
                 "pagefind/pagefind.js",
                 "assets/docs-site.css",
+                *(extra_keys or []),
             ]:
                 file_path = files / key.replace("/", "__")
                 file_path.write_text(key, encoding="utf-8")

--- a/scripts/docs-site/r2-upload.mjs
+++ b/scripts/docs-site/r2-upload.mjs
@@ -26,6 +26,7 @@ const putAll = process.env.R2_UPLOAD_PUT_ALL === "1";
 const dryRun = process.env.R2_UPLOAD_DRY_RUN === "1";
 const remoteManifestPath = process.env.R2_UPLOAD_REMOTE_MANIFEST_PATH || "";
 const uploadScope = process.env.R2_UPLOAD_SCOPE || "all";
+const reservedLocalePrefixes = new Set(["assets", "og", "pagefind"]);
 const uploadLocale = normalizeLocale(process.env.R2_UPLOAD_LOCALE || "");
 const uploadPagePath = normalizePagePath(process.env.R2_UPLOAD_PAGE_PATH || "");
 const partialUpload = process.env.R2_UPLOAD_PARTIAL === "1" || uploadScope !== "all";
@@ -47,6 +48,9 @@ if (!Array.isArray(manifest.entries)) throw new Error("dist/docs-r2-manifest.jso
 const scopedEntries = filterEntriesByScope(manifest.entries, uploadScope);
 if ((uploadScope === "page" || uploadScope === "locale") && scopedEntries.length === 0) {
   throw new Error(`R2_UPLOAD_SCOPE=${uploadScope} matched zero manifest entries`);
+}
+if (uploadScope === "locale" && !scopedEntries.some((entry) => isLocaleManifestEntry(entry, uploadLocale))) {
+  throw new Error(`R2_UPLOAD_SCOPE=locale matched no entries for locale ${uploadLocale}`);
 }
 const remoteManifest = await getRemoteManifest();
 if (partialUpload && !dryRun && remoteManifest.status !== "hit" && process.env.R2_UPLOAD_ALLOW_PARTIAL_WITHOUT_REMOTE !== "1") {
@@ -115,6 +119,11 @@ function isLocaleScopedEntry(entry, locale) {
   // search objects keeps a successful locale publish discoverable without
   // falling back to a full-site page upload.
   if (key.startsWith("pagefind/")) return true;
+  return isLocaleManifestEntry(entry, locale);
+}
+
+function isLocaleManifestEntry(entry, locale) {
+  const key = entry.key;
   return key === locale || key.startsWith(`${locale}/`);
 }
 
@@ -137,7 +146,12 @@ function normalizeLocale(value) {
   const locale = value.trim();
   if (!locale) throw new Error(`R2_UPLOAD_LOCALE is required for R2_UPLOAD_SCOPE=${uploadScope}`);
   if (locale === "en") throw new Error("R2_UPLOAD_LOCALE=en is not supported for translation-scoped uploads");
-  if (!Object.hasOwn(localeLabels, locale)) throw new Error(`R2_UPLOAD_LOCALE is not a configured locale: ${locale}`);
+  if (!/^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/u.test(locale)) {
+    throw new Error(`R2_UPLOAD_LOCALE must be a clean locale code, got ${locale}`);
+  }
+  if (reservedLocalePrefixes.has(locale)) {
+    throw new Error(`R2_UPLOAD_LOCALE cannot use reserved docs asset prefix: ${locale}`);
+  }
   return locale;
 }
 


### PR DESCRIPTION
## Summary
- allow scoped R2 uploads for clean canary locale codes when the built manifest contains matching locale/page objects
- keep safety checks for unknown locales with no manifest entries, pagefind-only locale uploads, traversal-like locale values, and reserved asset prefixes such as `assets` and `pagefind`

## Why
The hi canary R2 dispatch failed with `R2_UPLOAD_LOCALE is not a configured locale: hi` even though the translation workflow had produced a canary page artifact. Configured locale labels are too strict for canary validation; the R2 uploader should trust the built manifest scope instead.

## Proof
- `python3 .github/scripts/i18n/tests/test_i18n_scripts.py` (53 tests)
- `git diff --check`
- `node --check scripts/docs-site/r2-upload.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean, no accepted/actionable findings)

## Notes
This does not allow arbitrary top-level R2 prefixes to be treated as locales. The patch keeps a clean locale-code check, rejects reserved asset prefixes, and requires actual manifest entries for scoped uploads.
