### PR TITLE
chore(deps): refresh docs tooling

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.4
+        uses: github/codeql-action/init@v4.37.6
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.4
+        uses: github/codeql-action/analyze@v4.37.6
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs-code-ci.yml
+++ b/.github/workflows/docs-code-ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: npm test
 
       - name: Validate Worker bundle
-        run: npx wrangler@4.118.0 deploy --dry-run --config wrangler.toml
+        run: npx wrangler@4.119.0 deploy --dry-run --config wrangler.toml
 
       - name: Build shell artifact
         run: npm run docs:build:r2:shell

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm ci
 
       - name: Validate Worker bundle
-        run: npx wrangler@4.118.0 deploy --dry-run --config wrangler.toml
+        run: npx wrangler@4.119.0 deploy --dry-run --config wrangler.toml
 
       - name: Deploy to Cloudflare
         if: github.event_name == 'workflow_dispatch' && inputs.deploy_worker == true
@@ -61,7 +61,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx wrangler@4.118.0 deploy --config wrangler.toml \
+          npx wrangler@4.119.0 deploy --config wrangler.toml \
             --tag "${GITHUB_SHA::12}" \
             --message "openclaw/docs ${GITHUB_SHA}"
 

--- a/.github/workflows/r2-pages.yml
+++ b/.github/workflows/r2-pages.yml
@@ -357,7 +357,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx wrangler@4.118.0 deploy --config wrangler.toml \
+          npx wrangler@4.119.0 deploy --config wrangler.toml \
             --tag "${GITHUB_SHA::12}" \
             --message "openclaw/docs ${GITHUB_SHA}"
 

--- a/.github/workflows/translate-locale-reusable.yml
+++ b/.github/workflows/translate-locale-reusable.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Install Codex CLI
         if: steps.stale.outputs.skip != 'true'
-        run: npm install -g @openai/codex@0.146.0
+        run: npm install -g @openai/codex@0.146.1
 
       - name: Prune stale locale pages
         if: steps.stale.outputs.skip != 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "lucide": "1.28.0",
         "markdown-it": "15.0.0",
         "markdown-it-anchor": "9.2.1",
-        "mermaid": "11.16.0",
+        "mermaid": "11.16.1",
         "pagefind": "1.5.2",
         "playwright": "^1.62.1",
         "yaml": "2.9.0"
@@ -2363,9 +2363,9 @@
       "license": "MIT"
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs:smoke:shell": "DOCS_SITE_ARTIFACT_MODE=shell node scripts/docs-site/smoke.mjs",
     "docs:visual": "node scripts/docs-site/visual-smoke.mjs",
     "docs:check": "npm run docs:build && npm run docs:smoke && npm run docs:visual && node --check scripts/docs-site/llms-full.mjs",
-    "skills:install": "npx --yes skills@1.5.21 add openclaw/carapace --skill openclaw-design openclaw-brand openclaw-carapace openclaw-design-system openclaw-marketing-pages openclaw-design-audit --agent codex --copy --yes",
+    "skills:install": "npx --yes skills@1.5.22 add openclaw/carapace --skill openclaw-design openclaw-brand openclaw-carapace openclaw-design-system openclaw-marketing-pages openclaw-design-audit --agent codex --copy --yes",
     "test": "node --test scripts/docs-site/*.test.mjs"
   },
   "devDependencies": {
@@ -26,7 +26,7 @@
     "lucide": "1.28.0",
     "markdown-it": "15.0.0",
     "markdown-it-anchor": "9.2.1",
-    "mermaid": "11.16.0",
+    "mermaid": "11.16.1",
     "pagefind": "1.5.2",
     "playwright": "^1.62.1",
     "yaml": "2.9.0"


### PR DESCRIPTION
## Summary

- update Mermaid from 11.16.0 to 11.16.1
- update Wrangler from 4.118.0 to 4.119.0
- update the Codex CLI workflow pin from 0.146.0 to 0.146.1
- update the skills installer from 1.5.21 to 1.5.22
- update CodeQL Action from 4.37.4 to 4.37.6

## Proof

- `npm outdated --json` → `{}`
- `actionlint` and `git diff --check`
- exact Docs Code CI commands: syntax checks, `npm test`, Wrangler dry-run, shell build/smoke, visual smoke
- `npm run docs:check`: 30,561 pages built; 15,659 pages indexed across 21 languages; full smoke and visual smoke passed
- live generated-site proof: homepage and nested page 200, Pagefind client 200, missing page 404; Mermaid rendered to an interactive SVG figure in Chromium
- autoreview: clean, no accepted/actionable findings
