### PR TITLE
[codex] update DOMPurify to 3.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,9 +1328,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {


### PR DESCRIPTION
## What changed

- refresh the locked transitive `dompurify` package from 3.4.10 to 3.4.11
- keep the package manifest and all other resolved dependencies unchanged

## Why

GitHub Dependabot alert #3 reports GHSA-cmwh-pvxp-8882 against the committed 3.4.10 graph. DOMPurify 3.4.11 contains the upstream fix and remains within Mermaid's existing `^3.3.1` dependency range.

## Impact

This is a lockfile-only patch update for a development dependency used by the docs renderer. `npm audit` reports zero vulnerabilities after the refresh.

## Validation

- `npm ci`
- syntax-check every `.mjs` file under `scripts` and `.openclaw-sync`
- `npm test`
- `npx wrangler@4.88.0 deploy --dry-run --config wrangler.toml`
- `npm run docs:build:r2:shell`
- `npm run docs:smoke:shell`
- `npx playwright install chromium`
- `npm run docs:visual`

All checks passed locally.
