### PR TITLE
fix(i18n): shard incremental translation

### DIFF
--- a/.github/scripts/i18n/build_pending_manifest.py
+++ b/.github/scripts/i18n/build_pending_manifest.py
@@ -33,9 +33,10 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from translation_plan import is_locale_dir
+
 
 SOURCE_HASH_RE = re.compile(r"^x-i18n:\n(?:[ \t]+.*\n)*?[ \t]+source_hash: ([0-9a-f]{64})$", re.M)
-LOCALE_DIR_RE = re.compile(r"^[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})?$")
 
 
 @dataclass(frozen=True)
@@ -45,10 +46,6 @@ class PendingResult:
     pending_count: int
     pending_path: Path
     shard_files: list[Path]
-
-
-def is_locale_dir(path: Path) -> bool:
-    return path.is_dir() and LOCALE_DIR_RE.match(path.name) is not None and (path / ".i18n" / "README.md").exists()
 
 
 def stored_source_hash(path: Path) -> str:

--- a/.github/scripts/i18n/plan_full.py
+++ b/.github/scripts/i18n/plan_full.py
@@ -29,116 +29,24 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
-import re
-from dataclasses import dataclass
 from pathlib import Path
+
+from translation_plan import (
+    DEFAULT_MAX_SHARDS,
+    DEFAULT_TARGET_DOCS_PER_SHARD,
+    Locale,
+    expand_shards,
+    matrix_json,
+    normalize_target,
+    select_locales,
+    shard_total_for_doc_count,
+    source_doc_count,
+)
 
 
 MAX_BATCHES = 6
 DEFAULT_BATCH_SIZE = 4
-DEFAULT_TARGET_DOCS_PER_SHARD = 250
-DEFAULT_MAX_SHARDS = 4
-LOCALE_DIR_RE = re.compile(r"^[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})?$")
-LOCALES: tuple[tuple[str, str], ...] = (
-    ("zh-CN", "zh-cn"),
-    ("zh-TW", "zh-tw"),
-    ("ja-JP", "ja-jp"),
-    ("es", "es"),
-    ("pt-BR", "pt-br"),
-    ("ko", "ko"),
-    ("de", "de"),
-    ("fr", "fr"),
-    ("hi", "hi"),
-    ("ar", "ar"),
-    ("it", "it"),
-    ("vi", "vi"),
-    ("nl", "nl"),
-    ("fa", "fa"),
-    ("ru", "ru"),
-    ("tr", "tr"),
-    ("uk", "uk"),
-    ("id", "id"),
-    ("pl", "pl"),
-    ("th", "th"),
-)
-
-
-@dataclass(frozen=True)
-class Locale:
-    locale: str
-    locale_slug: str
-
-    def matrix_item(self) -> dict[str, str]:
-        return {"locale": self.locale, "locale_slug": self.locale_slug}
-
-    def matrix_item_with_shards(self, shard_total: int) -> dict[str, str]:
-        item = self.matrix_item()
-        item["shard_total"] = str(shard_total)
-        return item
-
-
-def is_locale_dir(path: Path) -> bool:
-    return path.is_dir() and LOCALE_DIR_RE.match(path.name) is not None and (path / ".i18n" / "README.md").exists()
-
-
-def source_doc_count(docs_root: Path) -> int:
-    locale_dirs = {path.name for path in docs_root.iterdir() if is_locale_dir(path)}
-    count = 0
-    for path in docs_root.rglob("*"):
-        if not path.is_file() or path.suffix.lower() not in {".md", ".mdx"}:
-            continue
-        rel = path.relative_to(docs_root)
-        parts = rel.parts
-        if parts and parts[0] in locale_dirs:
-            continue
-        rel_posix = rel.as_posix()
-        if rel_posix.startswith(".i18n/") or rel_posix.startswith(".generated/"):
-            continue
-        count += 1
-    return count
-
-
-def shard_total_for_doc_count(doc_count: int, target_docs_per_shard: int, max_shards: int) -> int:
-    if target_docs_per_shard < 1:
-        raise SystemExit(f"invalid target docs per shard: {target_docs_per_shard}")
-    if max_shards < 1:
-        raise SystemExit(f"invalid max shards: {max_shards}")
-    return max(1, min(max_shards, math.ceil(doc_count / target_docs_per_shard)))
-
-
-def expand_shards(batch: list[Locale], shard_total: int) -> list[dict[str, str]]:
-    return [
-        {
-            "locale": locale.locale,
-            "locale_slug": locale.locale_slug,
-            "shard_index": str(shard_index),
-            "shard_total": str(shard_total),
-        }
-        for locale in batch
-        for shard_index in range(shard_total)
-    ]
-
-
-def all_locales() -> list[Locale]:
-    return [Locale(locale, slug) for locale, slug in LOCALES]
-
-
-def normalize_target(value: str) -> str:
-    return (value or "all").strip()
-
-
-def select_locales(target_locale: str) -> list[Locale]:
-    target = normalize_target(target_locale)
-    locales = all_locales()
-    if target.lower() == "all":
-        return locales
-    for locale in locales:
-        if target in {locale.locale, locale.locale_slug}:
-            return [locale]
-    allowed = ", ".join(["all", *(locale.locale_slug for locale in locales)])
-    raise SystemExit(f"unknown target locale {target!r}; expected one of: {allowed}")
 
 
 def build_batches(selected: list[Locale], batch_size: int) -> list[list[Locale]]:
@@ -148,10 +56,6 @@ def build_batches(selected: list[Locale], batch_size: int) -> list[list[Locale]]
     if len(batches) > MAX_BATCHES:
         raise SystemExit(f"full translation needs {len(batches)} batches; max supported is {MAX_BATCHES}")
     return batches
-
-
-def matrix_json(items: list[dict[str, str]]) -> str:
-    return json.dumps({"include": items}, separators=(",", ":"))
 
 
 def append_outputs(selected: list[Locale], batches: list[list[Locale]], shard_total: int, source_docs: int) -> None:

--- a/.github/scripts/i18n/plan_incremental.py
+++ b/.github/scripts/i18n/plan_incremental.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Plan Translate Incremental locale shard matrix.
+
+Definition:
+  This script plans the incremental translation matrix from the same shared
+  shard policy used by Translate Full. GitHub Actions consumes the emitted
+  JSON matrix so incremental translation does not run one oversized locale job.
+
+Parameters:
+  --docs-root: Docs directory used to size shards. Default: docs.
+  --target-docs-per-shard: Desired source documents per shard. Default: 250.
+  --max-shards: Maximum shards per locale. Default: 4.
+
+Outputs:
+  GITHUB_OUTPUT receives locale_count, source_doc_count, shard_total, and
+  matrix. GITHUB_STEP_SUMMARY receives a short plan summary. Stdout prints the
+  same plan as formatted JSON for local inspection.
+
+Examples:
+  python .github/scripts/i18n/plan_incremental.py
+  python .github/scripts/i18n/plan_incremental.py --target-docs-per-shard 100 --max-shards 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from translation_plan import (
+    DEFAULT_MAX_SHARDS,
+    DEFAULT_TARGET_DOCS_PER_SHARD,
+    all_locales,
+    expand_shards,
+    matrix_json,
+    shard_total_for_doc_count,
+    source_doc_count,
+)
+
+
+def append_outputs(locale_count: int, source_docs: int, shard_total: int, matrix: str) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    with Path(output).open("a", encoding="utf-8") as fh:
+        fh.write(f"locale_count={locale_count}\n")
+        fh.write(f"source_doc_count={source_docs}\n")
+        fh.write(f"shard_total={shard_total}\n")
+        fh.write(f"matrix={matrix}\n")
+
+
+def append_summary(locale_count: int, source_docs: int, shard_total: int) -> None:
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary:
+        return
+    with Path(summary).open("a", encoding="utf-8") as fh:
+        fh.write("### Translate Incremental shard plan\n\n")
+        fh.write(f"- selected locales: `{locale_count}`\n")
+        fh.write(f"- source docs: `{source_docs}`\n")
+        fh.write(f"- shards per locale: `{shard_total}`\n")
+        fh.write(f"- translation jobs: `{locale_count * shard_total}`\n")
+
+
+def plan_incremental(
+    docs_root: Path | None = None,
+    target_docs_per_shard: int = DEFAULT_TARGET_DOCS_PER_SHARD,
+    max_shards: int = DEFAULT_MAX_SHARDS,
+) -> dict[str, object]:
+    locales = all_locales()
+    source_docs = source_doc_count(docs_root or Path("docs"))
+    shard_total = shard_total_for_doc_count(source_docs, target_docs_per_shard, max_shards)
+    shards = expand_shards(locales, shard_total)
+    matrix = matrix_json(shards)
+    append_outputs(len(locales), source_docs, shard_total, matrix)
+    append_summary(len(locales), source_docs, shard_total)
+    return {
+        "locale_count": len(locales),
+        "source_doc_count": source_docs,
+        "shard_total": shard_total,
+        "matrix": {"include": shards},
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Plan Translate Incremental locale shard matrix.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Outputs:
+  Writes locale_count, source_doc_count, shard_total, and matrix to GITHUB_OUTPUT.
+
+Examples:
+  python .github/scripts/i18n/plan_incremental.py
+  python .github/scripts/i18n/plan_incremental.py --target-docs-per-shard 100 --max-shards 4
+""",
+    )
+    parser.add_argument("--docs-root", default="docs", type=Path)
+    parser.add_argument("--target-docs-per-shard", default=DEFAULT_TARGET_DOCS_PER_SHARD, type=int)
+    parser.add_argument("--max-shards", default=DEFAULT_MAX_SHARDS, type=int)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    plan = plan_incremental(args.docs_root, args.target_docs_per_shard, args.max_shards)
+    print(json.dumps(plan, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/i18n/tests/test_i18n_scripts.py
+++ b/.github/scripts/i18n/tests/test_i18n_scripts.py
@@ -18,6 +18,9 @@ from unittest.mock import patch
 SCRIPT_DIR = Path(__file__).resolve().parents[1]
 REPO_ROOT = Path(__file__).resolve().parents[4]
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+NON_CLI_SCRIPT_MODULES = {SCRIPT_DIR / "translation_plan.py"}
 
 
 def load_module(name: str):
@@ -32,6 +35,7 @@ def load_module(name: str):
 workflow_shell_check = load_module("workflow_shell_check")
 budget_check = load_module("budget_check")
 prepare = load_module("prepare")
+translation_plan = load_module("translation_plan")
 pending = load_module("build_pending_manifest")
 package_artifact = load_module("package_artifact")
 mdx_repair_scope = load_module("mdx_repair_scope")
@@ -39,6 +43,7 @@ apply_artifacts = load_module("apply_artifacts")
 read_source_metadata = load_module("read_source_metadata")
 prune_stale_locale_pages = load_module("prune_stale_locale_pages")
 plan_full = load_module("plan_full")
+plan_incremental = load_module("plan_incremental")
 provider_preflight = load_module("provider_preflight")
 summarize_full = load_module("summarize_full")
 commit_locale_artifact = load_module("commit_locale_artifact")
@@ -102,13 +107,13 @@ class I18NScriptTests(unittest.TestCase):
                 else:
                     called_scripts.add(SCRIPT_DIR / match.group("temp"))
 
-        expected_scripts = set(SCRIPT_DIR.glob("*.py")) - {SCRIPT_DIR / "__init__.py"}
+        expected_scripts = set(SCRIPT_DIR.glob("*.py")) - {SCRIPT_DIR / "__init__.py"} - NON_CLI_SCRIPT_MODULES
         self.assertEqual(expected_scripts, called_scripts)
         for script in called_scripts:
             self.assertTrue(script.exists(), f"workflow calls missing script: {script}")
 
     def test_i18n_scripts_expose_help(self) -> None:
-        for script in sorted(SCRIPT_DIR.glob("*.py")):
+        for script in sorted(set(SCRIPT_DIR.glob("*.py")) - NON_CLI_SCRIPT_MODULES):
             result = subprocess.run(
                 [sys.executable, str(script), "--help"],
                 cwd=REPO_ROOT,
@@ -274,11 +279,46 @@ class I18NScriptTests(unittest.TestCase):
 
     def test_incremental_workflow_schedules_all_expected_finalizer_locales(self) -> None:
         text = (REPO_ROOT / ".github/workflows/translate-incremental.yml").read_text(encoding="utf-8")
+        expected = apply_artifacts.parse_expected(apply_artifacts.DEFAULT_EXPECTED_LOCALES)
 
-        for locale, slug in apply_artifacts.parse_expected(apply_artifacts.DEFAULT_EXPECTED_LOCALES).items():
-            self.assertIn(f"locale: {slug}", text)
-            self.assertIn(f"locale_slug: {locale}", text)
+        self.assertEqual(expected, {locale.locale_slug: locale.locale for locale in translation_plan.all_locales()})
+        self.assertIn('python "${I18N_SCRIPT_DIR}/plan_incremental.py"', text)
+        self.assertIn("matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}", text)
+        self.assertIn("max-parallel: 12", text)
+        self.assertIn("shard_index: ${{ matrix.shard_index }}", text)
+        self.assertIn("shard_total: ${{ matrix.shard_total }}", text)
+        self.assertIn("shard_total: ${{ needs.plan.outputs.shard_total }}", text)
+        self.assertIn('worker_parallel: "3"', text)
+        self.assertNotIn('shard_index: "0"', text)
+        self.assertNotIn('shard_total: "1"', text)
+        self.assertNotIn('worker_parallel: "8"', text)
+        for slug in expected.values():
             self.assertIn(f'!docs/{slug}/**', text)
+
+    def test_supported_locale_dirs_are_never_source_docs_without_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            docs = Path(tmp) / "docs"
+            docs.mkdir()
+            (docs / "index.md").write_text("# Index\n", encoding="utf-8")
+            for locale in translation_plan.all_locales():
+                locale_dir = docs / locale.locale
+                locale_dir.mkdir()
+                (locale_dir / "index.md").write_text(f"# {locale.locale}\n", encoding="utf-8")
+
+            incremental = plan_incremental.plan_incremental(docs, target_docs_per_shard=1, max_shards=4)
+            pending_result = pending.build_pending_manifest(
+                docs_root=docs,
+                openclaw_sync_dir=Path(tmp) / ".openclaw-sync",
+                locale="de",
+                locale_slug="de",
+                mode="incremental",
+                shard_index=0,
+                shard_total=1,
+            )
+
+            self.assertEqual(1, incremental["source_doc_count"])
+            self.assertEqual(1, pending_result.all_count)
+            self.assertEqual(1, pending_result.total_pending_count)
 
     def test_full_plan_all_uses_canary_and_small_batches(self) -> None:
         result = plan_full.plan_full("all", 4, FIXTURES / "pending-docs" / "docs")
@@ -287,6 +327,16 @@ class I18NScriptTests(unittest.TestCase):
         self.assertEqual(1, result["shard_total"])
         self.assertLessEqual(max(len(batch) for batch in result["batch_locales"]), 4)
         self.assertEqual(20, sum(len(batch) for batch in result["batches"]))
+
+    def test_translation_plan_shared_shard_policy(self) -> None:
+        self.assertEqual(1, translation_plan.shard_total_for_doc_count(0, 250, 4))
+        self.assertEqual(1, translation_plan.shard_total_for_doc_count(250, 250, 4))
+        self.assertEqual(2, translation_plan.shard_total_for_doc_count(251, 250, 4))
+        self.assertEqual(4, translation_plan.shard_total_for_doc_count(1200, 250, 4))
+        with self.assertRaises(SystemExit):
+            translation_plan.shard_total_for_doc_count(10, 0, 4)
+        with self.assertRaises(SystemExit):
+            translation_plan.shard_total_for_doc_count(10, 250, 0)
 
     def test_full_plan_shards_large_batches_without_increasing_locale_batch_size(self) -> None:
         result = plan_full.plan_full("ru", 4, FIXTURES / "pending-docs" / "docs", target_docs_per_shard=1, max_shards=4)
@@ -300,6 +350,55 @@ class I18NScriptTests(unittest.TestCase):
             result["batches"][0],
         )
         self.assertEqual([[{"locale": "ru", "locale_slug": "ru", "shard_total": "2"}]], result["batch_locales"])
+
+    def test_full_plan_excludes_supported_locale_dirs_without_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            docs = Path(tmp) / "docs"
+            docs.mkdir()
+            (docs / "index.md").write_text("# Index\n", encoding="utf-8")
+            (docs / "hi").mkdir()
+            (docs / "hi/index.md").write_text("# Hindi\n", encoding="utf-8")
+            (docs / "ru").mkdir()
+            (docs / "ru/index.md").write_text("# Russian\n", encoding="utf-8")
+            (docs / "fr/.i18n").mkdir(parents=True)
+            (docs / "fr/.i18n/README.md").write_text("# marker\n", encoding="utf-8")
+            (docs / "fr/index.md").write_text("# French\n", encoding="utf-8")
+
+            result = plan_full.plan_full("ru", 4, docs, target_docs_per_shard=1, max_shards=4)
+
+            self.assertEqual(1, result["source_doc_count"])
+            self.assertEqual(1, result["shard_total"])
+
+    def test_incremental_plan_reuses_shared_locale_and_shard_policy(self) -> None:
+        result = plan_incremental.plan_incremental(FIXTURES / "pending-docs" / "docs", target_docs_per_shard=1, max_shards=4)
+
+        self.assertEqual(20, result["locale_count"])
+        self.assertEqual(2, result["source_doc_count"])
+        self.assertEqual(2, result["shard_total"])
+        self.assertEqual(40, len(result["matrix"]["include"]))
+        self.assertEqual(
+            [
+                {"locale": "zh-CN", "locale_slug": "zh-cn", "shard_index": "0", "shard_total": "2"},
+                {"locale": "zh-CN", "locale_slug": "zh-cn", "shard_index": "1", "shard_total": "2"},
+            ],
+            result["matrix"]["include"][:2],
+        )
+
+    def test_incremental_plan_excludes_supported_locale_dirs_without_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            docs = Path(tmp) / "docs"
+            docs.mkdir()
+            (docs / "index.md").write_text("# Index\n", encoding="utf-8")
+            (docs / "hi").mkdir()
+            (docs / "hi/index.md").write_text("# Hindi\n", encoding="utf-8")
+            (docs / "ru").mkdir()
+            (docs / "ru/index.md").write_text("# Russian\n", encoding="utf-8")
+
+            result = plan_incremental.plan_incremental(docs, target_docs_per_shard=1, max_shards=4)
+
+            self.assertEqual(1, result["source_doc_count"])
+            self.assertEqual(1, result["shard_total"])
+            self.assertEqual(20, len(result["matrix"]["include"]))
 
     def test_full_plan_manual_single_locale_only_selects_target(self) -> None:
         result = plan_full.plan_full("fr", 3, FIXTURES / "pending-docs" / "docs")
@@ -412,6 +511,33 @@ class I18NScriptTests(unittest.TestCase):
             self.assertEqual(2, result.all_count)
             self.assertEqual(1, result.total_pending_count)
             self.assertTrue(result.shard_files[0].as_posix().endswith("/docs/guide/setup.mdx"))
+
+    def test_pending_manifest_excludes_supported_locale_dirs_without_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            docs = Path(tmp) / "docs"
+            docs.mkdir()
+            (docs / "index.md").write_text("# Index\n", encoding="utf-8")
+            (docs / "hi").mkdir()
+            (docs / "hi/index.md").write_text("# Hindi\n", encoding="utf-8")
+            (docs / "ru").mkdir()
+            (docs / "ru/index.md").write_text("# Russian\n", encoding="utf-8")
+            (docs / "fr/.i18n").mkdir(parents=True)
+            (docs / "fr/.i18n/README.md").write_text("# marker\n", encoding="utf-8")
+            (docs / "fr/index.md").write_text("# French\n", encoding="utf-8")
+
+            result = pending.build_pending_manifest(
+                docs_root=docs,
+                openclaw_sync_dir=Path(tmp) / ".openclaw-sync",
+                locale="de",
+                locale_slug="de",
+                mode="incremental",
+                shard_index=0,
+                shard_total=1,
+            )
+
+            self.assertEqual(1, result.all_count)
+            self.assertEqual(1, result.total_pending_count)
+            self.assertEqual(["index.md"], [file.name for file in result.shard_files])
 
     def test_pending_manifest_canary_limit_keeps_total_count_but_limits_sample(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/i18n/translation_plan.py
+++ b/.github/scripts/i18n/translation_plan.py
@@ -1,0 +1,143 @@
+"""Shared translation planning helpers.
+
+Definition:
+  This module owns locale selection, source-doc discovery, and shard expansion
+  for translation workflow control scripts. Both full and incremental
+  workflows call these helpers so shard sizing cannot drift between lanes.
+
+Parameters:
+  Functions accept locale selectors, docs roots, batch sizes, and shard sizing
+  limits. This module has no CLI parameters.
+
+Outputs:
+  Returns locale matrix dictionaries and source document counts. It does not
+  read or write GitHub output files by itself.
+
+Examples:
+  from translation_plan import all_locales
+  from translation_plan import shard_total_for_doc_count
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_TARGET_DOCS_PER_SHARD = 250
+DEFAULT_MAX_SHARDS = 4
+
+LOCALES: tuple[tuple[str, str], ...] = (
+    ("zh-CN", "zh-cn"),
+    ("zh-TW", "zh-tw"),
+    ("ja-JP", "ja-jp"),
+    ("es", "es"),
+    ("pt-BR", "pt-br"),
+    ("ko", "ko"),
+    ("de", "de"),
+    ("fr", "fr"),
+    ("hi", "hi"),
+    ("ar", "ar"),
+    ("it", "it"),
+    ("vi", "vi"),
+    ("nl", "nl"),
+    ("fa", "fa"),
+    ("ru", "ru"),
+    ("tr", "tr"),
+    ("uk", "uk"),
+    ("id", "id"),
+    ("pl", "pl"),
+    ("th", "th"),
+)
+
+LOCALE_NAMES = frozenset(locale for locale, _slug in LOCALES)
+
+
+@dataclass(frozen=True)
+class Locale:
+    locale: str
+    locale_slug: str
+
+    def matrix_item(self) -> dict[str, str]:
+        return {"locale": self.locale, "locale_slug": self.locale_slug}
+
+    def matrix_item_with_shards(self, shard_total: int) -> dict[str, str]:
+        item = self.matrix_item()
+        item["shard_total"] = str(shard_total)
+        return item
+
+
+def is_supported_locale_dir(path: Path) -> bool:
+    return path.is_dir() and path.name in LOCALE_NAMES
+
+
+def is_locale_dir(path: Path) -> bool:
+    return is_supported_locale_dir(path) or (path.is_dir() and (path / ".i18n" / "README.md").exists())
+
+
+def source_doc_count(docs_root: Path) -> int:
+    locale_dirs = {path.name for path in docs_root.iterdir() if is_locale_dir(path)}
+    count = 0
+    for path in docs_root.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in {".md", ".mdx"}:
+            continue
+        rel = path.relative_to(docs_root)
+        parts = rel.parts
+        if parts and parts[0] in locale_dirs:
+            continue
+        rel_posix = rel.as_posix()
+        if rel_posix.startswith(".i18n/") or rel_posix.startswith(".generated/"):
+            continue
+        count += 1
+    return count
+
+
+def shard_total_for_doc_count(
+    doc_count: int,
+    target_docs_per_shard: int = DEFAULT_TARGET_DOCS_PER_SHARD,
+    max_shards: int = DEFAULT_MAX_SHARDS,
+) -> int:
+    if target_docs_per_shard < 1:
+        raise SystemExit(f"invalid target docs per shard: {target_docs_per_shard}")
+    if max_shards < 1:
+        raise SystemExit(f"invalid max shards: {max_shards}")
+    return max(1, min(max_shards, math.ceil(doc_count / target_docs_per_shard)))
+
+
+def expand_shards(locales: list[Locale], shard_total: int) -> list[dict[str, str]]:
+    return [
+        {
+            "locale": locale.locale,
+            "locale_slug": locale.locale_slug,
+            "shard_index": str(shard_index),
+            "shard_total": str(shard_total),
+        }
+        for locale in locales
+        for shard_index in range(shard_total)
+    ]
+
+
+def matrix_json(items: list[dict[str, str]]) -> str:
+    return json.dumps({"include": items}, separators=(",", ":"))
+
+
+def all_locales() -> list[Locale]:
+    return [Locale(locale, slug) for locale, slug in LOCALES]
+
+
+def normalize_target(value: str) -> str:
+    return (value or "all").strip()
+
+
+def select_locales(target_locale: str) -> list[Locale]:
+    target = normalize_target(target_locale)
+    locales = all_locales()
+    if target.lower() == "all":
+        return locales
+    for locale in locales:
+        if target in {locale.locale, locale.locale_slug}:
+            return [locale]
+    allowed = ", ".join(["all", *(locale.locale_slug for locale in locales)])
+    raise SystemExit(f"unknown target locale {target!r}; expected one of: {allowed}")

--- a/.github/workflows/translate-incremental.yml
+++ b/.github/workflows/translate-incremental.yml
@@ -77,56 +77,58 @@ jobs:
 
           python .github/scripts/i18n/prepare.py --mode incremental --title "Translate Incremental"
 
+  plan:
+    name: Plan incremental shards
+    needs: prepare
+    if: needs.prepare.outputs.should_translate == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      locale_count: ${{ steps.plan.outputs.locale_count }}
+      source_doc_count: ${{ steps.plan.outputs.source_doc_count }}
+      shard_total: ${{ steps.plan.outputs.shard_total }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      # The planner runs workflow-control scripts from the workflow ref under
+      # test, while sizing shards from the debounced publish ref.
+      - name: Check out workflow scripts
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .openclaw-sync/workflow-ref
+          sparse-checkout: .github/scripts/i18n
+          persist-credentials: false
+
+      - name: Stage workflow scripts
+        run: |
+          set -euo pipefail
+          I18N_SCRIPT_DIR="${RUNNER_TEMP}/openclaw-i18n-scripts"
+          echo "I18N_SCRIPT_DIR=${I18N_SCRIPT_DIR}" >> "$GITHUB_ENV"
+          mkdir -p "${I18N_SCRIPT_DIR}"
+          cp -R .openclaw-sync/workflow-ref/.github/scripts/i18n/. "${I18N_SCRIPT_DIR}/"
+
+      - name: Check out publish ref
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.publish_ref }}
+          persist-credentials: false
+
+      - name: Build incremental shard matrix
+        id: plan
+        run: |
+          set -euo pipefail
+          python "${I18N_SCRIPT_DIR}/plan_incremental.py"
+
   translate:
     name: Translate ${{ matrix.locale }}
     needs:
       - prepare
       - provider-preflight
+      - plan
     if: needs.prepare.outputs.should_translate == 'true'
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - locale: zh-CN
-            locale_slug: zh-cn
-          - locale: zh-TW
-            locale_slug: zh-tw
-          - locale: ja-JP
-            locale_slug: ja-jp
-          - locale: es
-            locale_slug: es
-          - locale: pt-BR
-            locale_slug: pt-br
-          - locale: ko
-            locale_slug: ko
-          - locale: de
-            locale_slug: de
-          - locale: fr
-            locale_slug: fr
-          - locale: hi
-            locale_slug: hi
-          - locale: ar
-            locale_slug: ar
-          - locale: it
-            locale_slug: it
-          - locale: vi
-            locale_slug: vi
-          - locale: nl
-            locale_slug: nl
-          - locale: fa
-            locale_slug: fa
-          - locale: ru
-            locale_slug: ru
-          - locale: tr
-            locale_slug: tr
-          - locale: uk
-            locale_slug: uk
-          - locale: id
-            locale_slug: id
-          - locale: pl
-            locale_slug: pl
-          - locale: th
-            locale_slug: th
+      max-parallel: 12
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     uses: ./.github/workflows/translate-locale-reusable.yml
     with:
       locale: ${{ matrix.locale }}
@@ -134,9 +136,9 @@ jobs:
       publish_ref: ${{ needs.prepare.outputs.publish_ref }}
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
-      shard_index: "0"
-      shard_total: "1"
-      worker_parallel: "8"
+      shard_index: ${{ matrix.shard_index }}
+      shard_total: ${{ matrix.shard_total }}
+      worker_parallel: "3"
       thinking_effort: "medium"
       pending_limit: "0"
       artifact_prefix: i18n
@@ -168,10 +170,11 @@ jobs:
     needs:
       - prepare
       - provider-preflight
+      - plan
       - translate
-    if: always() && needs.prepare.result == 'success' && needs.provider-preflight.result == 'success' && needs.prepare.outputs.should_translate == 'true'
+    if: always() && needs.prepare.result == 'success' && needs.provider-preflight.result == 'success' && needs.plan.result == 'success' && needs.prepare.outputs.should_translate == 'true'
     uses: ./.github/workflows/translate-finalize-reusable.yml
     with:
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
-      shard_total: "1"
+      shard_total: ${{ needs.plan.outputs.shard_total }}


### PR DESCRIPTION
## Summary
- Share translation locale/source-doc/shard planning between full and incremental workflows.
- Add an incremental shard planner and wire `translate-incremental.yml` to consume its matrix instead of one `s0of1` job per locale.
- Exclude supported locale output directories from source-doc discovery even when they are missing `.i18n/README.md`, covering the `hi`/`ru` regression.
- Reduce incremental per-job worker parallelism from 8 to 3 and cap matrix `max-parallel` at 12 to avoid concentrating backend pressure.

## Root Cause
`build_pending_manifest.py` and `plan_full.py` treated a locale directory as generated output only when it had `docs/<locale>/.i18n/README.md`. Newly recovered `hi` and `ru` outputs lacked that marker, so incremental translation counted them as English source docs and generated huge pending lists. Incremental translation also had a fixed single-shard matrix, so oversized pending sets could run until the 120-minute job timeout.

## Validation
- `python .github/scripts/i18n/tests/test_i18n_scripts.py`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/translate-incremental.yml`
- `python .github/scripts/i18n/workflow_shell_check.py`
- `python .github/scripts/i18n/budget_check.py --workflow .github/workflows/translate-all.yml`
- `python .github/scripts/i18n/plan_incremental.py --help`
- `python .github/scripts/i18n/plan_incremental.py --target-docs-per-shard 250 --max-shards 4` -> `source_doc_count=699`, `shard_total=3`
- `LOCALE=de LOCALE_SLUG=de MODE=incremental SHARD_INDEX=0 SHARD_TOTAL=1 python .github/scripts/i18n/build_pending_manifest.py --openclaw-sync-dir /tmp/openclaw-i18n-check` -> `all_docs=699`, `total_pending_docs=39`, no `docs/hi/**` or `docs/ru/**` pending paths
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> no accepted/actionable findings
