### PR TITLE
fix(docs): publish complete static routes

### DIFF
--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -56,6 +56,7 @@ fs.rmSync(outDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100
 fs.mkdirSync(outDir, { recursive: true });
 
 const locales = buildLocales(config);
+const localeCodes = new Set(locales.map((locale) => locale.code));
 const allPages = [...collectPages(locales), ...(includeElementsFixture ? [elementsFixturePage()] : [])];
 const allPageByKey = new Map(allPages.map((page) => [pageKey(page.locale, page.slug), page]));
 let pages = allPages;
@@ -141,7 +142,7 @@ function collectPages(localeList) {
     const base = locale.root ? docsDir : path.join(docsDir, locale.code);
     for (const file of walkDocs(base)) {
       const rel = path.relative(base, file).replaceAll(path.sep, "/");
-      if (ignoredDocFiles.has(rel) || rel.endsWith("/AGENTS.md")) continue;
+      if (ignoredDocFiles.has(rel)) continue;
       const raw = fs.readFileSync(file, "utf8");
       const parsed = parseFrontmatter(raw);
       const slug = fileSlug(rel);
@@ -850,12 +851,24 @@ function writeStaticAssets() {
 }
 
 function copyPublicFiles() {
-  copyDir(path.join(docsDir, "assets"), path.join(outDir, "assets"));
-  for (const entry of fs.readdirSync(docsDir, { withFileTypes: true })) {
-    if (entry.isFile() && !ignoredDocFiles.has(entry.name) && !/\.(md|mdx|json)$/.test(entry.name)) {
-      fs.copyFileSync(path.join(docsDir, entry.name), path.join(outDir, entry.name));
-    }
+  for (const source of walkPublicFiles(docsDir)) {
+    const rel = path.relative(docsDir, source);
+    const dest = path.join(outDir, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(source, dest);
   }
+}
+
+function walkPublicFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name.startsWith(".")) return [];
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return walkPublicFiles(full);
+    const rel = path.relative(docsDir, full).replaceAll(path.sep, "/");
+    if (ignoredDocFiles.has(rel) || /\.(md|mdx|json|jsonl)$/.test(entry.name)) return [];
+    return [full];
+  });
 }
 
 function copyDir(source, dest, options = {}) {
@@ -948,6 +961,10 @@ function rewriteInternalUrls(html, locale) {
     const localizedPage = allPageByKey.get(pageKey(maybeLocale, localizedSlug));
     if (localizedPage) {
       return `${attr}="${internalPageUrl(localizedPage)}${suffix}"`;
+    }
+    if (localeCodes.has(maybeLocale)) {
+      const englishPage = allPageByKey.get(pageKey("en", localizedSlug));
+      if (englishPage) return `${attr}="${internalPageUrl(englishPage)}${suffix}"`;
     }
     const slug = normalizeSlug(target.replace(/\/$/, ""));
     const page = allPageByKey.get(pageKey(locale, slug)) ?? allPageByKey.get(pageKey("en", slug));

--- a/scripts/docs-site/elements-fixture.mjs
+++ b/scripts/docs-site/elements-fixture.mjs
@@ -165,7 +165,7 @@ Summarize the active OpenClaw Gateway health and include the exact command that 
   <Card title="Troubleshooting" href="/help/troubleshooting" icon="wrench">
     Diagnose startup, auth, channel, and provider issues.
   </Card>
-  <Card title="Plugin SDK" href="/plugins/sdk" icon="book">
+  <Card title="Plugin SDK" href="/plugins/sdk-overview" icon="book">
     Build plugin surfaces using the public SDK contracts.
   </Card>
   <Card title="Configuration" href="/gateway/configuration" icon="settings">
@@ -291,7 +291,7 @@ Channels,24
 Providers,18
 </Chart>
 
-<CTA title="Build the next plugin guide" eyebrow="Authoring flow" href="/plugins/sdk" label="Open SDK docs" secondaryHref="/tools/skills" secondaryLabel="Review skills">
+<CTA title="Build the next plugin guide" eyebrow="Authoring flow" href="/plugins/sdk-overview" label="Open SDK docs" secondaryHref="/tools/skills" secondaryLabel="Review skills">
 Use a CTA when a long-form article has one obvious next action. Keep it specific.
 </CTA>
 

--- a/scripts/docs-site/smoke.mjs
+++ b/scripts/docs-site/smoke.mjs
@@ -29,6 +29,9 @@ const required = [
   "zh-CN/tools/reactions/index.html",
   "de/tools/reactions/index.html",
   "de/gateway/heartbeat/index.html",
+  "reference/templates/AGENTS/index.html",
+  "images/groups-flow.svg",
+  "images/feishu-get-group-id.png",
   "assets/docs-site.css",
   "assets/docs-site.js",
   "assets/pixel-lobster.svg"
@@ -673,8 +676,52 @@ const showcase = fs.readFileSync(path.join(site, "start/showcase/index.html"), "
 if (!/href="https:\/\/x\.com\/i\/status\/2010878524543131691"/.test(showcase)) {
   throw new Error("showcase: external card href was not rendered");
 }
+assertInternalRoutes();
 assertEditSourceLinks();
 console.log(`docs site smoke ok: shell, routing, skin, and hidden fixture checks passed (${artifactMode})`);
+
+function assertInternalRoutes() {
+  const files = walkFiles(site);
+  const present = new Set(files.map((file) => path.relative(site, file).replaceAll(path.sep, "/")));
+  const basePath = `/${(process.env.DOCS_SITE_BASE_PATH ?? "").replace(/^\/+|\/+$/g, "")}`.replace(/^\/$/, "");
+  const missing = new Map();
+
+  for (const file of files) {
+    if (!file.endsWith(".html")) continue;
+    const rel = path.relative(site, file).replaceAll(path.sep, "/");
+    const html = fs.readFileSync(file, "utf8");
+    for (const match of html.matchAll(/\b(?:href|src)="(\/[^"<>]*)"/gu)) {
+      let target = match[1].split(/[?#]/u, 1)[0];
+      if (basePath && (target === basePath || target.startsWith(`${basePath}/`))) {
+        target = target.slice(basePath.length) || "/";
+      }
+      if (!target
+        || target.startsWith("//")
+        || target.startsWith("/api/")
+        || target.startsWith("/ask-molty/")
+        || target === "/mcp"
+        || target === "/mcp.search_open_claw") continue;
+      try {
+        target = decodeURIComponent(target);
+      } catch {
+        // Leave malformed URLs intact so the missing-route report exposes them.
+      }
+      const route = target.replace(/^\/+|\/+$/gu, "");
+      const candidates = route ? [route, `${route}/index.html`, `${route}.html`] : ["index.html"];
+      if (candidates.some((candidate) => present.has(candidate))) continue;
+      if (!missing.has(target)) missing.set(target, []);
+      if (missing.get(target).length < 3) missing.get(target).push(rel);
+    }
+  }
+
+  if (missing.size) {
+    const details = [...missing]
+      .slice(0, 20)
+      .map(([target, sources]) => `${target} from ${sources.join(", ")}`)
+      .join("; ");
+    throw new Error(`internal route audit: ${missing.size} missing target(s): ${details}`);
+  }
+}
 
 function assertEditSourceLinks() {
   const htmlFiles = walkHtml(site);
@@ -774,5 +821,13 @@ function walkHtml(dir) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) return walkHtml(full);
     return entry.isFile() && entry.name.endsWith(".html") ? [full] : [];
+  });
+}
+
+function walkFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    return entry.isDirectory() ? walkFiles(full) : [full];
   });
 }


### PR DESCRIPTION
## Summary

- publish nested static assets such as docs images and ClawHub screenshots
- render public nested `AGENTS.md` template pages while continuing to skip repo instruction files
- fall back to the English route when localized content links to a page that has not been translated
- make the hidden component fixture use the current Plugin SDK route
- audit every generated root-relative `href` and `src` during docs smoke tests

## Root cause

The static builder copied only `docs/assets/**` and top-level non-doc files, excluded every nested `AGENTS.md`, and preserved missing locale-prefixed routes instead of falling back to an existing English page. The hidden fixture also referenced a retired SDK route.

## Proof

- `npm test`
- `npm run docs:check`
  - 27,905 generated pages
  - 14,290 Pagefind pages across 21 languages
  - full static route audit clean
  - visual smoke clean
- `node scripts/docs-site/r2-prepare.mjs`
  - 45,639 files
  - 14,761 slashless aliases
  - 60,400 R2 objects
- exact built artifact served locally: template page, both previously missing images, ClawHub fallback targets, current SDK target, and hidden fixture all returned HTTP 200
- Codex autoreview: no accepted/actionable findings

## Risk

Low. Changes are confined to the repo-owned static-site builder and smoke fixture. Generated docs and translation output are untouched.
