### PR TITLE
chore: align pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,65 @@
+<!--
+Optional linked context:
+Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
+below this comment.
+
+Required PR title:
+type: user-facing description
+Use a parenthesized scope only when it adds clarity:
+fix(auth): login redirect loops when session cookie is expired
+
+Types: feat, fix, improve, refactor, docs, chore.
+For fixes, describe the user-visible symptom and trigger:
+fix: task list fails to load when user has no environments
+Avoid implementation details such as:
+fix: add null check to task query
+-->
+
+<details>
+<summary>Additional instructions</summary>
+
+**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
+can help update the branch when needed.
+
+</details>
+
+## What Problem This Solves
+
+<!--
+Describe the concrete user, product, or operational problem.
+For fixes, begin with:
+"Fixes an issue where users <do X> would <experience Y> when <condition>."
+or:
+"Resolves a problem where..."
+
+Name the affected UI surface or workflow. Do not describe the code-level cause here.
+-->
+
+## Why This Change Was Made
+
+<!--
+In one or two sentences, explain the complete shipped solution, key design
+decisions, and relevant boundaries or non-goals. Include implementation detail
+only when it helps reviewers understand user-visible behavior or risk.
+Avoid file-by-file narration.
+-->
+
+## User Impact
+
+<!--
+State what users, operators, or developers can now do or expect. Lead with the
+concrete benefit and use user-facing language. If there is no user-visible
+impact, say so plainly.
+-->
+
+## Evidence
+
+<!--
+Show the most useful proof that this change works. Screenshots, screencasts,
+terminal output, focused tests, CI results, live observations, redacted logs,
+and artifact links are all useful. Include before/after evidence for visual
+changes when it clarifies the result.
+
+Reviewers will inspect the code, tests, and CI. Use this section to make the
+validation easy to understand, not to restate the diff.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Publish mirror for `docs.openclaw.ai`. Source repo: `openclaw/openclaw`.
 
 - `AGENTS.md`, `CLAUDE.md`, `README.md`.
 - `.agents/skills/autoreview/**` for the repo-local canonical review skill mirror.
+- `.github/pull_request_template.md` for repo-owned contribution guidance.
 - `.github/assets/**` for repo-owned README media that must not be pruned by docs sync.
 - `.github/workflows/translate-*.yml`.
 - `.github/workflows/translate-locale-reusable.yml`.


### PR DESCRIPTION
## What Problem This Solves

Resolves inconsistent pull request descriptions across OpenClaw-owned repositories while keeping the generated documentation mirror's ownership policy explicit.

## Why This Change Was Made

Copies the canonical PR body template from `openclaw/openclaw` at commit `2ac723282c84286ad3f38aabbd2e70699aafb3c3` and adds the repository-owned template path to `AGENTS.md`'s editable allowlist.

## User Impact

Contributors and maintainers get the shared PR submission structure; generated documentation remains untouched and no runtime behavior changes.

## Evidence

- Canonical source blob: `e902c4789b21765ea16dfb75e436db5801b6450b` at `openclaw/openclaw@2ac723282c84286ad3f38aabbd2e70699aafb3c3`.
- Template SHA-256 matches canonical: `38845d7f2cfc96402062408ac8a87b1e3f5f81dd80924785b0547b64a0c914b6`.
- `AGENTS.md` now explicitly permits `.github/pull_request_template.md` as repo-owned contribution guidance.
- `git diff --check` passed; generated docs were not modified.
- AI-assisted batch maintenance change.
