### PR TITLE
fix(docs-site): fit expanded mobile section list

### DIFF
--- a/scripts/docs-site/assets.mjs
+++ b/scripts/docs-site/assets.mjs
@@ -87,7 +87,7 @@ ${designSystemCss}
   .mobile-section-chevron{display:grid;place-items:center;color:var(--muted);transition:transform var(--oc-duration-fast) var(--oc-ease-out),color var(--oc-duration-fast) var(--oc-ease-out)}
   .mobile-section-switcher[open] .mobile-section-chevron{transform:rotate(180deg);color:var(--brand)}
   .mobile-tabs{display:none}
-  .mobile-section-switcher[open] .mobile-tabs{display:grid;gap:2px;max-height:min(56vh,500px);margin:8px 0 0;padding:6px;overflow:auto;overscroll-behavior:contain;border:1px solid var(--line-strong);border-radius:var(--oc-radius-control);background:color-mix(in srgb,var(--paper) 88%,var(--bg) 12%);box-shadow:var(--oc-shadow-md)}
+  .mobile-section-switcher[open] .mobile-tabs{display:grid;gap:2px;max-height:min(56vh,520px);margin:8px 0 0;padding:6px;overflow:auto;overscroll-behavior:contain;border:1px solid var(--line-strong);border-radius:var(--oc-radius-control);background:color-mix(in srgb,var(--paper) 88%,var(--bg) 12%);box-shadow:var(--oc-shadow-md)}
   .mobile-tab-link{display:flex;align-items:center;min-width:0;min-height:40px;padding:9px 10px;border-radius:var(--oc-radius-control);color:var(--text);font:650 var(--oc-font-size-sm)/1.3 var(--oc-font-body);overflow-wrap:anywhere;transition:background var(--oc-duration-fast) var(--oc-ease-out),color var(--oc-duration-fast) var(--oc-ease-out)}
   .mobile-tab-link:hover,.mobile-tab-link:focus-visible{background:var(--paper-2);color:var(--ink);outline:0}
   .mobile-tab-link.active{background:var(--soft);color:var(--brand)}

--- a/scripts/docs-site/visual-smoke.mjs
+++ b/scripts/docs-site/visual-smoke.mjs
@@ -551,6 +551,21 @@ async function checkMobile() {
   if (!mobileCardColumns.length || mobileCardColumns.some((columns) => columns !== 1)) {
     throw new Error(`mobile card grids should collapse to one column: ${JSON.stringify(mobileCardColumns)}`);
   }
+  await page.evaluate(() => {
+    for (const selector of [".tabs", ".mobile-tabs"]) {
+      const container = document.querySelector(selector);
+      const links = [...container?.querySelectorAll("a") ?? []];
+      if (links.some((link) => link.textContent?.trim() === "Release & CI")) continue;
+      const help = links.find((link) => link.textContent?.trim() === "Help");
+      const release = help?.cloneNode();
+      if (!help || !(release instanceof HTMLAnchorElement)) throw new Error(`missing ${selector} Help fixture`);
+      release.href = "/releases";
+      release.textContent = "Release & CI";
+      release.removeAttribute("aria-current");
+      release.classList.remove("active");
+      help.before(release);
+    }
+  });
   await page.click("[data-nav-toggle]");
   await page.locator(".sidebar.open").waitFor({ state: "visible" });
   await page.waitForFunction(() => Math.abs(document.querySelector(".sidebar")?.getBoundingClientRect().left ?? -999) < 1);
@@ -605,6 +620,7 @@ async function checkMobile() {
       open: document.querySelector(".mobile-section-switcher")?.hasAttribute("open"),
       mobileTabCount: links.length,
       desktopTabCount: document.querySelectorAll(".tab-link").length,
+      labels: links.map((link) => link.textContent?.trim()),
       activeCount: document.querySelectorAll('.mobile-tab-link[aria-current="location"]').length,
       linksVisible: rects.every((rect) => rect.width > 0 && rect.height > 0),
       linksInViewport: rects.every((rect) => rect.left >= 0 && rect.right <= innerWidth),
@@ -612,13 +628,34 @@ async function checkMobile() {
     };
   });
   if (!sections.open
+    || sections.mobileTabCount !== 12
     || sections.mobileTabCount !== sections.desktopTabCount
+    || sections.labels.slice(-4).join("|") !== "Gateway & Ops|Reference|Release & CI|Help"
     || sections.activeCount !== 1
     || !sections.linksVisible
     || !sections.linksInViewport
     || !sections.lastLinkVisible) {
     throw new Error(`mobile docs section switcher failed: ${JSON.stringify(sections)}`);
   }
+  await page.setViewportSize({ width: 390, height: 700 });
+  const shortViewport = await page.evaluate(() => {
+    const container = document.querySelector(".mobile-tabs");
+    return {
+      clientHeight: container?.clientHeight ?? 0,
+      scrollHeight: container?.scrollHeight ?? 0,
+    };
+  });
+  if (shortViewport.scrollHeight <= shortViewport.clientHeight) {
+    throw new Error(`short mobile section switcher should remain scrollable: ${JSON.stringify(shortViewport)}`);
+  }
+  await page.locator(".mobile-tab-link").last().scrollIntoViewIfNeeded();
+  const lastLinkReachable = await page.evaluate(() => {
+    const container = document.querySelector(".mobile-tabs")?.getBoundingClientRect();
+    const lastLink = [...document.querySelectorAll(".mobile-tab-link")].at(-1)?.getBoundingClientRect();
+    return Boolean(container && lastLink && lastLink.top >= container.top - 1 && lastLink.bottom <= container.bottom + 1);
+  });
+  if (!lastLinkReachable) throw new Error("short mobile section switcher did not expose its final link");
+  await page.setViewportSize({ width: 390, height: 980 });
   await page.keyboard.press("Escape");
   const closed = await page.evaluate(() => ({
     bodyOpen: document.body.classList.contains("nav-open"),


### PR DESCRIPTION
## What Problem This Solves

The proposed 12-section docs navigation in [openclaw/openclaw#119802](https://github.com/openclaw/openclaw/pull/119802) needs 514 px for the complete mobile section list at 390×980. The existing 500 px ceiling leaves a 498 px scroll viewport, so the final **Help** row is not fully visible before scrolling.

This is the renderer-side companion to [openclaw/openclaw#119769](https://github.com/openclaw/openclaw/issues/119769).

## Why This Change Was Made

This PR proposes raising only the mobile switcher's hard ceiling from 500 px to 520 px while retaining the existing `56vh` limit. The 12-section list would fit without scrolling at 390×980, while shorter viewports would remain bounded and scrollable.

The visual smoke fixture now exercises the exact final order:

`Gateway & Ops → Reference → Release & CI → Help`

It accepts both the 11-section pre-sync mirror and the real 12-section configuration after the source navigation lands.

## User Impact

On standard narrow screens, readers would see every top-level docs section through **Help** when they open the section switcher. On shorter screens, the same list would remain scrollable and its final item reachable.

## Scope

- one CSS ceiling adjustment in the docs shell
- focused 12-section coverage at 390×980
- focused short-viewport scroll coverage at 390×700
- no docs content, navigation source, localization source, or deployment workflow changes

## Evidence

Validated at final head `66d56587232ce8cf6ab5d6244403a7509ca32906`:

- `npm test` — 4 tests passed
- `make docs-check` — passed; 30,561 pages built, 577/577 page cards, 777 search entries, 15,659 Pagefind pages across 21 languages, full smoke passed
- `npm run docs:visual` — passed; exact 12-section list visible at 390×980, desktop suite unchanged, shorter viewport remained scrollable with **Help** reachable
- `find scripts .openclaw-sync -name '*.mjs' -print0 | xargs -0 -n 1 node --check` — passed
- `npx wrangler@4.119.0 deploy --dry-run --config wrangler.toml` — passed
- `git diff --check origin/main...HEAD` — passed
- final advisory diff review — no actionable findings

## Automation and Localization Impact

The source-to-mirror sync, locale navigation composition, translation planning, R2 classification, and deploy paths are unchanged. The source navigation PR remains responsible for the English navigation and its curated zh-Hans label overlay; this companion changes only how the existing mobile list is sized and tested.

## Limitations

This PR does not add or reorder navigation sections. The proposed `Release & CI` section remains owned by [openclaw/openclaw#119802](https://github.com/openclaw/openclaw/pull/119802).
