### PR TITLE
fix: allow docs cache prefix purge

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      purge_urls:
+        description: "JSON array of exact HTTPS docs URLs to purge from Cloudflare cache."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   actions: write
@@ -65,6 +70,14 @@ jobs:
             --tag "${GITHUB_SHA::12}" \
             --message "openclaw/docs ${GITHUB_SHA}"
 
+      - name: Purge exact docs URLs
+        if: github.event_name == 'workflow_dispatch' && inputs.purge_urls != ''
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_PURGE_URLS: ${{ inputs.purge_urls }}
+          CLOUDFLARE_ZONE_NAME: openclaw.ai
+        run: node scripts/docs-site/cloudflare-purge.mjs
+
       - name: Cut over docs hostnames
         if: github.event_name == 'workflow_dispatch' && inputs.cutover_docs_hosts == true
         env:
@@ -72,7 +85,7 @@ jobs:
         run: node scripts/cloudflare-cutover-docs-hosts.mjs
 
       - name: Dispatch live smoke
-        if: github.event_name == 'workflow_dispatch' && (inputs.deploy_worker == true || inputs.cutover_docs_hosts == true)
+        if: github.event_name == 'workflow_dispatch' && (inputs.deploy_worker == true || inputs.cutover_docs_hosts == true || inputs.purge_urls != '')
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run docs-live-smoke.yml --ref main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,8 +22,8 @@ on:
         required: false
         type: boolean
         default: false
-      purge_urls:
-        description: "JSON array of exact HTTPS docs URLs to purge from Cloudflare cache."
+      purge_prefixes:
+        description: "JSON array of HTTPS docs URL prefixes to purge from Cloudflare cache."
         required: false
         type: string
         default: ""
@@ -70,11 +70,11 @@ jobs:
             --tag "${GITHUB_SHA::12}" \
             --message "openclaw/docs ${GITHUB_SHA}"
 
-      - name: Purge exact docs URLs
-        if: github.event_name == 'workflow_dispatch' && inputs.purge_urls != ''
+      - name: Purge docs URL prefixes
+        if: github.event_name == 'workflow_dispatch' && inputs.purge_prefixes != ''
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_PURGE_URLS: ${{ inputs.purge_urls }}
+          CLOUDFLARE_PURGE_PREFIXES: ${{ inputs.purge_prefixes }}
           CLOUDFLARE_ZONE_NAME: openclaw.ai
         run: node scripts/docs-site/cloudflare-purge.mjs
 
@@ -85,7 +85,7 @@ jobs:
         run: node scripts/cloudflare-cutover-docs-hosts.mjs
 
       - name: Dispatch live smoke
-        if: github.event_name == 'workflow_dispatch' && (inputs.deploy_worker == true || inputs.cutover_docs_hosts == true || inputs.purge_urls != '')
+        if: github.event_name == 'workflow_dispatch' && (inputs.deploy_worker == true || inputs.cutover_docs_hosts == true || inputs.purge_prefixes != '')
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run docs-live-smoke.yml --ref main

--- a/CLOUDFLARE.md
+++ b/CLOUDFLARE.md
@@ -64,6 +64,7 @@ Required Cloudflare API token scopes for bucket/domain/DNS setup:
 - `Account: Workers Scripts: Edit`
 - `Zone: DNS: Edit`
 - `Zone: Cache Rules: Edit` or `Zone: Rulesets: Edit`
+- `Zone: Cache Purge`
 - `Zone: Zone Settings: Edit`
 - `Zone: Read`
 
@@ -100,6 +101,17 @@ Production router deploy:
 2. Pushes validate the Worker bundle with `wrangler deploy --dry-run`.
 3. Manual dispatch with `deploy_worker=true` runs `npx wrangler@4.118.0 deploy --config wrangler.toml`.
 4. `docs-live-smoke.yml`
+
+Purge one or more exact stale docs URLs through the protected Cloudflare environment:
+
+```sh
+gh workflow run pages.yml --repo openclaw/docs --ref main \
+  -f deploy_worker=false \
+  -f cutover_docs_hosts=false \
+  -f purge_urls='["https://docs.openclaw.ai/releases/2026.8.1","https://docs.openclaw.ai/releases/2026.8.1/"]'
+```
+
+The purge input accepts at most 30 credential-free HTTPS URLs under `openclaw.ai`. It does not purge the zone broadly or change Worker routes.
 
 Local R2 build:
 

--- a/CLOUDFLARE.md
+++ b/CLOUDFLARE.md
@@ -102,16 +102,16 @@ Production router deploy:
 3. Manual dispatch with `deploy_worker=true` runs `npx wrangler@4.118.0 deploy --config wrangler.toml`.
 4. `docs-live-smoke.yml`
 
-Purge one or more exact stale docs URLs through the protected Cloudflare environment:
+Purge one or more stale docs URL prefixes through the protected Cloudflare environment. Prefix purge reaches the custom Cache API keys created by the Worker router:
 
 ```sh
 gh workflow run pages.yml --repo openclaw/docs --ref main \
   -f deploy_worker=false \
   -f cutover_docs_hosts=false \
-  -f purge_urls='["https://docs.openclaw.ai/releases/2026.8.1","https://docs.openclaw.ai/releases/2026.8.1/"]'
+  -f purge_prefixes='["https://docs.openclaw.ai/releases/2026.8.1"]'
 ```
 
-The purge input accepts at most 30 credential-free HTTPS URLs under `openclaw.ai`. It does not purge the zone broadly or change Worker routes.
+The purge input accepts at most 30 credential-free HTTPS URL prefixes under `openclaw.ai`, rejects hostname-wide prefixes, and strips the scheme before calling Cloudflare's prefix-purge API. It does not purge the zone broadly or change Worker routes.
 
 Local R2 build:
 

--- a/scripts/docs-site/cloudflare-purge.mjs
+++ b/scripts/docs-site/cloudflare-purge.mjs
@@ -4,37 +4,42 @@ import { fileURLToPath } from "node:url";
 
 const cloudflareApi = "https://api.cloudflare.com/client/v4";
 
-export function parsePurgeUrls(raw, zoneName) {
+export function parsePurgePrefixes(raw, zoneName) {
   let values;
   try {
     values = JSON.parse(raw);
   } catch (error) {
-    throw new Error(`CLOUDFLARE_PURGE_URLS must be a JSON array: ${error.message}`);
+    throw new Error(`CLOUDFLARE_PURGE_PREFIXES must be a JSON array: ${error.message}`);
   }
   if (!Array.isArray(values) || values.length === 0 || values.length > 30) {
-    throw new Error("CLOUDFLARE_PURGE_URLS must contain 1 to 30 URLs");
+    throw new Error("CLOUDFLARE_PURGE_PREFIXES must contain 1 to 30 URLs");
   }
-  const urls = [];
+  const prefixes = [];
   const seen = new Set();
   for (const value of values) {
-    if (typeof value !== "string") throw new Error("Every purge target must be a URL string");
+    if (typeof value !== "string") throw new Error("Every purge prefix must be a URL string");
     const url = new URL(value);
-    if (url.protocol !== "https:" || url.username || url.password || url.hash) {
-      throw new Error(`Purge target must be a credential-free HTTPS URL without a fragment: ${value}`);
+    if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) {
+      throw new Error(
+        `Purge prefix must be a credential-free HTTPS URL without a query or fragment: ${value}`,
+      );
     }
     if (url.hostname !== zoneName && !url.hostname.endsWith(`.${zoneName}`)) {
       throw new Error(`Purge target must belong to ${zoneName}: ${value}`);
     }
-    const normalized = url.toString();
+    if (url.pathname === "/") {
+      throw new Error("Purge prefix must include a path and cannot target the whole hostname");
+    }
+    const normalized = `${url.hostname}${url.pathname}`;
     if (!seen.has(normalized)) {
       seen.add(normalized);
-      urls.push(normalized);
+      prefixes.push(normalized);
     }
   }
-  return urls;
+  return prefixes;
 }
 
-export async function purgeCloudflareUrls({ fetchImpl = fetch, token, urls, zoneName }) {
+export async function purgeCloudflarePrefixes({ fetchImpl = fetch, prefixes, token, zoneName }) {
   if (!token) throw new Error("CLOUDFLARE_API_TOKEN is required");
   if (!zoneName) throw new Error("CLOUDFLARE_ZONE_NAME is required");
   const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
@@ -45,11 +50,11 @@ export async function purgeCloudflareUrls({ fetchImpl = fetch, token, urls, zone
     throw new Error(`Expected exactly one active Cloudflare zone for ${zoneName}`);
   }
   await cloudflare(fetchImpl, `/zones/${zones.result[0].id}/purge_cache`, {
-    body: JSON.stringify({ files: urls }),
+    body: JSON.stringify({ prefixes }),
     headers,
     method: "POST",
   });
-  return { count: urls.length, zoneId: zones.result[0].id };
+  return { count: prefixes.length, zoneId: zones.result[0].id };
 }
 
 async function cloudflare(fetchImpl, apiPath, init) {
@@ -67,11 +72,14 @@ async function cloudflare(fetchImpl, apiPath, init) {
 const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isMain) {
   const zoneName = process.env.CLOUDFLARE_ZONE_NAME || "openclaw.ai";
-  const urls = parsePurgeUrls(process.env.CLOUDFLARE_PURGE_URLS || "", zoneName);
-  const result = await purgeCloudflareUrls({
+  const prefixes = parsePurgePrefixes(
+    process.env.CLOUDFLARE_PURGE_PREFIXES || "",
+    zoneName,
+  );
+  const result = await purgeCloudflarePrefixes({
+    prefixes,
     token: process.env.CLOUDFLARE_API_TOKEN,
-    urls,
     zoneName,
   });
-  console.log(`purged ${result.count} exact URL(s) from ${zoneName}`);
+  console.log(`purged ${result.count} URL prefix(es) from ${zoneName}`);
 }

--- a/scripts/docs-site/cloudflare-purge.mjs
+++ b/scripts/docs-site/cloudflare-purge.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const cloudflareApi = "https://api.cloudflare.com/client/v4";
+
+export function parsePurgeUrls(raw, zoneName) {
+  let values;
+  try {
+    values = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`CLOUDFLARE_PURGE_URLS must be a JSON array: ${error.message}`);
+  }
+  if (!Array.isArray(values) || values.length === 0 || values.length > 30) {
+    throw new Error("CLOUDFLARE_PURGE_URLS must contain 1 to 30 URLs");
+  }
+  const urls = [];
+  const seen = new Set();
+  for (const value of values) {
+    if (typeof value !== "string") throw new Error("Every purge target must be a URL string");
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password || url.hash) {
+      throw new Error(`Purge target must be a credential-free HTTPS URL without a fragment: ${value}`);
+    }
+    if (url.hostname !== zoneName && !url.hostname.endsWith(`.${zoneName}`)) {
+      throw new Error(`Purge target must belong to ${zoneName}: ${value}`);
+    }
+    const normalized = url.toString();
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      urls.push(normalized);
+    }
+  }
+  return urls;
+}
+
+export async function purgeCloudflareUrls({ fetchImpl = fetch, token, urls, zoneName }) {
+  if (!token) throw new Error("CLOUDFLARE_API_TOKEN is required");
+  if (!zoneName) throw new Error("CLOUDFLARE_ZONE_NAME is required");
+  const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+  const zones = await cloudflare(fetchImpl, `/zones?name=${encodeURIComponent(zoneName)}&status=active`, {
+    headers,
+  });
+  if (!Array.isArray(zones.result) || zones.result.length !== 1 || !zones.result[0]?.id) {
+    throw new Error(`Expected exactly one active Cloudflare zone for ${zoneName}`);
+  }
+  await cloudflare(fetchImpl, `/zones/${zones.result[0].id}/purge_cache`, {
+    body: JSON.stringify({ files: urls }),
+    headers,
+    method: "POST",
+  });
+  return { count: urls.length, zoneId: zones.result[0].id };
+}
+
+async function cloudflare(fetchImpl, apiPath, init) {
+  const response = await fetchImpl(`${cloudflareApi}${apiPath}`, init);
+  const data = await response.json().catch(() => undefined);
+  if (!response.ok || !data?.success) {
+    const errors = Array.isArray(data?.errors)
+      ? data.errors.map((error) => error?.message).filter(Boolean).join("; ")
+      : "";
+    throw new Error(`Cloudflare API ${response.status}${errors ? `: ${errors}` : ""}`);
+  }
+  return data;
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const zoneName = process.env.CLOUDFLARE_ZONE_NAME || "openclaw.ai";
+  const urls = parsePurgeUrls(process.env.CLOUDFLARE_PURGE_URLS || "", zoneName);
+  const result = await purgeCloudflareUrls({
+    token: process.env.CLOUDFLARE_API_TOKEN,
+    urls,
+    zoneName,
+  });
+  console.log(`purged ${result.count} exact URL(s) from ${zoneName}`);
+}

--- a/scripts/docs-site/cloudflare-purge.test.mjs
+++ b/scripts/docs-site/cloudflare-purge.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { parse } from "yaml";
+import { parsePurgeUrls, purgeCloudflareUrls } from "./cloudflare-purge.mjs";
+
+test("accepts exact HTTPS URLs inside the configured zone", () => {
+  assert.deepEqual(
+    parsePurgeUrls(
+      JSON.stringify([
+        "https://docs.openclaw.ai/releases/2026.8.1",
+        "https://docs.openclaw.ai/releases/2026.8.1/",
+        "https://docs.openclaw.ai/releases/2026.8.1",
+      ]),
+      "openclaw.ai",
+    ),
+    [
+      "https://docs.openclaw.ai/releases/2026.8.1",
+      "https://docs.openclaw.ai/releases/2026.8.1/",
+    ],
+  );
+});
+
+for (const value of [
+  "http://docs.openclaw.ai/releases/2026.8.1",
+  "https://example.com/releases/2026.8.1",
+  "https://user@example.openclaw.ai/release",
+  "https://docs.openclaw.ai/release#fragment",
+]) {
+  test(`rejects unsafe purge target ${value}`, () => {
+    assert.throws(() => parsePurgeUrls(JSON.stringify([value]), "openclaw.ai"));
+  });
+}
+
+test("resolves the zone and purges only the supplied URLs", async () => {
+  const requests = [];
+  const urls = ["https://docs.openclaw.ai/releases/2026.8.1"];
+  const fetchImpl = async (url, init) => {
+    requests.push({ url, init });
+    if (url.includes("/zones?")) {
+      return jsonResponse({ success: true, result: [{ id: "zone-id" }] });
+    }
+    return jsonResponse({ success: true, result: { id: "purge-id" } });
+  };
+
+  assert.deepEqual(
+    await purgeCloudflareUrls({ fetchImpl, token: "secret", urls, zoneName: "openclaw.ai" }),
+    { count: 1, zoneId: "zone-id" },
+  );
+  assert.equal(requests.length, 2);
+  assert.match(requests[0].url, /\/zones\?name=openclaw\.ai&status=active$/u);
+  assert.match(requests[1].url, /\/zones\/zone-id\/purge_cache$/u);
+  assert.equal(requests[1].init.method, "POST");
+  assert.deepEqual(JSON.parse(requests[1].init.body), { files: urls });
+});
+
+test("Pages workflow exposes the protected exact-URL purge", () => {
+  const workflow = parse(
+    fs.readFileSync(new URL("../../.github/workflows/pages.yml", import.meta.url), "utf8"),
+  );
+  const dispatch = (workflow.on ?? workflow[true]).workflow_dispatch;
+  assert.equal(dispatch.inputs.purge_urls.type, "string");
+  const purge = workflow.jobs.worker.steps.find((step) => step.name === "Purge exact docs URLs");
+  assert.equal(purge.env.CLOUDFLARE_API_TOKEN, "${{ secrets.CLOUDFLARE_API_TOKEN }}");
+  assert.equal(purge.run, "node scripts/docs-site/cloudflare-purge.mjs");
+});
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    headers: { "Content-Type": "application/json" },
+    status,
+  });
+}

--- a/scripts/docs-site/cloudflare-purge.test.mjs
+++ b/scripts/docs-site/cloudflare-purge.test.mjs
@@ -2,22 +2,18 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
 import { parse } from "yaml";
-import { parsePurgeUrls, purgeCloudflareUrls } from "./cloudflare-purge.mjs";
+import { parsePurgePrefixes, purgeCloudflarePrefixes } from "./cloudflare-purge.mjs";
 
-test("accepts exact HTTPS URLs inside the configured zone", () => {
+test("normalizes HTTPS URLs into Cloudflare purge prefixes", () => {
   assert.deepEqual(
-    parsePurgeUrls(
+    parsePurgePrefixes(
       JSON.stringify([
         "https://docs.openclaw.ai/releases/2026.8.1",
-        "https://docs.openclaw.ai/releases/2026.8.1/",
         "https://docs.openclaw.ai/releases/2026.8.1",
       ]),
       "openclaw.ai",
     ),
-    [
-      "https://docs.openclaw.ai/releases/2026.8.1",
-      "https://docs.openclaw.ai/releases/2026.8.1/",
-    ],
+    ["docs.openclaw.ai/releases/2026.8.1"],
   );
 });
 
@@ -25,16 +21,18 @@ for (const value of [
   "http://docs.openclaw.ai/releases/2026.8.1",
   "https://example.com/releases/2026.8.1",
   "https://user@example.openclaw.ai/release",
+  "https://docs.openclaw.ai/",
+  "https://docs.openclaw.ai/release?variant=old",
   "https://docs.openclaw.ai/release#fragment",
 ]) {
   test(`rejects unsafe purge target ${value}`, () => {
-    assert.throws(() => parsePurgeUrls(JSON.stringify([value]), "openclaw.ai"));
+    assert.throws(() => parsePurgePrefixes(JSON.stringify([value]), "openclaw.ai"));
   });
 }
 
-test("resolves the zone and purges only the supplied URLs", async () => {
+test("resolves the zone and purges only the supplied prefixes", async () => {
   const requests = [];
-  const urls = ["https://docs.openclaw.ai/releases/2026.8.1"];
+  const prefixes = ["docs.openclaw.ai/releases/2026.8.1"];
   const fetchImpl = async (url, init) => {
     requests.push({ url, init });
     if (url.includes("/zones?")) {
@@ -44,23 +42,28 @@ test("resolves the zone and purges only the supplied URLs", async () => {
   };
 
   assert.deepEqual(
-    await purgeCloudflareUrls({ fetchImpl, token: "secret", urls, zoneName: "openclaw.ai" }),
+    await purgeCloudflarePrefixes({
+      fetchImpl,
+      prefixes,
+      token: "secret",
+      zoneName: "openclaw.ai",
+    }),
     { count: 1, zoneId: "zone-id" },
   );
   assert.equal(requests.length, 2);
   assert.match(requests[0].url, /\/zones\?name=openclaw\.ai&status=active$/u);
   assert.match(requests[1].url, /\/zones\/zone-id\/purge_cache$/u);
   assert.equal(requests[1].init.method, "POST");
-  assert.deepEqual(JSON.parse(requests[1].init.body), { files: urls });
+  assert.deepEqual(JSON.parse(requests[1].init.body), { prefixes });
 });
 
-test("Pages workflow exposes the protected exact-URL purge", () => {
+test("Pages workflow exposes the protected prefix purge", () => {
   const workflow = parse(
     fs.readFileSync(new URL("../../.github/workflows/pages.yml", import.meta.url), "utf8"),
   );
   const dispatch = (workflow.on ?? workflow[true]).workflow_dispatch;
-  assert.equal(dispatch.inputs.purge_urls.type, "string");
-  const purge = workflow.jobs.worker.steps.find((step) => step.name === "Purge exact docs URLs");
+  assert.equal(dispatch.inputs.purge_prefixes.type, "string");
+  const purge = workflow.jobs.worker.steps.find((step) => step.name === "Purge docs URL prefixes");
   assert.equal(purge.env.CLOUDFLARE_API_TOKEN, "${{ secrets.CLOUDFLARE_API_TOKEN }}");
   assert.equal(purge.run, "node scripts/docs-site/cloudflare-purge.mjs");
 });

--- a/scripts/docs-site/visual-smoke.mjs
+++ b/scripts/docs-site/visual-smoke.mjs
@@ -647,7 +647,7 @@ async function checkMobile() {
     throw new Error(`mobile menu did not close on Escape: ${JSON.stringify(closed)}`);
   }
   await page.goto(`${base}/channels/discord`, { waitUntil: "networkidle" });
-  await page.screenshot({ path: path.join(artifacts, "discord-mobile-dark.png"), fullPage: true });
+  await page.screenshot({ path: path.join(artifacts, "discord-mobile-dark.png"), fullPage: false });
   const discordOverflow = await page.evaluate(() => {
     const viewport = innerWidth;
     const longCode = [...document.querySelectorAll(".doc code")]


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an updated R2 docs object can remain hidden behind a stale Cloudflare cache entry at its canonical URL. The v2026.8.1 Markdown endpoint and cache-busted HTML returned the current 16,304-source page, while the normal HTML URL continued returning the older 10,500-source version.

## Why This Change Was Made

Adds a protected `purge_prefixes` input to the existing Pages workflow. It accepts only a JSON array of 1–30 credential-free HTTPS URL prefixes inside `openclaw.ai`, rejects hostname-wide targets, resolves the active zone with the repository’s existing Cloudflare secret, and calls Cloudflare’s prefix-purge API. Prefix purge reaches every Worker Cache API key beneath the page path, including the router’s hidden minute-suffixed variants. It cannot purge the whole zone or change Worker routes.

## User Impact

Maintainers can invalidate a stale docs route and its custom Worker cache keys through audited GitHub Actions without requiring personal dashboard access or broadly flushing unrelated documentation.

## Evidence

- Live stale-cache reproduction
  - canonical URL returned `X-OpenClaw-Docs-Cache: HIT`, old SHA-256 metadata, and the older page
  - the same URL with a new query parameter returned `MISS`, current SHA-256 metadata, and the current page
- Cloudflare’s current cache-key documentation states that URL purge cannot clear Cache API entries whose custom key was set by a Worker, while purge by prefix reaches all cache entries beneath the path.
- `npm test` — 57/57 tests passed
- `make docs-check`
  - full 30,574-page build passed
  - R2 preparation produced 85,593 objects
  - full routing and docs smoke checks passed
- Focused tests cover prefix normalization, URL validation, zone containment, hostname-wide/query/credential/fragment rejection, deduplication, Cloudflare API requests, and workflow wiring.
- The mobile visual screenshot is now viewport-sized because its overflow assertions inspect the viewport; three consecutive local visual runs pass, avoiding the repeated CI timeout caused by capturing the entire Discord guide.
