### PR TITLE
chore(deps): refresh docs tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mdx-js/mdx": "3.1.1",
         "@resvg/resvg-js": "^2.6.2",
         "highlight.js": "11.11.1",
-        "lucide": "1.28.0",
+        "lucide": "1.30.0",
         "markdown-it": "15.0.0",
         "markdown-it-anchor": "9.2.1",
         "mermaid": "11.16.1",
@@ -1649,9 +1649,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -2105,9 +2105,9 @@
       }
     },
     "node_modules/lucide": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/lucide/-/lucide-1.28.0.tgz",
-      "integrity": "sha512-sxVxWEXfq7rRNzmffDBRohYBOFjfoOhrO7jGGCLNNRoY2fPjeuqi2boXR2UAROEyQUm+xe13DGOQNtnmwv6Y3w==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-1.30.0.tgz",
+      "integrity": "sha512-K6fsjKaZmzrvDATXHpKdRRNresG/z5/RnGK6OPJRoZ5Pu4A/OOJRFM/BlGpDsUeRZl12Hj3ULmXqz1qObs6x3A==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@mdx-js/mdx": "3.1.1",
     "@resvg/resvg-js": "^2.6.2",
     "highlight.js": "11.11.1",
-    "lucide": "1.28.0",
+    "lucide": "1.30.0",
     "markdown-it": "15.0.0",
     "markdown-it-anchor": "9.2.1",
     "mermaid": "11.16.1",


### PR DESCRIPTION
## Summary

- update the exact Lucide tooling pin from 1.28.0 to 1.30.0
- refresh Mermaid's allowed DOMPurify resolution from 3.4.12 to 3.4.13, fixing GHSA-55q2-fjhq-7xh7

## Verification

- `npm test` — 4 tests passed
- `npm run docs:check` — 30,562 pages built; 15,660 pages indexed across 21 languages; routing, smoke, and visual checks passed
- `npm audit --json` — zero vulnerabilities
- `npm outdated --json` — no remaining updates
- source-blind local HTTP validation returned 200 for English, gateway, locale, and Pagefind routes
- Codex autoreview — clean, no accepted/actionable findings

No mirrored or generated docs source was edited.
