### PR TITLE
docs: use the preview build for visual proof

### DIFF
--- a/scripts/docs-site/AGENTS.md
+++ b/scripts/docs-site/AGENTS.md
@@ -6,6 +6,7 @@ Scope: docs shell generator, hidden visual fixtures, local smoke checks, and R2 
 - Keep authored docs under `docs/**` out of this subtree. Use virtual fixtures or generator code here when testing shell UI.
 - The hidden component fixture is generated at `/__elements`; keep it `noindex` and out of `sitemap.xml` and `llms.txt`.
 - Run `make docs-check` after renderer, shell CSS, visual fixture, asset, or smoke changes.
-- Use `make docs-elements` to build and smoke the hidden fixture, then `make docs-serve` plus `make docs-elements-open` for visual review.
+- For visual proof, run `DOCS_SITE_PREVIEW_INCLUDE_FIXTURE=1 npm run docs:build:preview`; do not rebuild the full locale corpus just to capture screenshots.
+- After the preview build, use `make docs-serve` plus `make docs-elements-open` for visual review.
 - Add smoke coverage in `scripts/docs-site/smoke.mjs` for any new visual contract that would be annoying to catch by eye later.
 - Keep R2 uploads diff-friendly: no generated timestamp churn, randomized output, or broad rewrites unless the source docs changed.


### PR DESCRIPTION
## Summary

- direct visual-proof builds to the 30-page English preview plus `/__elements`
- keep the full `make docs-check` gate separate from screenshot iteration
- update the visual-review command sequence accordingly

## Why

Capturing renderer screenshots does not require rebuilding the full translated site or regenerating every per-page OG card. The preview path exercises the same shell assets and includes the hidden component fixture when `DOCS_SITE_PREVIEW_INCLUDE_FIXTURE=1` is set.

## Validation

- `git diff --check`