### PR TITLE
fix(i18n): resume failed full translation shards

### DIFF
--- a/.github/scripts/i18n/merge_artifact_roots.py
+++ b/.github/scripts/i18n/merge_artifact_roots.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Merge prior and current translation artifacts for failed-shard resume.
+
+Definition:
+  Copies artifact directories into one flat finalizer input. Prior successful
+  shards are copied first; current rerun artifacts replace matching prior
+  artifact names.
+
+Parameters:
+  --previous-root: Optional artifacts downloaded from the resumed run.
+  --current-root: Artifacts produced by the current run.
+  --output-root: Fresh merged artifact directory.
+
+Outputs:
+  Recreates --output-root and prints the number of merged artifacts.
+
+Examples:
+  python .github/scripts/i18n/merge_artifact_roots.py \
+    --previous-root .openclaw-sync/resume-artifacts \
+    --current-root .openclaw-sync/current-artifacts \
+    --output-root .openclaw-sync/i18n-artifacts
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def artifact_dirs(root: Path | None) -> list[Path]:
+    if root is None or not root.exists():
+        return []
+    return sorted(path for path in root.rglob("*") if path.is_dir() and (path / "metadata.json").is_file())
+
+
+def merge_artifact_roots(previous_root: Path | None, current_root: Path, output_root: Path) -> int:
+    if output_root.exists():
+        shutil.rmtree(output_root)
+    output_root.mkdir(parents=True)
+    merged: set[str] = set()
+    for root in (previous_root, current_root):
+        names: set[str] = set()
+        for artifact in artifact_dirs(root):
+            if artifact.name in names:
+                raise SystemExit(f"duplicate artifact directory name in {root}: {artifact.name}")
+            names.add(artifact.name)
+            destination = output_root / artifact.name
+            if destination.exists():
+                shutil.rmtree(destination)
+            shutil.copytree(artifact, destination)
+            merged.add(artifact.name)
+    print(f"merged artifacts: {len(merged)}")
+    return len(merged)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Merge prior and current translation artifacts.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Examples:
+  python .github/scripts/i18n/merge_artifact_roots.py --current-root current --output-root merged
+  python .github/scripts/i18n/merge_artifact_roots.py --previous-root prior --current-root current --output-root merged
+""",
+    )
+    parser.add_argument("--previous-root", type=Path)
+    parser.add_argument("--current-root", required=True, type=Path)
+    parser.add_argument("--output-root", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    merge_artifact_roots(args.previous_root, args.current_root, args.output_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/i18n/plan_full.py
+++ b/.github/scripts/i18n/plan_full.py
@@ -12,6 +12,9 @@ Parameters:
   --docs-root: Docs directory used to size full-translation shards. Default: docs.
   --target-docs-per-shard: Desired source documents per shard. Default: 125.
   --max-shards: Maximum shards per locale. Default: 8.
+  --resume-artifacts-root: Prior run artifacts. When set, rerun only failed,
+    missing, or unusable shards and reuse successful artifacts in finalization.
+  --source-sha: Required with --resume-artifacts-root. Rejects stale artifacts.
 
 Outputs:
   GITHUB_OUTPUT receives locale_count, canary locale fields, selected_locales,
@@ -44,6 +47,7 @@ from translation_plan import (
 
 MAX_BATCHES = 6
 DEFAULT_BATCH_SIZE = 4
+RESUME_BATCH_SIZE = 28
 FULL_TARGET_DOCS_PER_SHARD = 125
 FULL_MAX_SHARDS = 8
 
@@ -57,7 +61,96 @@ def build_batches(selected: list[Locale], batch_size: int) -> list[list[Locale]]
     return batches
 
 
-def append_outputs(selected: list[Locale], batches: list[list[Locale]], shard_total: int, source_docs: int) -> None:
+def artifact_is_usable(artifact: Path, metadata: dict[str, object]) -> bool:
+    changed_path = artifact / "changed-files.txt"
+    deleted_path = artifact / "deleted-files.txt"
+    if not changed_path.is_file() or not deleted_path.is_file():
+        return False
+    changed = [line for line in changed_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    deleted = [line for line in deleted_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    try:
+        if int(metadata.get("changed_count") or 0) != len(changed):
+            return False
+        if int(metadata.get("deleted_count") or 0) != len(deleted):
+            return False
+    except (TypeError, ValueError):
+        return False
+    payload = artifact / "payload"
+    return all((payload / path).is_file() for path in changed)
+
+
+def build_resume_plan(
+    selected: list[Locale],
+    shard_total: int,
+    artifacts_root: Path,
+    source_sha: str,
+) -> list[list[dict[str, str]]]:
+    if not source_sha:
+        raise SystemExit("--source-sha is required with --resume-artifacts-root")
+    artifacts: dict[tuple[str, int], list[tuple[Path, dict[str, object]]]] = {}
+    selected_slugs = {locale.locale_slug for locale in selected}
+    for artifact in sorted(path for path in artifacts_root.rglob("*") if path.is_dir() and (path / "metadata.json").is_file()):
+        try:
+            metadata = json.loads((artifact / "metadata.json").read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(metadata, dict) or metadata.get("artifact_role", "locale") == "canary":
+            continue
+        slug = metadata.get("locale_slug")
+        if slug not in selected_slugs:
+            continue
+        if metadata.get("source_sha") != source_sha:
+            raise SystemExit(f"resume artifact {artifact.name} belongs to source {metadata.get('source_sha')}, expected {source_sha}")
+        if metadata.get("mode") != "full":
+            raise SystemExit(f"resume artifact {artifact.name} is not from a full translation run")
+        try:
+            shard_index = int(metadata.get("shard_index"))
+            artifact_shard_total = int(metadata.get("shard_total"))
+        except (TypeError, ValueError) as exc:
+            raise SystemExit(f"resume artifact {artifact.name} has invalid shard metadata") from exc
+        if artifact_shard_total != shard_total:
+            raise SystemExit(
+                f"resume artifact {artifact.name} uses {artifact_shard_total} shards, expected {shard_total}"
+            )
+        artifacts.setdefault((str(slug), shard_index), []).append((artifact, metadata))
+
+    failed_shards: list[dict[str, str]] = []
+    for locale in selected:
+        for shard_index in range(shard_total):
+            candidates = artifacts.get((locale.locale_slug, shard_index), [])
+            if len(candidates) > 1:
+                raise SystemExit(f"resume run contains duplicate artifacts for {locale.locale} shard {shard_index}/{shard_total}")
+            usable = False
+            if candidates:
+                artifact, metadata = candidates[0]
+                usable = not metadata.get("failed_reason") and artifact_is_usable(artifact, metadata)
+            if usable:
+                continue
+            failed_shards.append(
+                {
+                    "locale": locale.locale,
+                    "locale_slug": locale.locale_slug,
+                    "shard_index": str(shard_index),
+                    "shard_total": str(shard_total),
+                }
+            )
+    batches = [
+        failed_shards[index : index + RESUME_BATCH_SIZE]
+        for index in range(0, len(failed_shards), RESUME_BATCH_SIZE)
+    ]
+    if len(batches) > MAX_BATCHES:
+        raise SystemExit(f"resume needs {len(batches)} batches; max supported is {MAX_BATCHES}")
+    return batches
+
+
+def append_outputs(
+    selected: list[Locale],
+    batches: list[list[dict[str, str]]],
+    shard_total: int,
+    source_docs: int,
+    resume_mode: bool,
+    translation_required: bool,
+) -> None:
     output = os.environ.get("GITHUB_OUTPUT")
     if not output:
         return
@@ -71,13 +164,23 @@ def append_outputs(selected: list[Locale], batches: list[list[Locale]], shard_to
         fh.write(f"expected_locales={expected_locales}\n")
         fh.write(f"source_doc_count={source_docs}\n")
         fh.write(f"shard_total={shard_total}\n")
+        fh.write(f"resume_mode={'true' if resume_mode else 'false'}\n")
+        fh.write(f"translation_required={'true' if translation_required else 'false'}\n")
         for index in range(MAX_BATCHES):
             batch = batches[index] if index < len(batches) else []
             fh.write(f"batch_{index + 1}_count={len(batch)}\n")
-            fh.write(f"batch_{index + 1}={matrix_json(expand_shards(batch, shard_total))}\n")
+            fh.write(f"batch_{index + 1}={matrix_json(batch)}\n")
 
 
-def append_summary(target_locale: str, selected: list[Locale], batches: list[list[Locale]], shard_total: int, source_docs: int) -> None:
+def append_summary(
+    target_locale: str,
+    selected: list[Locale],
+    batches: list[list[dict[str, str]]],
+    shard_total: int,
+    source_docs: int,
+    resume_mode: bool,
+    translation_required: bool,
+) -> None:
     summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary:
         return
@@ -88,8 +191,11 @@ def append_summary(target_locale: str, selected: list[Locale], batches: list[lis
         fh.write(f"- canary locale: `{selected[0].locale}`\n")
         fh.write(f"- source docs: `{source_docs}`\n")
         fh.write(f"- shards per locale: `{shard_total}`\n")
+        fh.write(f"- resume mode: `{'true' if resume_mode else 'false'}`\n")
+        fh.write(f"- translation required: `{'true' if translation_required else 'false'}`\n")
         for index, batch in enumerate(batches, start=1):
-            fh.write(f"- batch {index}: `{', '.join(locale.locale for locale in batch)}`\n")
+            items = ", ".join(f"{item['locale']}:{item['shard_index']}" for item in batch)
+            fh.write(f"- batch {index}: `{items}`\n")
 
 
 def plan_full(
@@ -98,21 +204,39 @@ def plan_full(
     docs_root: Path | None = None,
     target_docs_per_shard: int = FULL_TARGET_DOCS_PER_SHARD,
     max_shards: int = FULL_MAX_SHARDS,
+    resume_artifacts_root: Path | None = None,
+    source_sha: str = "",
 ) -> dict[str, object]:
     selected = select_locales(target_locale)
-    batches = build_batches(selected, batch_size)
     source_docs = source_doc_count(docs_root or Path("docs"))
     shard_total = shard_total_for_doc_count(source_docs, target_docs_per_shard, max_shards)
+    resume_mode = resume_artifacts_root is not None
+    if resume_artifacts_root is not None:
+        matrix_batches = build_resume_plan(selected, shard_total, resume_artifacts_root, source_sha)
+    else:
+        batches = build_batches(selected, batch_size)
+        matrix_batches = [expand_shards(batch, shard_total) for batch in batches]
+    translation_required = any(matrix_batches)
     expected_locales = " ".join(f"{locale.locale_slug}={locale.locale}" for locale in selected)
-    append_outputs(selected, batches, shard_total, source_docs)
-    append_summary(target_locale, selected, batches, shard_total, source_docs)
+    append_outputs(selected, matrix_batches, shard_total, source_docs, resume_mode, translation_required)
+    append_summary(
+        target_locale,
+        selected,
+        matrix_batches,
+        shard_total,
+        source_docs,
+        resume_mode,
+        translation_required,
+    )
     return {
         "selected": [locale.matrix_item() for locale in selected],
         "canary": selected[0].matrix_item(),
         "expected_locales": expected_locales,
         "source_doc_count": source_docs,
         "shard_total": shard_total,
-        "batches": [expand_shards(batch, shard_total) for batch in batches],
+        "resume_mode": resume_mode,
+        "translation_required": translation_required,
+        "batches": matrix_batches,
     }
 
 
@@ -133,12 +257,22 @@ Examples:
     parser.add_argument("--docs-root", default="docs", type=Path)
     parser.add_argument("--target-docs-per-shard", default=FULL_TARGET_DOCS_PER_SHARD, type=int)
     parser.add_argument("--max-shards", default=FULL_MAX_SHARDS, type=int)
+    parser.add_argument("--resume-artifacts-root", type=Path)
+    parser.add_argument("--source-sha", default=os.environ.get("SOURCE_SHA", ""))
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    plan = plan_full(args.target_locale, args.batch_size, args.docs_root, args.target_docs_per_shard, args.max_shards)
+    plan = plan_full(
+        args.target_locale,
+        args.batch_size,
+        args.docs_root,
+        args.target_docs_per_shard,
+        args.max_shards,
+        args.resume_artifacts_root,
+        args.source_sha,
+    )
     print(json.dumps(plan, indent=2, sort_keys=True))
 
 

--- a/.github/scripts/i18n/repair_mdx_protected_attributes.mjs
+++ b/.github/scripts/i18n/repair_mdx_protected_attributes.mjs
@@ -47,11 +47,26 @@ function blankPreservingNewlines(value) {
   return value.replace(/[^\n]/gu, " ");
 }
 
+function replaceWithOffsetMap(prepared, offsets, start, end, replacement) {
+  const originalStart = offsets[start];
+  const originalEnd = offsets[end];
+  const replacementOffsets = [originalStart];
+  for (let index = 1; index < replacement.length; index += 1) {
+    replacementOffsets.push(originalStart);
+  }
+  replacementOffsets.push(originalEnd);
+  return {
+    prepared: prepared.slice(0, start) + replacement + prepared.slice(end),
+    offsets: [...offsets.slice(0, start), ...replacementOffsets, ...offsets.slice(end + 1)],
+  };
+}
+
 function parseMdxForOffsets(processor, markdownProcessor, value) {
   let prepared = value;
+  let offsets = Array.from({ length: value.length + 1 }, (_, index) => index);
   for (let attempt = 0; attempt < 1000; attempt += 1) {
     try {
-      return processor.parse(prepared);
+      return { tree: processor.parse(prepared), offsets };
     } catch (error) {
       const offset = error.place?.offset;
       if (!Number.isInteger(offset)) throw error;
@@ -60,10 +75,13 @@ function parseMdxForOffsets(processor, markdownProcessor, value) {
       if (prepared.startsWith("<!--", opening)) {
         const closing = prepared.indexOf("-->", opening + 4);
         if (closing < 0) throw error;
-        prepared =
-          prepared.slice(0, opening) +
-          blankPreservingNewlines(prepared.slice(opening, closing + 3)) +
-          prepared.slice(closing + 3);
+        ({ prepared, offsets } = replaceWithOffsetMap(
+          prepared,
+          offsets,
+          opening,
+          closing + 3,
+          blankPreservingNewlines(prepared.slice(opening, closing + 3)),
+        ));
         continue;
       }
 
@@ -71,15 +89,21 @@ function parseMdxForOffsets(processor, markdownProcessor, value) {
         ([start, end]) => opening >= start && opening < end,
       );
       if (!literal && JSX_TAG_START_RE.test(prepared[opening + 1] || "")) throw error;
-      prepared = prepared.slice(0, opening) + " " + prepared.slice(opening + 1);
+      ({ prepared, offsets } = replaceWithOffsetMap(prepared, offsets, opening, opening + 1, "&lt;"));
     }
   }
   throw new Error("too many rejected non-MDX less-than tokens");
 }
 
-function collectElements(tree, value) {
+function collectElements(parsed, value) {
+  const { tree, offsets } = parsed;
   const elements = [];
   let sequence = 0;
+
+  function originalOffset(offset) {
+    if (!Number.isInteger(offset) || offset < 0 || offset >= offsets.length) return undefined;
+    return offsets[offset];
+  }
 
   function addElement(name, attributes, offset, nameEnd, openingEnd) {
     if (!name || !Number.isInteger(offset) || !Number.isInteger(nameEnd) || !Number.isInteger(openingEnd)) return;
@@ -99,11 +123,11 @@ function collectElements(tree, value) {
         opening.attributes.map((attribute) => ({
           name: attribute.type === "JSXAttribute" ? jsxName(attribute.name) : "...",
           protected: attribute.type === "JSXSpreadAttribute" || PROTECTED_ATTRIBUTES.has(jsxName(attribute.name)),
-          raw: value.slice(attribute.start, attribute.end),
+          raw: value.slice(originalOffset(attribute.start), originalOffset(attribute.end)),
         })),
-        node.start,
-        opening.name.end,
-        opening.end,
+        originalOffset(node.start),
+        originalOffset(opening.name.end),
+        originalOffset(opening.end),
       );
     }
     for (const [key, child] of Object.entries(node)) {
@@ -115,9 +139,9 @@ function collectElements(tree, value) {
   function visitMdast(node) {
     if (!node || typeof node !== "object") return;
     if ((node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") && typeof node.name === "string") {
-      const start = node.position?.start?.offset;
+      const start = originalOffset(node.position?.start?.offset);
       const nameEnd = Number.isInteger(start) ? start + 1 + node.name.length : undefined;
-      const lastAttributeEnd = node.attributes.at(-1)?.position?.end?.offset;
+      const lastAttributeEnd = originalOffset(node.attributes.at(-1)?.position?.end?.offset);
       const searchFrom = Number.isInteger(lastAttributeEnd) ? lastAttributeEnd : nameEnd;
       const close = Number.isInteger(searchFrom) ? value.indexOf(">", searchFrom) : -1;
       addElement(
@@ -127,7 +151,10 @@ function collectElements(tree, value) {
           protected:
             attribute.type === "mdxJsxExpressionAttribute" ||
             (attribute.type === "mdxJsxAttribute" && PROTECTED_ATTRIBUTES.has(attribute.name)),
-          raw: value.slice(attribute.position.start.offset, attribute.position.end.offset),
+          raw: value.slice(
+            originalOffset(attribute.position.start.offset),
+            originalOffset(attribute.position.end.offset),
+          ),
         })),
         start,
         nameEnd,

--- a/.github/scripts/i18n/tests/test_i18n_scripts.py
+++ b/.github/scripts/i18n/tests/test_i18n_scripts.py
@@ -42,6 +42,7 @@ clear_pending_locale_outputs = load_module("clear_pending_locale_outputs")
 package_artifact = load_module("package_artifact")
 mdx_repair_scope = load_module("mdx_repair_scope")
 apply_artifacts = load_module("apply_artifacts")
+merge_artifact_roots = load_module("merge_artifact_roots")
 read_source_metadata = load_module("read_source_metadata")
 prune_stale_locale_pages = load_module("prune_stale_locale_pages")
 plan_full = load_module("plan_full")
@@ -197,6 +198,7 @@ class I18NScriptTests(unittest.TestCase):
         self.assertIn("schedule:", text)
         self.assertIn("workflow_dispatch:", text)
         self.assertIn("target_locale:", text)
+        self.assertIn("resume_run_id:", text)
         self.assertIn("canary_only:", text)
         self.assertIn("cancel-in-progress: false", text)
 
@@ -230,6 +232,10 @@ class I18NScriptTests(unittest.TestCase):
         self.assertIn("shard_total: ${{ matrix.shard_total }}", text)
         self.assertIn("commit_locale: false", text)
         self.assertIn("translate-finalize-reusable.yml", text)
+        self.assertIn("run-id: ${{ inputs.resume_run_id }}", text)
+        self.assertIn("resume_run_id: ${{ inputs.resume_run_id || '' }}", text)
+        self.assertIn("merge_artifact_roots.py", text)
+        self.assertIn("needs.plan.outputs.translation_required == 'false'", text)
         self.assertNotIn("translate-locale-finalize-reusable.yml", text)
         self.assertRegex(
             text,
@@ -546,6 +552,161 @@ class I18NScriptTests(unittest.TestCase):
             result["batches"][0],
         )
         self.assertEqual("ru=ru", result["expected_locales"])
+
+    def test_full_plan_resume_reruns_only_failed_shards(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = Path(tmp) / "artifacts"
+            base_metadata = {
+                "artifact_role": "locale",
+                "locale": "ru",
+                "locale_slug": "ru",
+                "mode": "full",
+                "shard_total": 2,
+                "source_sha": "source-a",
+                "changed_count": 0,
+                "deleted_count": 0,
+            }
+            self._write_artifact(
+                artifacts,
+                "i18n-ru-s0of2-source-a",
+                metadata={**base_metadata, "shard_index": 0, "failed_reason": ""},
+            )
+            self._write_artifact(
+                artifacts,
+                "i18n-ru-s1of2-source-a",
+                metadata={**base_metadata, "shard_index": 1, "failed_reason": "translation failed"},
+            )
+
+            result = plan_full.plan_full(
+                "ru",
+                4,
+                FIXTURES / "pending-docs" / "docs",
+                target_docs_per_shard=1,
+                max_shards=4,
+                resume_artifacts_root=artifacts,
+                source_sha="source-a",
+            )
+
+            self.assertTrue(result["resume_mode"])
+            self.assertTrue(result["translation_required"])
+            self.assertEqual([{"locale": "ru", "locale_slug": "ru"}], result["selected"])
+            self.assertEqual(
+                [[{"locale": "ru", "locale_slug": "ru", "shard_index": "1", "shard_total": "2"}]],
+                result["batches"],
+            )
+
+    def test_full_resume_keeps_successful_locales_in_finalization_set(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = Path(tmp) / "artifacts"
+            locales = [translation_plan.Locale("fr", "fr"), translation_plan.Locale("ru", "ru")]
+            for locale in locales:
+                for shard_index in range(2):
+                    failed = locale.locale == "ru" and shard_index == 1
+                    self._write_artifact(
+                        artifacts,
+                        f"i18n-{locale.locale_slug}-s{shard_index}of2-source-a",
+                        metadata={
+                            "artifact_role": "locale",
+                            "locale": locale.locale,
+                            "locale_slug": locale.locale_slug,
+                            "mode": "full",
+                            "shard_index": shard_index,
+                            "shard_total": 2,
+                            "source_sha": "source-a",
+                            "failed_reason": "translation failed" if failed else "",
+                            "changed_count": 0,
+                            "deleted_count": 0,
+                        },
+                    )
+
+            batches = plan_full.build_resume_plan(locales, 2, artifacts, "source-a")
+
+            self.assertEqual(
+                [[{"locale": "ru", "locale_slug": "ru", "shard_index": "1", "shard_total": "2"}]],
+                batches,
+            )
+            self.assertEqual(["fr", "ru"], [locale.locale for locale in locales])
+
+    def test_full_resume_without_artifacts_reruns_every_shard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            locales = [translation_plan.Locale("fr", "fr")]
+
+            batches = plan_full.build_resume_plan(locales, 2, Path(tmp), "source-a")
+
+            self.assertEqual(
+                [
+                    [
+                        {"locale": "fr", "locale_slug": "fr", "shard_index": "0", "shard_total": "2"},
+                        {"locale": "fr", "locale_slug": "fr", "shard_index": "1", "shard_total": "2"},
+                    ]
+                ],
+                batches,
+            )
+
+    def test_full_resume_with_all_successful_shards_requires_only_finalization(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = Path(tmp) / "artifacts"
+            for shard_index in range(2):
+                self._write_artifact(
+                    artifacts,
+                    f"i18n-ru-s{shard_index}of2-source-a",
+                    metadata={
+                        "artifact_role": "locale",
+                        "locale": "ru",
+                        "locale_slug": "ru",
+                        "mode": "full",
+                        "shard_index": shard_index,
+                        "shard_total": 2,
+                        "source_sha": "source-a",
+                        "failed_reason": "",
+                        "changed_count": 0,
+                        "deleted_count": 0,
+                    },
+                )
+
+            result = plan_full.plan_full(
+                "ru",
+                4,
+                FIXTURES / "pending-docs" / "docs",
+                target_docs_per_shard=1,
+                max_shards=4,
+                resume_artifacts_root=artifacts,
+                source_sha="source-a",
+            )
+
+            self.assertEqual([], result["batches"])
+            self.assertFalse(result["translation_required"])
+
+    def test_full_plan_resume_rejects_stale_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = Path(tmp) / "artifacts"
+            self._write_artifact(
+                artifacts,
+                "i18n-ru-s0of2-source-old",
+                metadata={
+                    "artifact_role": "locale",
+                    "locale": "ru",
+                    "locale_slug": "ru",
+                    "mode": "full",
+                    "shard_index": 0,
+                    "shard_total": 2,
+                    "source_sha": "source-old",
+                    "failed_reason": "",
+                    "changed_count": 0,
+                    "deleted_count": 0,
+                },
+            )
+
+            with self.assertRaisesRegex(SystemExit, "belongs to source source-old"):
+                plan_full.plan_full(
+                    "ru",
+                    4,
+                    FIXTURES / "pending-docs" / "docs",
+                    target_docs_per_shard=1,
+                    max_shards=4,
+                    resume_artifacts_root=artifacts,
+                    source_sha="source-new",
+                )
 
     def test_full_plan_defaults_to_max_sized_shards(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -1398,8 +1559,8 @@ class I18NScriptTests(unittest.TestCase):
           import {{ repairProtectedAttributes }} from {json.dumps(repair.as_uri())};
           const processor = createProcessor({{ format: "mdx" }});
           const markdownProcessor = createProcessor({{ format: "md" }});
-          const source = `Plain Markdown says n < 9 before the JSX.\\n<ParamField path="prompt" type="string" default="Analyze this PDF document." label="Prompt" />\\n`;
-          const translated = `Plain Markdown says n < 9 before the JSX.\\n<ParamField label="Eingabe" default="Analysieren Sie dieses PDF-Dokument." type="text" path="eingabe" />\\n`;
+          const source = `Plain Markdown says n < 9 and m < 12 before the JSX. 🚀\\n<ParamField path="prompt" type="string" default="Analyze this PDF document." label="Prompt" />\\n`;
+          const translated = `Plain Markdown says n < 9 and m < 12 before the JSX. 🚀\\n<ParamField label="Eingabe" default="Analysieren Sie dieses PDF-Dokument." type="text" path="eingabe" />\\n`;
           const result = repairProtectedAttributes(processor, markdownProcessor, source, translated);
           const expected = protectedAttributeSignatures(parseMdx(processor, markdownProcessor, source));
           const actual = protectedAttributeSignatures(parseMdx(processor, markdownProcessor, result.value));
@@ -1415,7 +1576,7 @@ class I18NScriptTests(unittest.TestCase):
         output = json.loads(result.stdout)
         self.assertTrue(output["result"]["changed"])
         self.assertEqual(output["expected"], output["actual"])
-        self.assertIn("n < 9", output["result"]["value"])
+        self.assertIn("n < 9 and m < 12", output["result"]["value"])
         self.assertIn('label="Eingabe"', output["result"]["value"])
         self.assertIn('path="prompt"', output["result"]["value"])
         self.assertIn('default="Analyze this PDF document."', output["result"]["value"])
@@ -2266,6 +2427,39 @@ class I18NScriptTests(unittest.TestCase):
             self.assertEqual(["fr: changed=5 deleted=2"], summary.successful)
             self.assertEqual([], summary.failed)
             self.assertEqual([], summary.skipped)
+
+    def test_merge_artifact_roots_prefers_current_rerun(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            previous = root / "previous"
+            current = root / "current"
+            output = root / "output"
+            metadata = {
+                "locale": "fr",
+                "locale_slug": "fr",
+                "mode": "full",
+                "shard_index": 1,
+                "shard_total": 2,
+                "source_sha": "source-a",
+                "changed_count": 0,
+                "deleted_count": 0,
+            }
+            self._write_artifact(
+                previous,
+                "i18n-fr-s1of2-source-a",
+                metadata={**metadata, "failed_reason": "translation failed"},
+            )
+            self._write_artifact(
+                current,
+                "i18n-fr-s1of2-source-a",
+                metadata={**metadata, "failed_reason": ""},
+            )
+
+            count = merge_artifact_roots.merge_artifact_roots(previous, current, output)
+
+            self.assertEqual(1, count)
+            merged = json.loads((output / "i18n-fr-s1of2-source-a/metadata.json").read_text(encoding="utf-8"))
+            self.assertEqual("", merged["failed_reason"])
 
     def test_apply_artifacts_applies_normal_fixture(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -37,6 +37,11 @@ on:
           - id
           - pl
           - th
+      resume_run_id:
+        description: Prior Translate Full run ID. Reuses successful shards and reruns failed or missing shards only.
+        required: false
+        default: ""
+        type: string
       canary_only:
         description: Run only the canary translation, publish, and live smoke.
         required: false
@@ -126,6 +131,8 @@ jobs:
       expected_locales: ${{ steps.plan.outputs.expected_locales }}
       source_doc_count: ${{ steps.plan.outputs.source_doc_count }}
       shard_total: ${{ steps.plan.outputs.shard_total }}
+      resume_mode: ${{ steps.plan.outputs.resume_mode }}
+      translation_required: ${{ steps.plan.outputs.translation_required }}
       batch_1_count: ${{ steps.plan.outputs.batch_1_count }}
       batch_1: ${{ steps.plan.outputs.batch_1 }}
       batch_2_count: ${{ steps.plan.outputs.batch_2_count }}
@@ -142,21 +149,37 @@ jobs:
       - name: Check out
         uses: actions/checkout@v7.0.1
 
+      - name: Download prior full-run artifacts
+        if: inputs.resume_run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.resume_run_id }}
+          pattern: i18n-*-${{ needs.prepare.outputs.source_sha }}
+          path: .openclaw-sync/resume-artifacts
+
       - name: Build full locale plan
         id: plan
         env:
           TARGET_LOCALE: ${{ inputs.target_locale || 'all' }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          RESUME_RUN_ID: ${{ inputs.resume_run_id || '' }}
         run: |
           set -euo pipefail
 
-          python .github/scripts/i18n/plan_full.py --batch-size 4
+          args=(--batch-size 4 --source-sha "${SOURCE_SHA}")
+          if [ -n "${RESUME_RUN_ID}" ]; then
+            args+=(--resume-artifacts-root .openclaw-sync/resume-artifacts)
+          fi
+          python .github/scripts/i18n/plan_full.py "${args[@]}"
 
   provider-preflight:
     name: Check translation provider
     needs:
       - prepare
       - plan
-    if: needs.prepare.outputs.should_translate == 'true'
+    if: needs.prepare.outputs.should_translate == 'true' && needs.plan.outputs.translation_required == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out
@@ -178,7 +201,7 @@ jobs:
       - prepare
       - plan
       - provider-preflight
-    if: needs.prepare.outputs.should_translate == 'true'
+    if: needs.prepare.outputs.should_translate == 'true' && needs.plan.outputs.translation_required == 'true'
     uses: ./.github/workflows/translate-locale-reusable.yml
     with:
       locale: ${{ needs.plan.outputs.canary_locale }}
@@ -389,13 +412,14 @@ jobs:
       - translate-batch-4
       - translate-batch-5
       - translate-batch-6
-    if: always() && needs.prepare.outputs.should_translate == 'true' && inputs.canary_only != true && inputs.diagnostic_canary_only != true && needs.translate-canary.result == 'success'
+    if: always() && needs.prepare.outputs.should_translate == 'true' && inputs.canary_only != true && inputs.diagnostic_canary_only != true && (needs.plan.outputs.translation_required == 'false' || needs.translate-canary.result == 'success')
     uses: ./.github/workflows/translate-finalize-reusable.yml
     with:
       source_sha: ${{ needs.prepare.outputs.source_sha }}
       mode: ${{ needs.prepare.outputs.mode }}
       shard_total: ${{ needs.plan.outputs.shard_total }}
       expected_locales: ${{ needs.plan.outputs.expected_locales }}
+      resume_run_id: ${{ inputs.resume_run_id || '' }}
     secrets: inherit
 
   full-status:
@@ -418,18 +442,43 @@ jobs:
       - name: Check out
         uses: actions/checkout@v7.0.1
 
-      - name: Download full locale artifacts
+      - name: Download prior full-run artifacts
+        if: inputs.resume_run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.resume_run_id }}
+          pattern: i18n-*-${{ needs.prepare.outputs.source_sha }}
+          path: .openclaw-sync/resume-artifacts
+
+      - name: Download current full locale artifacts
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           pattern: i18n-*-${{ needs.prepare.outputs.source_sha }}
-          path: .openclaw-sync/i18n-artifacts
+          path: .openclaw-sync/current-artifacts
+
+      - name: Merge full locale artifacts
+        run: |
+          set -euo pipefail
+          args=(
+            --current-root .openclaw-sync/current-artifacts
+            --output-root .openclaw-sync/i18n-artifacts
+          )
+          if [ -n "${RESUME_RUN_ID}" ]; then
+            args+=(--previous-root .openclaw-sync/resume-artifacts)
+          fi
+          python .github/scripts/i18n/merge_artifact_roots.py "${args[@]}"
+        env:
+          RESUME_RUN_ID: ${{ inputs.resume_run_id || '' }}
 
       - name: Summarize full run
         env:
           SELECTED_LOCALES: ${{ needs.plan.outputs.selected_locales }}
           LOCALE_COUNT: ${{ needs.plan.outputs.locale_count }}
           CANARY_ONLY: ${{ inputs.canary_only || false }}
+          RESUME_RUN_ID: ${{ inputs.resume_run_id || '' }}
           PROVIDER_RESULT: ${{ needs.provider-preflight.result }}
           CANARY_RESULT: ${{ needs.translate-canary.result }}
           BATCH_1_RESULT: ${{ needs.translate-batch-1.result }}
@@ -448,6 +497,7 @@ jobs:
             echo "- selected locales: \`${SELECTED_LOCALES}\`"
             echo "- locale count: \`${LOCALE_COUNT}\`"
             echo "- canary only: \`${CANARY_ONLY}\`"
+            echo "- resumed run: \`${RESUME_RUN_ID:-none}\`"
             echo "- provider preflight: \`${PROVIDER_RESULT}\`"
             echo "- canary: \`${CANARY_RESULT}\`"
             echo "- batch 1: \`${BATCH_1_RESULT}\`"

--- a/.github/workflows/translate-finalize-reusable.yml
+++ b/.github/workflows/translate-finalize-reusable.yml
@@ -16,6 +16,10 @@ on:
         required: false
         default: zh-cn=zh-CN zh-tw=zh-TW ja-jp=ja-JP es=es pt-br=pt-BR ko=ko de=de fr=fr hi=hi ar=ar it=it vi=vi nl=nl fa=fa ru=ru tr=tr uk=uk id=id pl=pl th=th
         type: string
+      resume_run_id:
+        required: false
+        default: ""
+        type: string
 
 permissions:
   actions: write
@@ -52,13 +56,37 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download locale artifacts
+      - name: Download prior full-run artifacts
+        if: inputs.resume_run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.resume_run_id }}
+          pattern: i18n-*-${{ inputs.source_sha }}
+          path: .openclaw-sync/resume-artifacts
+
+      - name: Download current locale artifacts
         id: download
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           pattern: i18n-*-${{ inputs.source_sha }}
-          path: .openclaw-sync/i18n-artifacts
+          path: .openclaw-sync/current-artifacts
+
+      - name: Merge locale artifacts
+        env:
+          RESUME_RUN_ID: ${{ inputs.resume_run_id }}
+        run: |
+          set -euo pipefail
+          args=(
+            --current-root .openclaw-sync/current-artifacts
+            --output-root .openclaw-sync/i18n-artifacts
+          )
+          if [ -n "${RESUME_RUN_ID}" ]; then
+            args+=(--previous-root .openclaw-sync/resume-artifacts)
+          fi
+          python "${I18N_SCRIPT_DIR}/merge_artifact_roots.py" "${args[@]}"
 
       - name: Apply locale artifacts
         id: apply


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a long Translate Full run had to retransmit every locale shard after a small subset failed. It also fixes protected-attribute repair offsets when MDX parsing normalizes escaped comparison operators.

## Why This Change Was Made

Full translation runs can now resume from a prior workflow run, reuse validated successful artifacts, rerun only failed or unusable shards, and merge the two artifact roots before finalization. The planner fails closed on incompatible source revisions, modes, or shard layouts, while missing prior artifacts intentionally degrade to a full rerun.

Protected-attribute repair now maps parser offsets from the normalized MDX input back to the original text before applying edits.

## User Impact

Maintainers can recover partial full-translation failures without repeating successful work. Finalization still covers the complete selected locale set, including a finalization-only resume when every prior shard is already usable.

## Evidence

- 102/102 i18n script tests passed.
- Workflow shell extraction and validation passed.
- `node --check` passed for the changed JavaScript.
- Python byte-compilation passed for the changed scripts.
- `git diff --check` passed.
- CodeQL passed for Actions and JavaScript/TypeScript.
- Real artifacts from failed Translate Full run `30187722394` selected only failed pt-BR shard `4/7` while reusing the other six.
- Mandatory autoreview passed after adding complete-locale finalization plus no-artifact and all-success boundary coverage.

Companion validator fix: https://github.com/openclaw/openclaw/pull/115204
