### PR TITLE
chore(deps): bump lucide to 1.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mdx-js/mdx": "3.1.1",
         "@resvg/resvg-js": "^2.6.2",
         "highlight.js": "11.11.1",
-        "lucide": "1.30.0",
+        "lucide": "1.31.0",
         "markdown-it": "15.0.0",
         "markdown-it-anchor": "9.2.1",
         "mermaid": "11.16.1",
@@ -2105,9 +2105,9 @@
       }
     },
     "node_modules/lucide": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/lucide/-/lucide-1.30.0.tgz",
-      "integrity": "sha512-K6fsjKaZmzrvDATXHpKdRRNresG/z5/RnGK6OPJRoZ5Pu4A/OOJRFM/BlGpDsUeRZl12Hj3ULmXqz1qObs6x3A==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-1.31.0.tgz",
+      "integrity": "sha512-iPJC7py8o990ZSmvFZlS+4+bNasP+ANDkD0IeDOGgQZjTm3p85F2Ldut7leM1yhYavr1pmoPfigm9MDHyyCOrw==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@mdx-js/mdx": "3.1.1",
     "@resvg/resvg-js": "^2.6.2",
     "highlight.js": "11.11.1",
-    "lucide": "1.30.0",
+    "lucide": "1.31.0",
     "markdown-it": "15.0.0",
     "markdown-it-anchor": "9.2.1",
     "mermaid": "11.16.1",


### PR DESCRIPTION
## Summary

- bump the docs renderer's pinned `lucide` dependency from 1.30.0 to 1.31.0
- refresh the npm lockfile resolution and integrity hash

## Verification

- `npm outdated --json` → `{}`
- `npm test` → 4 tests passed
- `npm run docs:check` → 30,564 pages built; 15,662 pages indexed across 21 languages; smoke and visual checks passed
- `make docs-serve`, then fetched `/`, `/install/`, and `/pagefind/pagefind.js` successfully; served HTML contained rendered Lucide SVG classes
- `.agents/skills/autoreview/scripts/autoreview --mode local` → clean, no accepted/actionable findings
