### PR TITLE
fix: add localized legacy redirects

### DIFF
--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -714,11 +714,27 @@ function writeRedirects() {
   for (const redirect of config.redirects ?? []) {
     const source = cleanPath(redirect.source);
     const dest = cleanPath(redirect.destination);
-    writeRedirectFile(source, publicPath(dest));
-    for (const prefix of new Set([basePath, legacyBasePath].filter(Boolean))) {
-      writeRedirectFile(`${prefix}${source}`, publicPath(dest));
+    writeRedirectVariants(source, publicPath(dest));
+    for (const locale of locales) {
+      if (locale.root) continue;
+      writeRedirectVariants(`/${locale.code}${source}`, localizedRedirectDestination(locale.code, dest));
     }
   }
+}
+
+function writeRedirectVariants(source, dest) {
+  writeRedirectFile(source, dest);
+  for (const prefix of new Set([basePath, legacyBasePath].filter(Boolean))) {
+    writeRedirectFile(`${prefix}${source}`, dest);
+  }
+}
+
+function localizedRedirectDestination(locale, dest) {
+  const [pathname, hash] = dest.split("#");
+  const slug = normalizeSlug(pathname.replace(/^\/+|\/+$/g, ""));
+  const page = allPageByKey.get(pageKey(locale, slug));
+  if (!page) return publicPath(dest);
+  return publicPath(`${pageRoute(page)}${hash ? `#${hash}` : ""}`);
 }
 
 function writeRedirectFile(source, dest) {

--- a/scripts/docs-site/smoke.mjs
+++ b/scripts/docs-site/smoke.mjs
@@ -20,6 +20,7 @@ const previewOrigin = (process.env.DOCS_SITE_CNAME ? `https://${process.env.DOCS
 const llmsFullAvailable = process.env.DOCS_SITE_LLMS_FULL_AVAILABLE === "1";
 const artifactMode = process.env.DOCS_SITE_ARTIFACT_MODE ?? "full";
 const shellOnly = artifactMode === "shell";
+const basePath = `/${(process.env.DOCS_SITE_BASE_PATH ?? "").replace(/^\/+|\/+$/g, "")}`.replace(/^\/$/, "");
 if (!["full", "shell"].includes(artifactMode)) {
   throw new Error(`DOCS_SITE_ARTIFACT_MODE must be full or shell, got ${artifactMode}`);
 }
@@ -734,6 +735,19 @@ if (!fs.existsSync(legacyDigitalOcean)) {
 if (!/url=\/(?:docs\/)?install\/digitalocean/.test(fs.readFileSync(legacyDigitalOcean, "utf8"))) {
   throw new Error("legacy DigitalOcean redirect: wrong destination");
 }
+for (const locale of activeLocaleCodes()) {
+  if (locale === "en") continue;
+  const localizedCodexSupervisor = path.join(site, locale, "plugins/reference/codex-supervisor/index.html");
+  if (!fs.existsSync(localizedCodexSupervisor)) {
+    throw new Error(`localized Codex Supervisor redirect: missing /${locale}/plugins/reference/codex-supervisor`);
+  }
+  const localizedDestination = fs.existsSync(path.join(docsDir, locale, "plugins/codex-supervision.md"))
+    ? `${basePath}/${locale}/plugins/codex-supervision`
+    : `${basePath}/plugins/codex-supervision`;
+  if (!fs.readFileSync(localizedCodexSupervisor, "utf8").includes(`url=${localizedDestination}`)) {
+    throw new Error(`localized Codex Supervisor redirect: wrong ${locale} destination`);
+  }
+}
 const showcase = fs.readFileSync(path.join(site, "start/showcase/index.html"), "utf8");
 if (!/href="https:\/\/x\.com\/i\/status\/2010878524543131691"/.test(showcase)) {
   throw new Error("showcase: external card href was not rendered");
@@ -745,7 +759,6 @@ console.log(`docs site smoke ok: shell, routing, skin, and hidden fixture checks
 function assertInternalRoutes() {
   const files = walkFiles(site);
   const present = new Set(files.map((file) => path.relative(site, file).replaceAll(path.sep, "/")));
-  const basePath = `/${(process.env.DOCS_SITE_BASE_PATH ?? "").replace(/^\/+|\/+$/g, "")}`.replace(/^\/$/, "");
   const missing = new Map();
 
   for (const file of files) {


### PR DESCRIPTION
## What Problem This Solves

R2 Pages fails its internal route audit while localized plugin inventories still link a recently retired route such as `/ar/plugins/reference/codex-supervisor`. English redirects exist, but the static builder did not emit locale-prefixed redirect files, so translation lag blocked every docs publish.

## Why This Change Was Made

Generate locale-prefixed variants for every configured redirect instead of weakening the route audit or restoring retired plugin pages. Redirects use the localized destination when that page exists and fall back to the canonical English destination until translation catches up. Existing authored pages remain untouched.

## User Impact

Docs publishes can proceed while localized pages lag behind English source changes. Stale localized links continue to resolve, and users stay in their locale whenever the translated destination exists.

## Evidence

- `make docs-check` — passed; rendered 27,898 pages, prepared 78,652 R2 objects, indexed 21 languages, and passed the full internal route audit.
- `DOCS_SITE_BASE_PATH=/docs npm run docs:build:shell` — generated both base-path and locale-prefixed redirect variants.
- Direct artifact checks proved `/ar/plugins/reference/codex-supervisor` falls back to `/plugins/codex-supervision`, while `/ar/session` redirects to `/ar/concepts/session`.
- Codex autoreview — clean after fixing its accepted base-path smoke finding.
