### PR TITLE
fix: keep docs publishing during steady updates

### DIFF
--- a/.github/workflows/r2-pages.yml
+++ b/.github/workflows/r2-pages.yml
@@ -158,8 +158,27 @@ jobs:
           echo "content_sha=${content_sha}" >> "${GITHUB_OUTPUT}"
           echo "Scoped docs content refreshed from main ${content_sha}."
 
+      # Admit once while holding the deployment queue, before expensive work.
+      # Catch-up after publication schedules missing successors without a veto.
+      - name: Check current docs main
+        if: steps.artifact-scope.outputs.scope != 'none' || steps.artifact-scope.outputs.deploy_worker == '1'
+        id: current-main
+        env:
+          SCOPED_CONTENT_SHA: ${{ steps.scoped-content.outputs.content_sha || '' }}
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          SMOKE_COMMIT_RANGE: ${{ inputs.smoke_commit_range || '' }}
+        run: node scripts/docs-site/head-drift.mjs admit
+
+      - name: Fail stale scoped translation deploy
+        if: github.event_name == 'workflow_dispatch' && steps.current-main.outputs.stale == 'true' && (steps.artifact-scope.outputs.scope == 'locale' || steps.artifact-scope.outputs.scope == 'page')
+        run: |
+          echo "Scoped translation content went stale before build admission; retry this dispatch against latest main." >&2
+          exit 1
+
       - name: Read source metadata
-        if: steps.artifact-scope.outputs.scope == 'full' || steps.artifact-scope.outputs.scope == 'locale' || steps.artifact-scope.outputs.scope == 'page'
+        if: steps.current-main.outputs.stale == 'false' && (steps.artifact-scope.outputs.scope == 'full' || steps.artifact-scope.outputs.scope == 'locale' || steps.artifact-scope.outputs.scope == 'page')
         id: source-meta
         run: |
           node - <<'NODE'
@@ -171,7 +190,7 @@ jobs:
           NODE
 
       - name: Check out OpenClaw source
-        if: steps.artifact-scope.outputs.scope == 'full' || steps.artifact-scope.outputs.scope == 'locale' || steps.artifact-scope.outputs.scope == 'page'
+        if: steps.current-main.outputs.stale == 'false' && (steps.artifact-scope.outputs.scope == 'full' || steps.artifact-scope.outputs.scope == 'locale' || steps.artifact-scope.outputs.scope == 'page')
         uses: actions/checkout@v7.0.1
         with:
           repository: ${{ steps.source-meta.outputs.repository }}
@@ -180,22 +199,22 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Node
-        if: steps.artifact-scope.outputs.scope != 'none' || steps.artifact-scope.outputs.deploy_worker == '1'
+        if: steps.current-main.outputs.stale == 'false' && (steps.artifact-scope.outputs.scope != 'none' || steps.artifact-scope.outputs.deploy_worker == '1')
         uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
 
       - name: Install
-        if: steps.artifact-scope.outputs.scope != 'none' || steps.artifact-scope.outputs.deploy_worker == '1'
+        if: steps.current-main.outputs.stale == 'false' && (steps.artifact-scope.outputs.scope != 'none' || steps.artifact-scope.outputs.deploy_worker == '1')
         run: npm ci
 
       - name: Install librsvg2-bin
-        if: steps.artifact-scope.outputs.scope != 'none'
+        if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
         run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
 
       - name: Build R2 artifact
-        if: steps.artifact-scope.outputs.scope != 'none'
+        if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
         env:
           DOCS_SOURCE_REPO_DIR: source
           DOCS_SOURCE_REPO_URL: https://github.com/${{ steps.source-meta.outputs.repository }}
@@ -208,7 +227,7 @@ jobs:
           fi
 
       - name: Smoke generated site
-        if: steps.artifact-scope.outputs.scope != 'none'
+        if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
         run: |
           if [ "${{ steps.artifact-scope.outputs.scope }}" = "shell" ]; then
             npm run docs:smoke:shell
@@ -216,76 +235,8 @@ jobs:
             npm run docs:smoke
           fi
 
-      - name: Check current docs main
-        if: steps.artifact-scope.outputs.scope != 'none' || steps.artifact-scope.outputs.deploy_worker == '1'
-        id: current-main
-        env:
-          SCOPED_CONTENT_SHA: ${{ steps.scoped-content.outputs.content_sha || '' }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          git fetch --quiet origin main
-          latest="$(git rev-parse refs/remotes/origin/main)"
-          echo "latest=${latest}" >> "${GITHUB_OUTPUT}"
-          expected="${SCOPED_CONTENT_SHA:-${GITHUB_SHA}}"
-          if [ "${expected}" = "${latest}" ]; then
-            echo "stale=false" >> "${GITHUB_OUTPUT}"
-            echo "dispatch=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-          # Never infer a successor run from changed paths: skip-ci annotations,
-          # GITHUB_TOKEN pushes (i18n finalizer), and >300-file filter truncation
-          # all skip push runs. Verify against the Actions API; dispatch when absent.
-          verdict="$(git diff --name-only "${expected}" "${latest}" | node scripts/docs-site/head-drift.mjs)"
-          if [ "${verdict}" = "artifact-unaffected" ]; then
-            echo "stale=false" >> "${GITHUB_OUTPUT}"
-            echo "dispatch=false" >> "${GITHUB_OUTPUT}"
-            echo "::notice::Docs main moved to ${latest} without artifact-relevant changes; continuing upload for ${expected}."
-          elif [ "${verdict}" = "artifact-affected" ]; then
-            echo "stale=true" >> "${GITHUB_OUTPUT}"
-            successor_runs="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/r2-pages.yml/runs?head_sha=${latest}&per_page=1" --jq '.total_count' || echo '')"
-            if [ "${successor_runs}" != "" ] && [ "${successor_runs}" -gt 0 ]; then
-              echo "dispatch=false" >> "${GITHUB_OUTPUT}"
-              echo "::notice::Docs main moved to ${latest}; yielding the R2 upload for ${expected} to its existing run."
-            else
-              echo "dispatch=true" >> "${GITHUB_OUTPUT}"
-              echo "::notice::Docs main moved to ${latest} with no run of its own; dispatching a fresh full run."
-            fi
-          else
-            echo "Unexpected head-drift verdict: ${verdict}" >&2
-            exit 1
-          fi
-
-      - name: Dispatch run for successorless head
-        if: steps.current-main.outputs.dispatch == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          BEFORE_SHA: ${{ github.event.before || '' }}
-          SMOKE_COMMIT_RANGE: ${{ inputs.smoke_commit_range || '' }}
-          LATEST_SHA: ${{ steps.current-main.outputs.latest }}
-        run: |
-          set -euo pipefail
-          base=""
-          if [[ "${EVENT_NAME}" == "push" && "${BEFORE_SHA}" =~ ^[0-9a-f]{7,40}$ && ! "${BEFORE_SHA}" =~ ^0+$ ]]; then
-            base="${BEFORE_SHA}"
-          elif [ -n "${SMOKE_COMMIT_RANGE}" ]; then
-            base="${SMOKE_COMMIT_RANGE%%..*}"
-          fi
-          range=""
-          if [ -n "${base}" ]; then
-            range="${base}..${LATEST_SHA}"
-          fi
-          gh workflow run r2-pages.yml --ref main -f artifact_scope=full -f request_id="head-drift-${GITHUB_RUN_ID}" -f smoke_commit_range="${range}"
-
-      - name: Fail stale scoped translation deploy
-        if: github.event_name == 'workflow_dispatch' && steps.current-main.outputs.stale == 'true' && (steps.artifact-scope.outputs.scope == 'locale' || steps.artifact-scope.outputs.scope == 'page')
-        run: |
-          echo "Scoped translation content went stale before upload; retry this dispatch against latest main." >&2
-          exit 1
-
       - name: Resolve R2 credentials
-        if: steps.artifact-scope.outputs.scope != 'none' && steps.current-main.outputs.stale != 'true'
+        if: steps.artifact-scope.outputs.scope != 'none' && steps.current-main.outputs.stale == 'false'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -388,7 +339,7 @@ jobs:
 
       - name: Upload changed R2 objects
         id: upload-r2
-        if: steps.artifact-scope.outputs.scope != 'none' && steps.current-main.outputs.stale != 'true'
+        if: steps.artifact-scope.outputs.scope != 'none' && steps.current-main.outputs.stale == 'false'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_R2_BUCKET: openclaw-docs
@@ -403,6 +354,7 @@ jobs:
         run: npm run docs:r2:upload
 
       - name: Deploy Worker before live smoke
+        id: deploy-worker
         if: steps.artifact-scope.outputs.deploy_worker == '1' && steps.current-main.outputs.stale == 'false'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -429,3 +381,13 @@ jobs:
             range="${SMOKE_COMMIT_RANGE}"
           fi
           gh workflow run docs-live-smoke.yml --ref main -f commit_range="${range}"
+
+      - name: Catch up docs main after publication
+        if: ${{ !cancelled() && steps.current-main.outputs.stale == 'false' && (steps.upload-r2.outcome == 'success' || steps.deploy-worker.outcome == 'success') && (steps.artifact-scope.outputs.deploy_worker != '1' || steps.deploy-worker.outcome == 'success') }}
+        env:
+          SCOPED_CONTENT_SHA: ${{ steps.scoped-content.outputs.content_sha || '' }}
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          SMOKE_COMMIT_RANGE: ${{ inputs.smoke_commit_range || '' }}
+        run: node scripts/docs-site/head-drift.mjs catch-up

--- a/CLOUDFLARE.md
+++ b/CLOUDFLARE.md
@@ -94,9 +94,13 @@ Production docs object deploy:
 3. `npm run docs:smoke`
 4. `npm run docs:r2:upload`
 
+The global `r2-pages` queue serializes admission, build, and publication. After scope classification and any page/locale content refresh from main, the workflow checks freshness before source checkout, dependency installation, and build. Artifact-relevant stale snapshots yield to an existing successor run or dispatch a full successor when none exists; stale scoped translation dispatches fail so callers retry. Artifact-unaffected drift is admitted. Once admitted, the job publishes that snapshot even if main advances during the build; there is no second freshness veto before upload. Page/locale dispatches retain their selected workflow code and existing partial-upload boundaries, using the refreshed docs and source metadata throughout the build.
+
+After successful R2 publication (or a Worker-only deployment), the same head/successor helper checks main again and dispatches a full successor for artifact-relevant drift with no verified run. This catches changes whose push did not trigger R2, including `GITHUB_TOKEN` and skip-ci pushes during the build. API lookup failure biases to dispatch; dispatch failure fails the job without undoing publication. Catch-up also runs if live-smoke scheduling failed after publication. It never changes the admission verdict or gates the completed upload. This ordering applies to the automatic R2 queue without relying on FIFO ordering; manual Pages router deployment remains operator-owned outside that queue.
+
 Production router deploy:
 
-1. On a main push that changes `workers/**` or `wrangler.toml`, `r2-pages.yml` deploys the matching Worker after any required R2 upload, provided that snapshot has not been superseded.
+1. On a main push that changes `workers/**` or `wrangler.toml`, `r2-pages.yml` deploys the matching Worker after any required R2 upload, provided that snapshot passed admission before the build.
 2. `pages.yml` pushes validate the Worker bundle with `wrangler deploy --dry-run`; they do not deploy it.
 3. Manual `pages.yml` dispatch with `deploy_worker=true` deploys the router using the workflow's pinned Wrangler version. Leave `cutover_docs_hosts=false` for an ordinary router update.
 4. Successful deployments dispatch `docs-live-smoke.yml`. Verify the actual upload and Worker deployment steps, not just a green workflow that skipped a stale snapshot. If a docs-only successor uploads the artifact without deploying the changed Worker, use the manual router dispatch.

--- a/scripts/docs-site/head-drift.mjs
+++ b/scripts/docs-site/head-drift.mjs
@@ -1,5 +1,5 @@
-// Classify only whether drift can change the built artifact or deployed worker.
-// The workflow verifies run existence against the Actions API, never paths.
+// Own admission and post-publication catch-up for the serialized R2 workflow.
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
@@ -44,6 +44,57 @@ export function classifyHeadDrift(changedPaths) {
   return "artifact-affected";
 }
 
+function command(program, ...args) {
+  return execFileSync(program, args, {
+    encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], maxBuffer: 8 * 1024 * 1024,
+  });
+}
+
+function checkHead(phase) {
+  if (!["admit", "catch-up"].includes(phase) || process.argv.length !== 3) {
+    throw new Error("Usage: node scripts/docs-site/head-drift.mjs <admit|catch-up>");
+  }
+  const expected = process.env.SCOPED_CONTENT_SHA || process.env.GITHUB_SHA;
+  if (!expected) throw new Error("Missing docs snapshot SHA");
+  command("git", "fetch", "--quiet", "origin", "main");
+  const latest = command("git", "rev-parse", "refs/remotes/origin/main").trim();
+  const stale = expected !== latest && classifyHeadDrift(
+    command("git", "diff", "--name-only", "-z", expected, latest).split("\0"),
+  ) === "artifact-affected";
+
+  if (stale) {
+    // Paths cannot prove a successor exists: skip-ci, GITHUB_TOKEN pushes and
+    // truncated push filters can suppress runs. API failure biases to dispatch.
+    let count = "";
+    try {
+      count = command("gh", "api", `repos/${process.env.GITHUB_REPOSITORY}/actions/workflows/r2-pages.yml/runs?head_sha=${latest}&per_page=1`, "--jq", ".total_count").trim();
+    } catch {
+      console.log("::warning::Could not verify successor runs; attempting a full successor dispatch.");
+    }
+    if (/^\d+$/.test(count) && Number(count) > 0) {
+      console.log(`::notice::Docs main moved to ${latest}; an R2 run already exists for that head.`);
+    } else {
+      const { EVENT_NAME, BEFORE_SHA = "", SMOKE_COMMIT_RANGE = "" } = process.env;
+      const base = EVENT_NAME === "push" && /^[0-9a-f]{7,40}$/.test(BEFORE_SHA) && !/^0+$/.test(BEFORE_SHA)
+        ? BEFORE_SHA : SMOKE_COMMIT_RANGE.split("..")[0];
+      command("gh", "workflow", "run", "r2-pages.yml", "--ref", "main",
+        "-f", "artifact_scope=full", "-f", `request_id=head-drift-${process.env.GITHUB_RUN_ID}`,
+        "-f", `smoke_commit_range=${base ? `${base}..${latest}` : ""}`);
+      console.log(`::notice::Dispatched a full R2 successor for docs main ${latest}.`);
+    }
+  } else if (expected !== latest) {
+    console.log(`::notice::Docs main moved to ${latest} without artifact-relevant changes from ${expected}.`);
+  }
+
+  // Catch-up can fail scheduling, but cannot revoke the published admission.
+  if (phase === "admit") fs.appendFileSync(process.env.GITHUB_OUTPUT, `stale=${stale}\n`);
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  process.stdout.write(`${classifyHeadDrift(fs.readFileSync(0, "utf8").split("\n"))}\n`);
+  try {
+    checkHead(process.argv[2]);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/docs-site/head-drift.test.mjs
+++ b/scripts/docs-site/head-drift.test.mjs
@@ -1,17 +1,207 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { runInNewContext } from "node:vm";
 import { parse } from "yaml";
 import { classifyHeadDrift, pushTriggerPaths } from "./head-drift.mjs";
 
 const script = fileURLToPath(new URL("./head-drift.mjs", import.meta.url));
+const workflow = parse(fs.readFileSync(new URL("../../.github/workflows/r2-pages.yml", import.meta.url), "utf8"));
+const steps = workflow.jobs.deploy.steps;
+
+function step(name) {
+  const found = steps.find((entry) => entry.name === name);
+  assert.ok(found, `missing workflow step: ${name}`);
+  return found;
+}
+
+function conditionMatches(name, scope, stale, deployWorker = "0", event = "push", { upload = "success", worker = "skipped", cancelled = false } = {}) {
+  const expression = step(name).if
+    .replace(/^\$\{\{(.*)\}\}$/s, "$1")
+    .replaceAll("steps.artifact-scope.outputs.scope", JSON.stringify(scope))
+    .replaceAll("steps.artifact-scope.outputs.deploy_worker", JSON.stringify(deployWorker))
+    .replaceAll("steps.current-main.outputs.stale", JSON.stringify(stale))
+    .replaceAll("steps.upload-r2.outcome", JSON.stringify(upload))
+    .replaceAll("steps.deploy-worker.outcome", JSON.stringify(worker))
+    .replaceAll("cancelled()", String(cancelled))
+    .replaceAll("github.event_name", JSON.stringify(event));
+  return runInNewContext(expression);
+}
+
+function gitFixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "docs-head-drift-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const remote = path.join(root, "remote.git");
+  const writer = path.join(root, "writer");
+  const checkout = path.join(root, "checkout");
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin);
+  const env = {
+    PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+    GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_AUTHOR_NAME: "Fixture", GIT_AUTHOR_EMAIL: "fixture@example.invalid",
+    GIT_COMMITTER_NAME: "Fixture", GIT_COMMITTER_EMAIL: "fixture@example.invalid",
+    GITHUB_REPOSITORY: "fixture/docs", GITHUB_RUN_ID: "123", EVENT_NAME: "push",
+  };
+  const git = (cwd, ...args) => execFileSync("git", args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  git(root, "init", "--bare", "--initial-branch=main", remote);
+  git(root, "init", "--initial-branch=main", writer);
+  git(writer, "remote", "add", "origin", remote);
+  fs.mkdirSync(path.join(writer, ".openclaw-sync"));
+  fs.writeFileSync(path.join(writer, ".openclaw-sync/source.json"), JSON.stringify({ repository: "fixture/source", sha: "source-a" }));
+  const statePath = path.join(root, "gh-state.json");
+  const callsPath = path.join(root, "gh-calls.jsonl");
+  const state = { latest: "", count: "0", apiFailure: false, dispatchFailure: false };
+  const saveState = () => fs.writeFileSync(statePath, JSON.stringify(state));
+  fs.writeFileSync(callsPath, "");
+  fs.writeFileSync(path.join(bin, "gh"), `#!${process.execPath}
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8"));
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(callsPath)}, JSON.stringify(args) + "\\n");
+if (args[0] === "api") {
+  assert.deepEqual(args, ["api", "repos/fixture/docs/actions/workflows/r2-pages.yml/runs?head_sha=" + state.latest + "&per_page=1", "--jq", ".total_count"]);
+  if (state.apiFailure) { console.error("synthetic API failure"); process.exit(1); }
+  console.log(state.count);
+} else {
+  assert.deepEqual(args.slice(0, 7), ["workflow", "run", "r2-pages.yml", "--ref", "main", "-f", "artifact_scope=full"]);
+  if (state.dispatchFailure) { console.error("synthetic dispatch failure"); process.exit(1); }
+}
+`, { mode: 0o755 });
+  function advance(file = "docs/page.md", body = "B") {
+    fs.mkdirSync(path.dirname(path.join(writer, file)), { recursive: true });
+    fs.writeFileSync(path.join(writer, file), body);
+    git(writer, "add", ".");
+    git(writer, "commit", "-m", "fixture update [skip ci]");
+    git(writer, "push", "origin", "main");
+    state.latest = git(writer, "rev-parse", "HEAD");
+    saveState();
+    return state.latest;
+  }
+  const initial = advance("docs/page.md", "A");
+  git(root, "clone", "--quiet", remote, checkout);
+  fs.mkdirSync(path.join(checkout, "scripts/docs-site"), { recursive: true });
+  fs.copyFileSync(script, path.join(checkout, "scripts/docs-site/head-drift.mjs"));
+  let invocation = 0;
+  function runStep(name, overrides = {}) {
+    const output = path.join(root, `output-${invocation++}`);
+    fs.writeFileSync(output, "");
+    const result = spawnSync("bash", ["-e", "-o", "pipefail", "-c", step(name).run], {
+      cwd: checkout, encoding: "utf8", input: "",
+      env: { ...env, GITHUB_SHA: initial, BEFORE_SHA: initial, GITHUB_OUTPUT: output, ...overrides },
+    });
+    return { ...result, output: fs.readFileSync(output, "utf8") };
+  }
+  const calls = () => fs.readFileSync(callsPath, "utf8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+  return { initial, checkout, advance, runStep, calls, state, saveState, git };
+}
+
+test("a successorless docs push during an admitted build is scheduled after the snapshot publishes", (t) => {
+  const f = gitFixture(t);
+  const admitted = f.runStep("Check current docs main");
+  assert.equal(admitted.status, 0, admitted.stderr);
+  assert.match(admitted.output, /^stale=false$/m);
+  const latest = f.advance();
+  assert.deepEqual(f.calls(), [], "admission at current main must not dispatch");
+  assert.equal(conditionMatches("Upload changed R2 objects", "full", "false"), true);
+  const published = path.join(f.checkout, "published.txt");
+  fs.copyFileSync(path.join(f.checkout, "docs/page.md"), published);
+  const caughtUp = f.runStep("Catch up docs main after publication");
+  assert.equal(caughtUp.status, 0, caughtUp.stderr);
+  assert.equal(fs.readFileSync(published, "utf8"), "A");
+  assert.match(admitted.output, /^stale=false$/m);
+  assert.doesNotMatch(caughtUp.output, /stale=/);
+  assert.deepEqual(f.calls().at(-1), ["workflow", "run", "r2-pages.yml", "--ref", "main", "-f", "artifact_scope=full", "-f", "request_id=head-drift-123", "-f", `smoke_commit_range=${f.initial}..${latest}`]);
+});
+
+const sourceSteps = ["Read source metadata", "Check out OpenClaw source"];
+const setupSteps = ["Set up Node", "Install"];
+const artifactSteps = ["Install librsvg2-bin", "Build R2 artifact", "Smoke generated site", "Resolve R2 credentials", "Upload changed R2 objects"];
 
 test("push trigger paths stay in sync with the R2 Pages workflow", () => {
-  const workflow = new URL("../../.github/workflows/r2-pages.yml", import.meta.url);
-  const doc = parse(fs.readFileSync(workflow, "utf8"));
-  assert.deepEqual(pushTriggerPaths, (doc.on ?? doc[true]).push.paths);
+  assert.deepEqual(pushTriggerPaths, workflow.on.push.paths);
+});
+
+test("obsolete queued snapshots yield or fail before source checkout, setup, and build", () => {
+  const admission = ["Classify artifact scope", "Refresh scoped docs content from main", "Check current docs main", "Fail stale scoped translation deploy"];
+  for (const [index, name] of admission.entries()) {
+    if (index > 0) assert.ok(steps.indexOf(step(admission[index - 1])) < steps.indexOf(step(name)), `${admission[index - 1]} must precede ${name}`);
+  }
+  for (const name of [...sourceSteps, ...setupSteps, ...artifactSteps]) {
+    assert.ok(steps.indexOf(step(admission.at(-1))) < steps.indexOf(step(name)), `admission must finish before ${name}; stale queued snapshots must not consume build time`);
+  }
+});
+
+test("only admitted snapshots do expensive work or publish, including worker-only and skipped scopes", () => {
+  for (const scope of ["full", "shell", "locale", "page", "none"]) {
+    for (const stale of ["false", "true", ""]) {
+      for (const deployWorker of ["0", "1"]) {
+        const admitted = stale === "false";
+        for (const name of [...sourceSteps, ...setupSteps, ...artifactSteps, "Deploy Worker before live smoke"]) {
+          const ownsWork = sourceSteps.includes(name) ? ["full", "locale", "page"].includes(scope)
+            : setupSteps.includes(name) ? scope !== "none" || deployWorker === "1"
+            : name === "Deploy Worker before live smoke" ? deployWorker === "1" : scope !== "none";
+          assert.equal(conditionMatches(name, scope, stale, deployWorker), admitted && ownsWork, `${name}: scope=${scope}, stale=${JSON.stringify(stale)}, worker=${deployWorker}`);
+        }
+      }
+    }
+    for (const deployWorker of ["0", "1"]) {
+      assert.equal(conditionMatches("Check current docs main", scope, "", deployWorker), scope !== "none" || deployWorker === "1");
+    }
+  }
+});
+
+test("scoped dispatches admit refreshed main content and fail stale admission for caller retries", () => {
+  assert.equal(step("Check current docs main").env.SCOPED_CONTENT_SHA, "${{ steps.scoped-content.outputs.content_sha || '' }}");
+  assert.match(step("Refresh scoped docs content from main").run, /git checkout "\$\{content_sha\}" -- docs \.openclaw-sync\/source\.json/);
+  assert.deepEqual(step("Catch up docs main after publication").env, step("Check current docs main").env);
+  for (const event of ["push", "workflow_dispatch"]) {
+    for (const scope of ["full", "shell", "locale", "page", "none"]) {
+      const scopedDispatch = event === "workflow_dispatch" && ["locale", "page"].includes(scope);
+      assert.equal(conditionMatches("Refresh scoped docs content from main", scope, "", "0", event), scopedDispatch);
+      for (const stale of ["false", "true", ""]) {
+        assert.equal(conditionMatches("Fail stale scoped translation deploy", scope, stale, "0", event), scopedDispatch && stale === "true");
+      }
+    }
+  }
+});
+
+test("head checks bracket publication, with no late admission veto", () => {
+  assert.deepEqual(workflow.concurrency, { group: "r2-pages", queue: "max", "cancel-in-progress": false });
+  assert.equal(step("Check current docs main").run, "node scripts/docs-site/head-drift.mjs admit");
+  assert.equal(step("Catch up docs main after publication").run, "node scripts/docs-site/head-drift.mjs catch-up");
+  const publishing = steps.slice(steps.indexOf(step("Check current docs main")) + 1, steps.indexOf(step("Deploy Worker before live smoke")) + 1);
+  for (const entry of publishing) {
+    assert.doesNotMatch(entry.run || "", /git fetch[^\n]*\bmain\b|refs\/remotes\/origin\/main|head-drift\.mjs|stale=(?:true|false)/, `${entry.name} must use the admission verdict instead of rechecking main during publication`);
+  }
+  assert.ok(steps.indexOf(step("Upload changed R2 objects")) < steps.indexOf(step("Deploy Worker before live smoke")));
+  assert.ok(steps.indexOf(step("Deploy Worker before live smoke")) < steps.indexOf(step("Dispatch live smoke")));
+  assert.ok(steps.indexOf(step("Dispatch live smoke")) < steps.indexOf(step("Catch up docs main after publication")));
+});
+
+test("catch-up requires admitted publication, including unchanged uploads and Worker-only deployments", () => {
+  for (const scope of ["full", "shell", "locale", "page", "none"]) {
+    for (const stale of ["false", "true", ""]) {
+      for (const cancelled of [false, true]) {
+        for (const [deployWorker, upload, worker, published] of [
+          ["0", scope === "none" ? "skipped" : "success", "skipped", scope !== "none"],
+          ["1", scope === "none" ? "skipped" : "success", "success", true],
+          ["0", "failure", "skipped", false],
+          ["1", "success", "failure", false],
+          ["1", "skipped", "skipped", false],
+        ]) {
+          assert.equal(conditionMatches("Catch up docs main after publication", scope, stale, deployWorker, "push", { upload, worker, cancelled }), published && stale === "false" && !cancelled);
+        }
+      }
+    }
+  }
+  assert.equal(step("Deploy Worker before live smoke").id, "deploy-worker");
+  assert.notEqual(step("Catch up docs main after publication")["continue-on-error"], true);
 });
 
 const cases = [
@@ -39,12 +229,86 @@ for (const [paths, verdict] of cases) {
   });
 }
 
-for (const [input, verdict] of [
-  ["README.md\n", "artifact-unaffected"],
-  [".openclaw-sync/source.json\n", "artifact-affected"],
-  ["weird.txt\n", "artifact-affected"],
-]) {
-  test(`CLI prints ${verdict} with a trailing newline`, () => {
-    assert.equal(execFileSync(process.execPath, [script], { encoding: "utf8", input }), `${verdict}\n`);
+for (const [count, apiFailure, dispatches] of [["0", false, 1], ["1", false, 0], ["", true, 1], ["invalid", false, 1]]) {
+  test(`both head checks preserve successor lookup: count=${JSON.stringify(count)}, API failure=${apiFailure}`, (t) => {
+    const f = gitFixture(t);
+    f.advance();
+    Object.assign(f.state, { count, apiFailure });
+    f.saveState();
+    for (const name of ["Check current docs main", "Catch up docs main after publication"]) {
+      const before = f.calls().length;
+      const result = f.runStep(name);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(f.calls().slice(before).filter((call) => call[0] === "workflow").length, dispatches);
+      if (name === "Check current docs main") assert.match(result.output, /^stale=true$/m);
+      else assert.doesNotMatch(result.output, /stale=/);
+      if (apiFailure) assert.match(result.stdout, /Could not verify successor/);
+    }
   });
 }
+
+test("artifact-unaffected drift and refreshed scoped identity do not schedule unnecessary successors", (t) => {
+  const f = gitFixture(t);
+  const scoped = f.advance();
+  const refreshed = f.runStep("Refresh scoped docs content from main");
+  assert.equal(refreshed.status, 0, refreshed.stderr);
+  const contentSha = refreshed.output.match(/^content_sha=(.+)$/m)?.[1];
+  assert.equal(contentSha, scoped);
+  assert.equal(f.git(f.checkout, "rev-parse", "HEAD"), f.initial, "workflow code stays on its selected ref");
+  assert.equal(fs.readFileSync(path.join(f.checkout, "docs/page.md"), "utf8"), "B");
+  const overrides = { EVENT_NAME: "workflow_dispatch", SCOPED_CONTENT_SHA: contentSha };
+  const admitted = f.runStep("Check current docs main", overrides);
+  assert.equal(admitted.status, 0, admitted.stderr);
+  assert.match(admitted.output, /^stale=false$/m);
+  f.advance("README.md", "unrelated update");
+  for (const name of ["Check current docs main", "Catch up docs main after publication"]) {
+    const result = f.runStep(name, overrides);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /without artifact-relevant changes/);
+  }
+  assert.deepEqual(f.calls(), []);
+});
+
+test("successor dispatch retains manual smoke base and leaves absent or zero push bases empty", (t) => {
+  const f = gitFixture(t);
+  const latest = f.advance();
+  for (const [overrides, base] of [
+    [{ EVENT_NAME: "workflow_dispatch", SMOKE_COMMIT_RANGE: `${f.initial}..${f.initial}` }, f.initial],
+    [{ EVENT_NAME: "workflow_dispatch" }, ""],
+    [{ BEFORE_SHA: "0".repeat(40) }, ""],
+  ]) {
+    const result = f.runStep("Catch up docs main after publication", overrides);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(f.calls().at(-1).at(-1), `smoke_commit_range=${base ? `${base}..${latest}` : ""}`);
+  }
+});
+
+test("dispatch failure fails both phases without changing a completed publication or granting admission", (t) => {
+  const f = gitFixture(t);
+  const admitted = f.runStep("Check current docs main");
+  assert.equal(admitted.status, 0, admitted.stderr);
+  assert.match(admitted.output, /^stale=false$/m);
+  const published = path.join(f.checkout, "published.txt");
+  fs.copyFileSync(path.join(f.checkout, "docs/page.md"), published);
+  f.advance();
+  f.state.dispatchFailure = true;
+  f.saveState();
+  for (const name of ["Check current docs main", "Catch up docs main after publication"]) {
+    const result = f.runStep(name);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /synthetic dispatch failure/);
+    assert.equal(result.output, "");
+  }
+  assert.equal(fs.readFileSync(published, "utf8"), "A");
+});
+
+test("Git failure cannot grant admission or silently succeed at catch-up", (t) => {
+  const f = gitFixture(t);
+  f.git(f.checkout, "remote", "remove", "origin");
+  for (const name of ["Check current docs main", "Catch up docs main after publication"]) {
+    const result = f.runStep(name);
+    assert.notEqual(result.status, 0);
+    assert.equal(result.output, "");
+  }
+  assert.deepEqual(f.calls(), []);
+});


### PR DESCRIPTION
Related: https://github.com/openclaw/docs/pull/143 — successive discarded R2 builds delayed publication of the merged Markdown-alias repair until a quiet window.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where readers continue seeing old documentation or missing pages during steady source updates even though R2 Pages reports successful workflow runs. The full build takes roughly six minutes, source syncs arrive at a similar cadence, and several consecutive completed builds skipped publication.

## Why This Change Was Made

Use one head/successor owner at two boundaries: admit a snapshot under the serialized `r2-pages` queue before source checkout, installation and build; then check for missing successors after successful publication. Obsolete queued builds yield immediately, but an admitted coherent snapshot finishes even when main advances during its build. Post-publication catch-up schedules missed updates without revoking admission or vetoing the completed upload.

The existing artifact-relevance classification, successor lookup, scoped content identity and smoke-range/request-id context remain. Stale scoped dispatches fail early so callers retry. The former inline shell policy and internal stdin-classifier CLI are removed rather than retained as parallel paths. No permissions, concurrency, credentials, workflow inputs, dependencies, storage, Worker routing or uploader algorithm change.

## User Impact

Documentation publication can make forward progress while updates continue arriving. Changes made during a build through `GITHUB_TOKEN`, skip-ci pushes or truncated push filters still get a successor when no run exists. Operators verify actual upload and Worker deployment steps; a green skipped run is not deployment proof.

## Evidence

- Live pre-fix runs [33345324046](https://github.com/openclaw/docs/actions/runs/33345324046), [33345925980](https://github.com/openclaw/docs/actions/runs/33345925980) and [33346637948](https://github.com/openclaw/docs/actions/runs/33346637948) completed successfully but skipped both **Upload changed R2 objects** and **Deploy Worker before live smoke** after main advanced during their builds. Live aliases still lacked Markdown-target metadata. A later quiet window finally allowed [33347542672](https://github.com/openclaw/docs/actions/runs/33347542672) to upload; this PR removes the dependence on such a window.
- Independent early-admission regression against `9ec5f58a7f8e28fafd7dd94d224d4646fb99bc09`: failure because admission follows source preparation.
- The first draft exposed a connected regression: a successorless docs push during an admitted build would be missed. The boundary test failed after admitting A, advancing a real temporary Git remote to B and recording publication of the A fixture. The final owner schedules B afterward without modifying admission. Git operations are real; only the GitHub CLI boundary is faked, with its requests checked.
- Final `node --test scripts/docs-site/head-drift.test.mjs`: **31/31 passed**, including scope/worker-only/none gates, real Git refresh, scoped source identity, successor existence, API lookup failure, dispatch failure, smoke-range forwarding and Git failure. `npm test`: **87/87 passed**.
- Scoped publication caller tests: **11** mocked R2-dispatch tests plus **1** canary/batch gating test passed. These are not live deployment claims.
- `actionlint .github/workflows/r2-pages.yml`, `node --check scripts/docs-site/head-drift.mjs` and `git diff --check` passed.
- Fresh isolated Codex review of the complete final four-file patch: **scoped-clean at the configured P0 blocking threshold**. [Exact-head Docs Code CI](https://github.com/openclaw/docs/actions/runs/33348823384) and [CodeQL](https://github.com/openclaw/docs/actions/runs/33348823388) passed on `07ea4a3733e81219cc8cd22506d26c30d85be7ed`. The docs-code job covers script syntax, all helpers, Worker bundle, shell artifact, routing smoke and visual smoke. Live production proof passed after merge: [an obsolete queued run](https://github.com/openclaw/docs/actions/runs/33349227198) completed admission in one second and skipped the expensive build immediately. [An admitted full publication](https://github.com/openclaw/docs/actions/runs/33352330393) checked main at 02:59:05 UTC, built afterward, successfully uploaded at 03:04:05–03:04:12, and completed post-publication catch-up at 03:04:16. Both phases ran in their intended order without a late upload veto.

Commands:

```bash
node --test scripts/docs-site/head-drift.test.mjs
```

```bash
npm test
```

```bash
python3 -B .github/scripts/i18n/tests/test_i18n_scripts.py -k dispatch_r2_pages
```

```bash
python3 -B .github/scripts/i18n/tests/test_i18n_scripts.py I18NScriptTests.test_full_workflow_gates_batches_after_canary
```

```bash
actionlint .github/workflows/r2-pages.yml
```

Production/tooling: **+93/-80 (net +13)** after moving the existing decision/dispatch behavior into one shared owner. The remaining growth carries the necessary second catch-up boundary and explicit publication outcomes; duplicate shell policy and obsolete CLI behavior are deleted. Tests: **+275/-11 (net +264)**. Hosting guidance: **+5/-1 (net +4)**. No generated docs were hand-edited.

The automatic R2 safety boundary is one admitted snapshot per serialized workflow, not an assumption about FIFO ordering. [GitHub's concurrency contract](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) allows one active workflow in the group. Publishing every stale queued snapshot permits regression; refreshing during a build mixes snapshots; retaining a late veto preserves starvation; dropping post-publication catch-up loses successorless updates. Manual Pages router deployment remains operator-owned outside automatic R2 ordering. Existing successor lookup remains existence-based, and a docs-only successor still does not inherit a skipped Worker deployment.
