### PR TITLE
docs: add v2026.9.1 release notes

### DIFF
--- a/docs/releases/2026.9.1.md
+++ b/docs/releases/2026.9.1.md
@@ -1,0 +1,1309 @@
+---
+title: "v2026.9.1"
+summary: "Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and lower overhead for long conversations and large installations."
+description: "Detailed OpenClaw v2026.9.1 release notes covering setup, the Control UI, updates, messaging, memory, skills, native apps, models, automations, browser and computer use, plugins, security, performance, fixes, and maintainer changes."
+keywords:
+  - OpenClaw
+  - v2026.9.1
+  - release notes
+  - Mermaid
+  - Control UI
+  - Android
+---
+
+# v2026.9.1
+
+v2026.9.1 makes conversations feel more like the same OpenClaw across the browser and supported native apps. Mermaid diagrams now render directly in the Control UI, Android, iPhone, iPad, and Mac, Android gets a fuller chat and session experience, and updates do more to preserve working state or stop with a real recovery path before a known problem becomes a broken restart. Underneath that visible work is a broad pass over long conversations, large session lists, multi-agent installations, model routing, scheduled jobs, channel delivery, plugins, and memory repair, reducing the amount of repeated work without pretending every path or provider is identical.
+
+**Release scale:** 922 pull requests, 6 direct commits, and 241 contributors.
+
+
+## Installation and Onboarding
+
+Setup is more careful about where it writes and more useful when something goes wrong. Guided onboarding can verify custom and local providers again, Windows npm installs tolerate harmless warnings, and OpenClaw stops before credentials are written when the CLI and the running Gateway point at different state directories. On macOS, cancelled or failed AI setup stays visible and retryable instead of being mistaken for a Gateway failure.
+
+<AccordionGroup>
+
+<Accordion title="Setup that keeps the choices you made">
+
+The [installation](/install) and [guided setup](/start/wizard) paths now carry the selected model, provider, state directory, and shell environment through more of the real conditions people encounter. Quick fixes cover Windows command discovery, PowerShell downloads, completion paths with shell-sensitive characters, failed connect inputs, and clearer recovery when npm itself fails.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(llama-cpp): extract managed release archives safely ([#129035](https://github.com/openclaw/openclaw/pull/129035)). Thanks @pgondhi987.
+- fix(setup): keep verification detached until promotion ([#132477](https://github.com/openclaw/openclaw/pull/132477)).
+- feat(onboarding): quick-start lane opens the web dashboard from one prompt ([#134221](https://github.com/openclaw/openclaw/pull/134221)). Thanks @fuller-stack-dev.
+- fix(install): tolerate npm stderr warnings on Windows ([#134385](https://github.com/openclaw/openclaw/pull/134385)). Thanks @ly85206559.
+- fix(cli): detect CLI/gateway state-dir split-brain before credential writes ([#134403](https://github.com/openclaw/openclaw/pull/134403)). Thanks @obviyus.
+- fix(install): use basic parsing for MinGit downloads ([#134412](https://github.com/openclaw/openclaw/pull/134412)). Thanks @ly85206559.
+- fix(macos): show confirmed setup cancellation clearly ([#134654](https://github.com/openclaw/openclaw/pull/134654)).
+- fix: installer points users to an error log that no longer exists ([#134655](https://github.com/openclaw/openclaw/pull/134655)). Thanks @mohamedelrefaiy.
+- fix(onboarding): restore verified custom provider setup ([#134907](https://github.com/openclaw/openclaw/pull/134907)).
+- fix(docs): list connect in CLI command index ([#134917](https://github.com/openclaw/openclaw/pull/134917)). Thanks @qingminglong.
+- fix(cli): bound --target-file reads and preserve file on read errors ([#134957](https://github.com/openclaw/openclaw/pull/134957)). Thanks @xialonglee, @obviyus.
+- fix(macos): replace misleading AI setup progress ([#135041](https://github.com/openclaw/openclaw/pull/135041)).
+- fix(agents): resolve Windows bare commands through PATHEXT ([#135138](https://github.com/openclaw/openclaw/pull/135138)). Thanks @gaoanze888, @Vasanthdev2004.
+- fix(cli): preserve literal completion cache paths ([#136241](https://github.com/openclaw/openclaw/pull/136241)). Thanks @steipete.
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## The New Web UI
+
+The [Control UI](/web/control-ui) can now render completed Mermaid diagrams directly in a conversation, with the source, copy, and zoom controls beside the result. New Session and Chat start with less work, pending sends appear immediately, and the sidebar, settings, model picker, task cards, compaction markers, and long conversations hold their place more consistently across reconnects and large session lists.
+
+<AccordionGroup>
+
+<Accordion title="A clearer workspace for conversations and live work">
+
+Multi-agent work is easier to follow without views crossing agent boundaries, while Side chat, Home, dashboards, approvals, attachments, dictation, queued messages, and restarted cloud or device sessions provide clearer state and recovery. The smaller details matter too, from useful loading shapes and keyboard-safe menus to drafts that stay available after a failed start.
+
+One narrow accessibility caveat remains. The shorter pin and unpin label also serves as the icon button's accessible name, so assistive-technology users can lose the session-specific context that was previously repeated there.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(ui): stop retry loop when the chat file editor chunk fails to load ([#123220](https://github.com/openclaw/openclaw/pull/123220)). Thanks @wanyongstar.
+- fix(ui): attachment close tap misses on mobile ([#123893](https://github.com/openclaw/openclaw/pull/123893)).
+- fix(usage): preserve compressed archive source identity ([#131017](https://github.com/openclaw/openclaw/pull/131017)). Thanks @Alix-007, @emes.
+- fix(ui): make dashboard widgets fill mobile width ([#133814](https://github.com/openclaw/openclaw/pull/133814)). Thanks @MoerAI, @vyctorbrzezowski.
+- fix(ui): give the chat composer a stable accessible name ([#133829](https://github.com/openclaw/openclaw/pull/133829)). Thanks @aniruddhaadak80.
+- improve(ui): move sidebar controls into agent header ([#134365](https://github.com/openclaw/openclaw/pull/134365)). Thanks @vyctorbrzezowski.
+- fix(ui): retire interrupted runs from history ([#134457](https://github.com/openclaw/openclaw/pull/134457)). Thanks @RomneyDa.
+- UI: simplify Side chat clear action ([#134478](https://github.com/openclaw/openclaw/pull/134478)). Thanks @Patrick-Erichsen.
+- fix(ui): make tall task progress content scrollable ([#134517](https://github.com/openclaw/openclaw/pull/134517)). Thanks @VACInc, @cpgeek, @nybbs2003.
+- fix(ui): separate optionless free-text questions ([#134598](https://github.com/openclaw/openclaw/pull/134598)). Thanks @Patrick-Erichsen, @goslingmanagment.
+- fix(ui): session group action icons match Sessions toolbar ([#134631](https://github.com/openclaw/openclaw/pull/134631)). Thanks @Patrick-Erichsen.
+- improve: simplify session hovercard attribution ([#134636](https://github.com/openclaw/openclaw/pull/134636)). Thanks @Patrick-Erichsen.
+- fix(ui): stop pin tooltips repeating session titles ([#134651](https://github.com/openclaw/openclaw/pull/134651)). Thanks @Patrick-Erichsen.
+- fix(ui): delay microphone hover reveal ([#134653](https://github.com/openclaw/openclaw/pull/134653)). Thanks @Patrick-Erichsen.
+- fix(ui): align settings headers and Automations controls ([#134659](https://github.com/openclaw/openclaw/pull/134659)). Thanks @Patrick-Erichsen.
+- fix(ui): streamline the shared Agent picker ([#134680](https://github.com/openclaw/openclaw/pull/134680)). Thanks @Patrick-Erichsen.
+- fix(ui): replace settings loading text with skeletons ([#134684](https://github.com/openclaw/openclaw/pull/134684)). Thanks @Patrick-Erichsen.
+- fix: show WebChat reset denials without admin scope ([#134696](https://github.com/openclaw/openclaw/pull/134696)).
+- fix: keep dashboards and task rails on the selected agent ([#134714](https://github.com/openclaw/openclaw/pull/134714)). Thanks @ctbritt, @MertBasar0.
+- fix(ui): highlight inherited Full Access on initial load ([#134732](https://github.com/openclaw/openclaw/pull/134732)). Thanks @Patrick-Erichsen.
+- improve(ui): add space before session status icons ([#134764](https://github.com/openclaw/openclaw/pull/134764)). Thanks @Patrick-Erichsen.
+- fix(ui): pinned sessions show a filled neutral pin ([#134775](https://github.com/openclaw/openclaw/pull/134775)). Thanks @Patrick-Erichsen.
+- fix: restore Ask OpenClaw connections and preserve conversation recovery ([#134776](https://github.com/openclaw/openclaw/pull/134776)).
+- fix(ui): simplify pull request hovercard stats ([#134791](https://github.com/openclaw/openclaw/pull/134791)). Thanks @Patrick-Erichsen.
+- fix(ui): prevent overlapping text in collapsed user messages ([#134833](https://github.com/openclaw/openclaw/pull/134833)). Thanks @steipete.
+- fix(ui): reconcile commentary by run and item identity ([#134888](https://github.com/openclaw/openclaw/pull/134888)).
+- feat(ui): render Mermaid diagrams in chat ([#134913](https://github.com/openclaw/openclaw/pull/134913)).
+- fix(ui): keep reopened dropdowns dismissible ([#135006](https://github.com/openclaw/openclaw/pull/135006)). Thanks @vyctorbrzezowski.
+- fix(ui): remove duplicate OpenClaw shortcut from Inbox ([#135008](https://github.com/openclaw/openclaw/pull/135008)).
+- improve(ui): speed up session switching ([#135021](https://github.com/openclaw/openclaw/pull/135021)).
+- fix(ui): restore failed cloud sessions from Chat ([#135024](https://github.com/openclaw/openclaw/pull/135024)). Thanks @jalehman.
+- fix(ui): keep late dictation transcript after Stop ([#135109](https://github.com/openclaw/openclaw/pull/135109)). Thanks @obviyus, @jadabreu.
+- fix(agents): preserve failed-exec warnings on silent turns ([#135119](https://github.com/openclaw/openclaw/pull/135119)).
+- perf(ui): defer Settings English until needed ([#135131](https://github.com/openclaw/openclaw/pull/135131)). Thanks @steipete.
+- fix: usage peak error hours shift during daylight saving ([#135153](https://github.com/openclaw/openclaw/pull/135153)).
+- fix(gateway): keep attachment failure cards out of durable model history ([#135185](https://github.com/openclaw/openclaw/pull/135185)). Thanks @gaoanze888, @obviyus, @snls1994, @gordonzhy.
+- improve(ui): reduce session-switch sidebar work ([#135332](https://github.com/openclaw/openclaw/pull/135332)).
+- fix(ui): accept the next prompt immediately after send ([#135345](https://github.com/openclaw/openclaw/pull/135345)). Thanks @Takhoffman.
+- fix(webchat): restore replies to attachment-only assistant messages ([#135393](https://github.com/openclaw/openclaw/pull/135393)).
+- fix(gateway): retain terminal timeout reasons in sidebar ([#135466](https://github.com/openclaw/openclaw/pull/135466)). Thanks @steipete.
+- fix(ui): hide rewind while agent is working ([#135521](https://github.com/openclaw/openclaw/pull/135521)). Thanks @Patrick-Erichsen.
+- fix(ui): keep group titles on one marquee line ([#135523](https://github.com/openclaw/openclaw/pull/135523)). Thanks @Patrick-Erichsen.
+- fix: Recent Chats list has cleaner alignment and hover feedback ([#135524](https://github.com/openclaw/openclaw/pull/135524)). Thanks @Patrick-Erichsen.
+- fix(ui): simplify session context menu grouping ([#135526](https://github.com/openclaw/openclaw/pull/135526)). Thanks @vyctorbrzezowski.
+- fix(ui): group accent color with theme ([#135547](https://github.com/openclaw/openclaw/pull/135547)). Thanks @vyctorbrzezowski.
+- fix(ui): keep sidebar and chat fades off scrollbars ([#135564](https://github.com/openclaw/openclaw/pull/135564)). Thanks @vyctorbrzezowski.
+- fix(control-ui): replies appear above queued prompts during recovery ([#135568](https://github.com/openclaw/openclaw/pull/135568)).
+- improve(ui): speed up switching in large session lists ([#135574](https://github.com/openclaw/openclaw/pull/135574)).
+- fix(ui): explain trusted-proxy login failures ([#135584](https://github.com/openclaw/openclaw/pull/135584)).
+- fix(gateway): avoid stale Control UI 304 responses ([#135619](https://github.com/openclaw/openclaw/pull/135619)).
+- fix(ui): restore keyboard navigation after switching submenus ([#135629](https://github.com/openclaw/openclaw/pull/135629)).
+- fix(ui): label device workers correctly during startup ([#135681](https://github.com/openclaw/openclaw/pull/135681)).
+- fix(control-ui): reconcile hydrated assistant replies by identity ([#135715](https://github.com/openclaw/openclaw/pull/135715)). Thanks @starship863, @dustin-nowak.
+- refactor(ui): simplify transcript composition and placement ([#135738](https://github.com/openclaw/openclaw/pull/135738)).
+- fix(ui): display wildcard tool policies correctly ([#135786](https://github.com/openclaw/openclaw/pull/135786)). Thanks @steipete.
+- fix(ui): avoid false storage errors after removing queued input ([#135790](https://github.com/openclaw/openclaw/pull/135790)).
+- fix: remove redundant waiting receipt from accepted chat messages ([#135901](https://github.com/openclaw/openclaw/pull/135901)).
+- fix(ui): let task reviews fill the side panel ([#135926](https://github.com/openclaw/openclaw/pull/135926)). Thanks @obviyus, @asgeirtj.
+- fix(ui): restore compact output token counts ([#135951](https://github.com/openclaw/openclaw/pull/135951)).
+- fix(agents): show commentary progress before final reply validation ([#135954](https://github.com/openclaw/openclaw/pull/135954)). Thanks @JosephNatsu.
+- improve: give chat compaction a folding shimmer animation ([#135988](https://github.com/openclaw/openclaw/pull/135988)). Thanks @steipete.
+- fix: compact the Publish PR account control ([#136002](https://github.com/openclaw/openclaw/pull/136002)).
+- chore(ui): refresh control ui locales ([#136006](https://github.com/openclaw/openclaw/pull/136006)).
+- fix(ui): reduce startup work on New Session and Chat ([#136021](https://github.com/openclaw/openclaw/pull/136021)). Thanks @steipete.
+- fix(ui): limit sidebar catalog groups to five sessions ([#136040](https://github.com/openclaw/openclaw/pull/136040)). Thanks @fuller-stack-dev.
+- fix(ui): show new-session sends immediately under load ([#136069](https://github.com/openclaw/openclaw/pull/136069)).
+- fix(ui): keep sent images visible during history handoff ([#136072](https://github.com/openclaw/openclaw/pull/136072)). Thanks @steipete.
+- fix: show requester titles on projected approval cards ([#136091](https://github.com/openclaw/openclaw/pull/136091)).
+- refactor(ui): share one shimmer primitive across skeletons and text sweeps ([#136153](https://github.com/openclaw/openclaw/pull/136153)).
+- improve(ui): simplify model picker footer ([#136160](https://github.com/openclaw/openclaw/pull/136160)).
+- fix: keep compaction in one persistent transcript marker ([#136169](https://github.com/openclaw/openclaw/pull/136169)).
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Updates and Maintenance
+
+[Updates](/install/updating) now stop earlier when plugin consent, local memory readiness, or another repair must be handled first, and they preserve more of the configuration, credentials, plugins, workspaces, and agent settings already on the machine. When an interactive update fails, OpenClaw can hand the original, sanitized failure context to a configured coding agent for investigation without restarting into a state it already knows is broken.
+
+<AccordionGroup>
+
+<Accordion title="Updates that stop safely and help you recover">
+
+Doctor can repair more legacy session, workspace, credential, pairing, plugin, cron, and multi-agent state without overwriting newer work. Malformed scheduled jobs are quarantined with their identifiers and reasons, managed Tailscale upgrades recover their ordinary route, Windows agent-launched restarts survive the old process tree, and a second repair pass stays clean after the first one succeeds.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(doctor): converge empty legacy state roots ([#114678](https://github.com/openclaw/openclaw/pull/114678)). Thanks @harjothkhara, @obviyus, @xiaodongEdtech.
+- fix(snapshot): Windows backup fails when PowerShell 7 is installed ([#121618](https://github.com/openclaw/openclaw/pull/121618)). Thanks @fr-meyer.
+- fix(cron): refuse doctor store rewrites when another process committed after the snapshot ([#127999](https://github.com/openclaw/openclaw/pull/127999)). Thanks @yetval.
+- fix(gateway): recover startup under load ([#132186](https://github.com/openclaw/openclaw/pull/132186)). Thanks @galiniliev.
+- fix(doctor): reconcile incomplete Skill Workshop proposal migrations (#132862) ([#132917](https://github.com/openclaw/openclaw/pull/132917)). Thanks @xydt-juyaohui, @obviyus, @lakemike.
+- fix(state): make schema-17 session repair atomic ([#134272](https://github.com/openclaw/openclaw/pull/134272)). Thanks @RileyJJY, @obviyus, @abacha.
+- fix(cli): preserve user data in uninstall defaults ([#134299](https://github.com/openclaw/openclaw/pull/134299)). Thanks @PollyBot13, @kodi.
+- fix: prevent device pairing migration crash on contaminated records ([#134483](https://github.com/openclaw/openclaw/pull/134483)). Thanks @qdivan, @obviyus, @samson1357924.
+- fix(update): preserve configuration and hand failed upgrades to triage ([#134490](https://github.com/openclaw/openclaw/pull/134490)). Thanks @fuller-stack-dev.
+- fix(gateway): gateway stays offline after agent restart on Windows ([#134549](https://github.com/openclaw/openclaw/pull/134549)). Thanks @nerclid, @w1130150306.
+- fix: migrate identical session event replays ([#134568](https://github.com/openclaw/openclaw/pull/134568)). Thanks @shakkernerd.
+- fix: doctor --fix never completes when a reserved workspace attestation is empty ([#134641](https://github.com/openclaw/openclaw/pull/134641)). Thanks @leilei3167, @obviyus, @rosssaunders, @courtneyr-dev, @guarismo.
+- fix(doctor): finish MCP lint when SQLite is busy ([#134698](https://github.com/openclaw/openclaw/pull/134698)). Thanks @obviyus, @pfrederiksen.
+- fix(update): block restart when plugin readiness fails ([#134699](https://github.com/openclaw/openclaw/pull/134699)). Thanks @Patrick-Erichsen, @vyctorbrzezowski.
+- fix(cron): gateway startup fails on malformed legacy jobs ([#134704](https://github.com/openclaw/openclaw/pull/134704)). Thanks @obviyus, @Nielsh82.
+- fix(doctor): repair keyed multi-agent rosters without ownership ([#134706](https://github.com/openclaw/openclaw/pull/134706)). Thanks @Lendersmark.
+- fix: doctor preserves official plugin config before install ([#134717](https://github.com/openclaw/openclaw/pull/134717)). Thanks @obviyus, @abacha.
+- fix(doctor): report plugin version drift after upgrades ([#134719](https://github.com/openclaw/openclaw/pull/134719)). Thanks @Lendersmark, @oshunter.
+- fix(doctor): identify blocked workspace migration cleanup ([#134751](https://github.com/openclaw/openclaw/pull/134751)). Thanks @rosssaunders.
+- fix: persist doctor migrations for explicit agent rosters ([#134758](https://github.com/openclaw/openclaw/pull/134758)). Thanks @Lendersmark, @vdruts.
+- fix(doctor): leave legacy transcript checks to migration ([#134765](https://github.com/openclaw/openclaw/pull/134765)). Thanks @obviyus, @LiuwqGit, @sblindt, @ayaangazali.
+- fix(backup): reject a blank --every instead of substituting the 24h default ([#134799](https://github.com/openclaw/openclaw/pull/134799)). Thanks @marmar9615-cloud.
+- fix(doctor): detect shared auth migration by provenance ([#134808](https://github.com/openclaw/openclaw/pull/134808)). Thanks @fuller-stack-dev.
+- fix(gateway): run BOOT.md when a previous boot session exists ([#134831](https://github.com/openclaw/openclaw/pull/134831)). Thanks @miguelarios.
+- feat(update): enter built-in triage after failures ([#134865](https://github.com/openclaw/openclaw/pull/134865)).
+- fix(state): renew maintenance leases during synchronous work ([#134880](https://github.com/openclaw/openclaw/pull/134880)).
+- fix: preserve workspaces when upgrading legacy agent lists ([#134892](https://github.com/openclaw/openclaw/pull/134892)). Thanks @Lendersmark.
+- fix(doctor): report shared auth health without a default agent ([#134902](https://github.com/openclaw/openclaw/pull/134902)). Thanks @Lendersmark.
+- refactor(deps): remove Sharp dependency chains ([#134923](https://github.com/openclaw/openclaw/pull/134923)).
+- fix(auth): recover interrupted shared credential migrations ([#134952](https://github.com/openclaw/openclaw/pull/134952)). Thanks @steipete, @erameson.
+- fix(doctor): converge redundant shared auth relocation subsets ([#135096](https://github.com/openclaw/openclaw/pull/135096)). Thanks @jodok, @felixboenkost-droid.
+- fix: select Doctor readiness owners before loading health APIs ([#135161](https://github.com/openclaw/openclaw/pull/135161)).
+- fix(cli): reject empty gateway suspend wait values ([#135270](https://github.com/openclaw/openclaw/pull/135270)). Thanks @qingminglong.
+- docs: list database CLI in command index ([#135279](https://github.com/openclaw/openclaw/pull/135279)). Thanks @qingminglong.
+- docs(doctor): warn about explicit external repair paths ([#135312](https://github.com/openclaw/openclaw/pull/135312)). Thanks @vdruts.
+- fix(auth): recover credentials stranded by completed migrations ([#135346](https://github.com/openclaw/openclaw/pull/135346)). Thanks @steipete, @erameson.
+- fix(tailscale): recover managed ingress after upgrades ([#135394](https://github.com/openclaw/openclaw/pull/135394)). Thanks @jjjhenriksen, @Lendersmark.
+- fix(doctor): recover stale npm plugins during update repair ([#135451](https://github.com/openclaw/openclaw/pull/135451)). Thanks @steipete.
+- fix(doctor): reject incomplete exec approvals migration ([#135454](https://github.com/openclaw/openclaw/pull/135454)). Thanks @steipete.
+- fix(update): fail finalization on unresolved plugin consent ([#135460](https://github.com/openclaw/openclaw/pull/135460)). Thanks @steipete, @hannesrudolph, @xiaomijituan, @weirdo-world.
+- fix(config): preserve authored values and agents during Doctor repair ([#135671](https://github.com/openclaw/openclaw/pull/135671)). Thanks @fuller-stack-dev.
+- fix(update): hand agent-launched updates to managed helper ([#135701](https://github.com/openclaw/openclaw/pull/135701)). Thanks @steipete.
+- fix: allow degraded gateway startup for migration warnings ([#135713](https://github.com/openclaw/openclaw/pull/135713)). Thanks @Zak-Finance.
+- fix: harden release upgrade and installation boundaries ([#135736](https://github.com/openclaw/openclaw/pull/135736)).
+- fix(doctor): resolve stale workspace setup migration loops ([#135755](https://github.com/openclaw/openclaw/pull/135755)). Thanks @jjjhenriksen, @Deregtx, @guarismo.
+- fix(plugins): preserve external payloads during doctor repair ([#135791](https://github.com/openclaw/openclaw/pull/135791)). Thanks @hannesrudolph, @weirdo-world, @xiaomijituan.
+- fix(infra): name the operator fix when the tailscale sudo fallback fails ([#135825](https://github.com/openclaw/openclaw/pull/135825)). Thanks @pengzh1, @obviyus, @ezimerman.
+- fix(backup): exclude workspaces before traversal ([#135830](https://github.com/openclaw/openclaw/pull/135830)). Thanks @obviyus, @jarvismazz, @yubingjiaocn, @ericcaiwx-star, @ruel225.
+- fix(doctor): bind package repair diagnostics to installed roots ([#135834](https://github.com/openclaw/openclaw/pull/135834)).
+- fix(doctor): retire empty legacy exec approvals stubs ([#135981](https://github.com/openclaw/openclaw/pull/135981)). Thanks @Ma77h3hac83r.
+- fix(release): qualify 2026.9.1 archive installation ([`bdf508b8ad`](https://github.com/openclaw/openclaw/commit/bdf508b8ad7e02b06f4e944c29ef835ced2bef22)). Thanks @steipete.
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Messaging
+
+Messages and replies now keep more of the context, ownership, and delivery state people expect across [channels](/channels). Operators can approve or deny delegated configuration changes from supported channels and see the real result, older external channel plugins keep receiving inbound replies after a host update, and failed channels remain visible with a safe recovery hint instead of disappearing.
+
+<AccordionGroup>
+
+<Accordion title="Replies and approvals that reach the right conversation">
+
+Telegram, Slack, Discord, Matrix, LINE, Feishu and Lark, WhatsApp, Google Chat, Tlon, and iMessage each receive focused fixes for stalled queues, controls, previews, threads, Markdown, voice, acknowledgements, and restart recovery. Rejection paths answer before closing the connection, while quiet or cancelled work stays quiet instead of producing duplicate fallbacks or stale narration.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(doctor): report shadowed WhatsApp ack emoji ([#119501](https://github.com/openclaw/openclaw/pull/119501)). Thanks @harjothkhara, @obviyus, @abacha.
+- fix(signal): reject invalid UTF-8 in container REST JSON responses ([#121569](https://github.com/openclaw/openclaw/pull/121569)). Thanks @sunlit-deng.
+- fix(slack): avoid duplicate Enterprise thread lookups ([#121598](https://github.com/openclaw/openclaw/pull/121598)). Thanks @mikasa0818.
+- fix: Slack agent RPC messages use configured identity ([#122078](https://github.com/openclaw/openclaw/pull/122078)). Thanks @Iskam31.
+- fix(channels): release rejected webhook connections after answering them ([#126818](https://github.com/openclaw/openclaw/pull/126818)). Thanks @edenfunf, @obviyus.
+- fix(matrix): exclude code regions from spoiler collision predicate ([#128453](https://github.com/openclaw/openclaw/pull/128453)). Thanks @ruel225, @petergaultney.
+- fix(msteams): thread context is dropped when a channel reply has no replyToId ([#129345](https://github.com/openclaw/openclaw/pull/129345)). Thanks @amalysh.
+- fix(doctor): report lossy WhatsApp acknowledgement scope migration ([#129825](https://github.com/openclaw/openclaw/pull/129825)). Thanks @zhangguiping-xydt, @obviyus.
+- fix(line): preserve card content when media is unavailable ([#132571](https://github.com/openclaw/openclaw/pull/132571)). Thanks @edenfunf.
+- fix(slack): surface pre-dispatch message rejections ([#132723](https://github.com/openclaw/openclaw/pull/132723)). Thanks @zhangguiping-xydt, @Phillis, @ayaangazali.
+- fix(link-understanding): cancel preprocessing with reply lifetime ([#132883](https://github.com/openclaw/openclaw/pull/132883)). Thanks @SunnyShu0925, @steipete.
+- fix(matrix): deliver the controls an agent reply offers ([#133268](https://github.com/openclaw/openclaw/pull/133268)). Thanks @edenfunf, @ml12580.
+- fix(channels): scope HTTP routes to account lifetimes ([#133297](https://github.com/openclaw/openclaw/pull/133297)). Thanks @zhangguiping-xydt, @goffern.
+- fix(telegram): acknowledge durably queued callbacks promptly ([#133379](https://github.com/openclaw/openclaw/pull/133379)). Thanks @Paeddy87, @zhangguiping-xydt.
+- fix(outbound): a delivery mirrored into another session is silently dropped ([#134083](https://github.com/openclaw/openclaw/pull/134083)). Thanks @edenfunf, @VACInc, @abacha.
+- fix(imessage): sends keep failing with an opaque timeout after the private-API bridge dies ([#134572](https://github.com/openclaw/openclaw/pull/134572)). Thanks @omarshahine.
+- feat(gateway): deliver delegated system-agent config approvals to channels ([#134670](https://github.com/openclaw/openclaw/pull/134670)). Thanks @obviyus.
+- Keep quiet Slack previews on the latest preamble ([#134716](https://github.com/openclaw/openclaw/pull/134716)). Thanks @pash-openai.
+- fix(matrix): persist sync cache after schema upgrades ([#134742](https://github.com/openclaw/openclaw/pull/134742)). Thanks @w9n, @obviyus.
+- fix(slack): socket and relay startup fail on an unused signing secret ([#134827](https://github.com/openclaw/openclaw/pull/134827)).
+- fix: cancel narration requests when their turn ends ([#134839](https://github.com/openclaw/openclaw/pull/134839)).
+- fix(line): tell the agent it has the buttons LINE renders ([#134915](https://github.com/openclaw/openclaw/pull/134915)). Thanks @edenfunf.
+- fix(line): keep the words and options a quick-reply prompt leaves behind ([#134976](https://github.com/openclaw/openclaw/pull/134976)). Thanks @edenfunf.
+- fix(auto-reply): bound prompt segment scans at EOF ([#135070](https://github.com/openclaw/openclaw/pull/135070)).
+- fix(ai): make generated commentary segment identities unique per segment ([#135081](https://github.com/openclaw/openclaw/pull/135081)). Thanks @akagifreeez, @obviyus, @tomroberts78.
+- fix(channels): expose failed plugin accounts in status and health ([#135082](https://github.com/openclaw/openclaw/pull/135082)). Thanks @vguyon-dev, @0xCyda, @liemnhoang.
+- fix(auto-reply): refresh stale session dispatches ([#135154](https://github.com/openclaw/openclaw/pull/135154)). Thanks @brettdaman, @obviyus.
+- fix(plugin-sdk): run lifecycle-less prepared channel turns ([#135179](https://github.com/openclaw/openclaw/pull/135179)). Thanks @nissl24, @fridaylans2000-art, @obviyus, @jooey, @fufales, @itanyplus, @dtump, @XXlaoxxc, @desksk, @chengoak.
+- fix(tlon): preserve parser progress and unify outbound preparation ([#135181](https://github.com/openclaw/openclaw/pull/135181)).
+- fix(line): let a group mention reach the turn that answers it ([#135195](https://github.com/openclaw/openclaw/pull/135195)). Thanks @edenfunf.
+- fix(markdown): preserve task lists across chunk boundaries ([#135200](https://github.com/openclaw/openclaw/pull/135200)).
+- fix(line): give up a card LINE will refuse instead of losing the reply ([#135229](https://github.com/openclaw/openclaw/pull/135229)). Thanks @edenfunf.
+- fix(feishu): deliver the controls an agent reply offers ([#135255](https://github.com/openclaw/openclaw/pull/135255)). Thanks @edenfunf.
+- fix(link-understanding): parse complete markdown links ([#135341](https://github.com/openclaw/openclaw/pull/135341)). Thanks @teddytennant, @obviyus.
+- fix(routing): keep empty-id peers out of the peerless route cache slot ([#135351](https://github.com/openclaw/openclaw/pull/135351)). Thanks @teddytennant, @obviyus.
+- fix(discord): stop error replies after voice consult cancellation ([#135380](https://github.com/openclaw/openclaw/pull/135380)).
+- fix: apply Discord model picker choices without false failures ([#135382](https://github.com/openclaw/openclaw/pull/135382)). Thanks @Call44, @BoatAngle.
+- fix(discord): honor reply visibility for session-busy notices ([#135444](https://github.com/openclaw/openclaw/pull/135444)).
+- fix(message): resolve explicit channels through the scoped plugin registry ([#135831](https://github.com/openclaw/openclaw/pull/135831)). Thanks @ruel225, @obviyus, @TailsProwerWorks.
+- fix(discord): bound voice capture under one lifecycle owner ([#135870](https://github.com/openclaw/openclaw/pull/135870)). Thanks @LZY3538.
+- fix(codex): preserve inbound audio for automatic voice replies ([#135884](https://github.com/openclaw/openclaw/pull/135884)). Thanks @hyper-sdn.
+- fix(discord): preserve webhook reply limits and delivery outcomes ([#135963](https://github.com/openclaw/openclaw/pull/135963)).
+- Keep connected apps usable and Slack previews quiet ([#136092](https://github.com/openclaw/openclaw/pull/136092)). Thanks @pash-openai.
+- fix: Google Chat labeled links vanish when the label has a space ([#136151](https://github.com/openclaw/openclaw/pull/136151)). Thanks @ericcaiwx-star, @obviyus, @KimOckHyun.
+- fix(media): preserve literal Markdown and balanced image URLs ([#136228](https://github.com/openclaw/openclaw/pull/136228)).
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Memory
+
+[Memory](/concepts/memory) is easier to repair without sacrificing conversation history. Indexes can be reset and rebuilt without deleting sessions or transcripts, Doctor preserves each agent's retrieval paths and search choices through legacy upgrades, and replies remain available while a damaged legacy index is being repaired.
+
+<AccordionGroup>
+
+<Accordion title="Memory that can recover without forgetting the conversation">
+
+Clean one-shot searches no longer trigger needless reindexing, forced reindexes keep the prior published cache when the replacement fails, and stale locks can recover safely after process reuse. LanceDB capture survives compaction and shutdown more reliably, Active Memory tells the model when recall was skipped or unavailable, and custom compatible embedding providers can use saved API-key or bearer-token profiles.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(memory-lancedb): preserve capture progress through compaction ([#131329](https://github.com/openclaw/openclaw/pull/131329)). Thanks @hartmark.
+- fix(bedrock): reject malformed embedding response encoding ([#133716](https://github.com/openclaw/openclaw/pull/133716)). Thanks @RileyJJY.
+- fix(memory): recover automatic reindex after concurrent writes ([#134333](https://github.com/openclaw/openclaw/pull/134333)). Thanks @TheAngryPit, @obviyus.
+- fix(docker): install libgomp1 in the runtime image for managed llama.cpp ([#134532](https://github.com/openclaw/openclaw/pull/134532)). Thanks @chelsealong, @henrique-simoes.
+- fix(memory): resolve profile auth for compatible embeddings ([#134744](https://github.com/openclaw/openclaw/pull/134744)). Thanks @0x-Parzival.
+- fix(doctor): preserve per-agent memory search during upgrades ([#134760](https://github.com/openclaw/openclaw/pull/134760)). Thanks @obviyus, @vdruts.
+- fix(memory): skip non-regular workspace memory files instead of aborting the sync ([#135042](https://github.com/openclaw/openclaw/pull/135042)). Thanks @ruel225, @obviyus, @kiranvk-2011.
+- fix(memory-core): recover orphaned workspace locks after PID reuse ([#135051](https://github.com/openclaw/openclaw/pull/135051)). Thanks @pengzh1, @obviyus, @gru-10k.
+- fix(memory): keep replies responsive during legacy index repair ([#135062](https://github.com/openclaw/openclaw/pull/135062)). Thanks @LifeViwer.
+- fix(memory-core): keep deep consolidation working with explicit ownership ([#135166](https://github.com/openclaw/openclaw/pull/135166)). Thanks @zhangguiping-xydt, @obviyus, @giangthb.
+- fix(active-memory): surface recall outcomes to the model ([#135193](https://github.com/openclaw/openclaw/pull/135193)). Thanks @Alix-007, @obviyus, @wave-workflow.
+- fix: reduce memory retained by transcript scans and chat views ([#135326](https://github.com/openclaw/openclaw/pull/135326)).
+- fix(memory): prevent cache overflow during forced reindex publication ([#135373](https://github.com/openclaw/openclaw/pull/135373)). Thanks @AlexisBallo2.
+- fix: retain memory repair guidance when wiki search succeeds ([#135415](https://github.com/openclaw/openclaw/pull/135415)).
+- docs(memory): preserve session history during index recovery ([#135431](https://github.com/openclaw/openclaw/pull/135431)). Thanks @AlexisBallo2.
+- fix(memory): keep clean transient CLI search off the reindex path ([#135520](https://github.com/openclaw/openclaw/pull/135520)). Thanks @gaoanze888, @obviyus, @LifeViwer.
+- feat(memory): reset derived indexes without deleting sessions ([#135653](https://github.com/openclaw/openclaw/pull/135653)). Thanks @AlexisBallo2.
+- fix(memory): attribute index identity mismatches and preserve scan failure paths ([#135864](https://github.com/openclaw/openclaw/pull/135864)). Thanks @yetval, @obviyus, @CjTruHeart.
+- fix(memory): avoid unnecessary full rebuilds during memory search ([#136064](https://github.com/openclaw/openclaw/pull/136064)). Thanks @ThatGuySizemore.
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Skills
+
+Shared Gateways can give each teammate a private skill library they can create, import, update, and reuse without host access, with optional sharing that does not hand over edit rights. Supporting files and executable permissions stay with the selected revision as work moves between sessions and workers.
+
+<AccordionGroup>
+
+<Accordion title="Personal skills and agent workspaces">
+
+[Skills](/tools/skills) can now work from a real project directory for local agents while keeping OpenClaw's managed workspace guidance and memory. Message forks retain native history through restarts, personal-skill capacity is reserved across profiles, and successful PDF or image analysis is kept instead of being repeated by Code Mode or Tool Search.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(agents): apply the fallback delegation gate to CLI-backend runs ([#115405](https://github.com/openclaw/openclaw/pull/115405)). Thanks @MertBasar0.
+- fix: preserve ordering for nested session writes ([#131456](https://github.com/openclaw/openclaw/pull/131456)). Thanks @gaoanze888, @Grynn.
+- fix(sessions): buildSessionContext never returns on a cyclic parent chain ([#131567](https://github.com/openclaw/openclaw/pull/131567)). Thanks @igs-rogenlo.
+- fix(exec): surface backgrounded follow-up route in tool details ([#132756](https://github.com/openclaw/openclaw/pull/132756)). Thanks @sashankh, @shad0wca7.
+- fix(auto-reply): show real exit status for failed /bash commands ([#133414](https://github.com/openclaw/openclaw/pull/133414)). Thanks @MoerAI.
+- feat(skills): add personal libraries for shared Gateways ([#134068](https://github.com/openclaw/openclaw/pull/134068)). Thanks @RomneyDa, @steipete.
+- fix(migrate-claude): preserve overwritten generated skills in backups ([#134302](https://github.com/openclaw/openclaw/pull/134302)). Thanks @PollyBot13, @steipete.
+- feat(codex): preserve native history in supervised message forks ([#134660](https://github.com/openclaw/openclaw/pull/134660)). Thanks @kevin2966n.
+- fix: preserve PDF and image analysis in Code Mode ([#135037](https://github.com/openclaw/openclaw/pull/135037)).
+- fix(tooling): preserve compiled plugin loading in source Gateways ([#135077](https://github.com/openclaw/openclaw/pull/135077)).
+- feat(agents): configure run cwd and describe directory roles ([#135080](https://github.com/openclaw/openclaw/pull/135080)).
+- fix(agents): harden cleanup completion paths ([#135098](https://github.com/openclaw/openclaw/pull/135098)).
+- fix(agents): surface bucketed tool-loop warnings ([#135103](https://github.com/openclaw/openclaw/pull/135103)). Thanks @steipete.
+- fix: prevent stale CLI recovery from replacing newer sessions ([#135168](https://github.com/openclaw/openclaw/pull/135168)). Thanks @mushuiyu886, @obviyus.
+- fix: preserve context-free harness policy reasons ([#135206](https://github.com/openclaw/openclaw/pull/135206)). Thanks @fuller-stack-dev, @goslingmanagment.
+- fix(tools): release terminal summaries after nested calls settle ([#135398](https://github.com/openclaw/openclaw/pull/135398)).
+- fix: preserve explicit fleet diagnostic ownership ([#135447](https://github.com/openclaw/openclaw/pull/135447)). Thanks @Hansen1018, @abacha.
+- fix(skills): keep one profile from exhausting pending ZIP imports ([#135593](https://github.com/openclaw/openclaw/pull/135593)).
+- fix(hooks): install optional hook-pack dependencies ([#136050](https://github.com/openclaw/openclaw/pull/136050)).
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Native Apps
+
+[Android](/platforms/android) gets a fuller chat, session, sidebar, and appearance experience aligned with the browser workspace, while Android, [iPhone and iPad](/platforms/ios), and [macOS](/platforms/macos) can render Mermaid diagrams directly in chat. Source, copy, retry, zoom, and full-screen controls follow the capabilities of each app, with an offline-capable vector preview on iOS.
+
+<AccordionGroup>
+
+<Accordion title="Richer native chat with steadier reconnects and voice">
+
+Native chat also behaves better when the connection or screen is awkward. Android acknowledgements advance messages beyond Sending after reconnect, deleted queued messages stay deleted, narrow and large-text layouts remain usable, and model availability is explained before a send. macOS keeps composer controls reachable in narrow windows and packages the resources its MLX speech path needs, while Watch and realtime voice work stay attached to the turn that started them.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- chore(i18n): refresh native locales ([#134627](https://github.com/openclaw/openclaw/pull/134627)). Thanks @steipete.
+- fix(chat): publish retry state for settings failures ([#134752](https://github.com/openclaw/openclaw/pull/134752)).
+- fix(macos): reveal onboarding failures and restore retry actions ([#134756](https://github.com/openclaw/openclaw/pull/134756)).
+- fix(android): prevent sends with auth-unavailable models ([#134884](https://github.com/openclaw/openclaw/pull/134884)). Thanks @fuller-stack-dev.
+- fix(worker): close owned state before removing runtime directory ([#134911](https://github.com/openclaw/openclaw/pull/134911)).
+- fix(voice-call): stop reporting host cancellation as tool failure ([#134924](https://github.com/openclaw/openclaw/pull/134924)).
+- fix(node-host): preserve native Claude login for blank credentials ([#134932](https://github.com/openclaw/openclaw/pull/134932)). Thanks @rockytanf.
+- feat(android): align chat, sidebar, and appearance with the web UI ([#134939](https://github.com/openclaw/openclaw/pull/134939)). Thanks @IWhatsskill, @obviyus.
+- fix(ios): restore dependency resolution with WebRTC 152 ([#134942](https://github.com/openclaw/openclaw/pull/134942)).
+- fix(talk): preserve consult ownership across clients ([#135031](https://github.com/openclaw/openclaw/pull/135031)). Thanks @astra-openclaw.
+- fix(ios): disclose model targets and enforce availability ([#135044](https://github.com/openclaw/openclaw/pull/135044)). Thanks @fuller-stack-dev, @goslingmanagment.
+- fix(native): share invoke timeout ownership and gate callbacks ([#135287](https://github.com/openclaw/openclaw/pull/135287)). Thanks @steipete.
+- feat(android): render Mermaid diagrams in chat ([#135342](https://github.com/openclaw/openclaw/pull/135342)). Thanks @steipete.
+- fix(macos): avoid rebuilding speech recognizers between voice captures ([#135401](https://github.com/openclaw/openclaw/pull/135401)). Thanks @Colton-Harris.
+- fix(ui): keep selected agent on native progress cards ([#135426](https://github.com/openclaw/openclaw/pull/135426)). Thanks @obviyus, @rwinkelman, @Synthetic2802.
+- fix(android): keep narrow chat composers readable ([#135432](https://github.com/openclaw/openclaw/pull/135432)). Thanks @KangBumS.
+- fix(gateway): prevent long temp paths from breaking desktop tunnels ([#135456](https://github.com/openclaw/openclaw/pull/135456)). Thanks @ly85206559.
+- feat(ios): render Mermaid diagrams in native chat ([#135470](https://github.com/openclaw/openclaw/pull/135470)). Thanks @steipete.
+- fix(macos): keep dynamic UI copy in generated localization coverage ([#135511](https://github.com/openclaw/openclaw/pull/135511)).
+- chore(i18n): refresh native locales ([#135543](https://github.com/openclaw/openclaw/pull/135543)).
+- chore(linux): update Tauri app dependencies ([#135557](https://github.com/openclaw/openclaw/pull/135557)). Thanks @steipete.
+- chore(android): refresh libraries and build tooling ([#135563](https://github.com/openclaw/openclaw/pull/135563)).
+- chore(deps): refresh macOS and iOS app dependencies ([#135592](https://github.com/openclaw/openclaw/pull/135592)).
+- chore(i18n): refresh native locales ([#135600](https://github.com/openclaw/openclaw/pull/135600)).
+- feat(macos): streamline native chat composer ([#135608](https://github.com/openclaw/openclaw/pull/135608)).
+- fix(linux): restore first-run Gateway choices without the CLI ([#135650](https://github.com/openclaw/openclaw/pull/135650)). Thanks @steipete.
+- fix: openclaw node worker never exits after a stop when stdin is held open or a plugin child pins the event loop ([#135665](https://github.com/openclaw/openclaw/pull/135665)). Thanks @Colton-Harris, @obviyus.
+- chore(android): update Room storage and KaTeX rendering ([#135670](https://github.com/openclaw/openclaw/pull/135670)).
+- fix(ios): keep Watch voice replies and playback with their original turn ([#135697](https://github.com/openclaw/openclaw/pull/135697)).
+- fix(macos): preserve the Talk overlay through quick toggles ([#135731](https://github.com/openclaw/openclaw/pull/135731)). Thanks @HuzaifaChaudary.
+- feat(macos): render Mermaid diagrams in native chat ([#135746](https://github.com/openclaw/openclaw/pull/135746)).
+- fix(watch): explain when a spoken reply times out ([#135765](https://github.com/openclaw/openclaw/pull/135765)).
+- fix(ios): avoid duplicate replies after chat history refresh ([#135789](https://github.com/openclaw/openclaw/pull/135789)).
+- fix(android): offer recording when dictation is unavailable ([#135794](https://github.com/openclaw/openclaw/pull/135794)). Thanks @RaviTharuma.
+- fix(ios): keep realtime voice consults with their own replies ([#135795](https://github.com/openclaw/openclaw/pull/135795)).
+- fix(android): keep reconnect cleanup scoped to its connection ([#135878](https://github.com/openclaw/openclaw/pull/135878)).
+- fix(watch): stop command delivery after device revocation ([#135904](https://github.com/openclaw/openclaw/pull/135904)).
+- fix(android): keep reconnected messages from getting stuck sending ([#135961](https://github.com/openclaw/openclaw/pull/135961)).
+- refactor(android): simplify native flows and preserve chat ownership ([#136078](https://github.com/openclaw/openclaw/pull/136078)).
+- fix(android): keep deleted queued messages from reappearing ([#136161](https://github.com/openclaw/openclaw/pull/136161)).
+- fix(macos): centralize bounded native pipe reads and final drains ([#136214](https://github.com/openclaw/openclaw/pull/136214)).
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Models and Providers
+
+[Model selection](/concepts/models) now makes scope and recovery clearer before a choice changes working configuration. The Control UI brings important defaults into one autosaving card, a route without an activatable harness cannot replace a working model, and provider or credential changes refresh the available inventory without requiring a Gateway restart.
+
+<AccordionGroup>
+
+<Accordion title="Model choices that keep their route and recover cleanly">
+
+Long-running Codex work no longer stops merely because progress is quiet, changed prompt-hook policy takes effect safely on persistent turns, and eligible models keep Ultra across supported runtime and child-session boundaries. Transient provider failures retry within a bounded window before normal fallback, hard Anthropic and Bedrock refusals stop rather than multiplying requests, and local or CLI-backed routes avoid unusable remote tools when no executable node is connected.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(openai): repair stale doctor route pins ([#102180](https://github.com/openclaw/openclaw/pull/102180)). Thanks @849261680, @cpwilhelmi.
+- fix(anthropic): keep context usage for providers that never write cache ([#126473](https://github.com/openclaw/openclaw/pull/126473)). Thanks @ayaangazali, @Oliverbot26.
+- fix(codex): channel-aware hooks reject authenticated users ([#129402](https://github.com/openclaw/openclaw/pull/129402)). Thanks @ashawwal.
+- fix(llama-cpp): bound managed server inspection responses ([#132490](https://github.com/openclaw/openclaw/pull/132490)). Thanks @RileyJJY, @steipete.
+- fix(process): Gateway survives late CLI output after timeout ([#132582](https://github.com/openclaw/openclaw/pull/132582)). Thanks @TARSDrakon.
+- fix(zai): honor thinkingLevelMap when no thinking level is requested ([#132697](https://github.com/openclaw/openclaw/pull/132697)). Thanks @wangjx-xydt, @nina-grech.
+- fix(ai): exclude tools from the HTTP continuation request-equality check ([#132951](https://github.com/openclaw/openclaw/pull/132951)). Thanks @hartmark.
+- fix: llama.cpp context-size-exceeded not treated as overflow ([#133888](https://github.com/openclaw/openclaw/pull/133888)). Thanks @gokay-ai, @Areson.
+- fix(volcengine): reject invalid UTF-8 in TTS responses ([#134010](https://github.com/openclaw/openclaw/pull/134010)). Thanks @ZengWen-DT.
+- fix(ui): ignore tool-only model auth rows ([#134218](https://github.com/openclaw/openclaw/pull/134218)). Thanks @wantosure, @beastyrabbit.
+- fix: model fallback cycles every provider when session already has an active turn claim ([#134219](https://github.com/openclaw/openclaw/pull/134219)). Thanks @obviyus, @svdwalt007, @tzlwn1.
+- fix(agents): own transient LLM retries in one failover retry controller ([#134281](https://github.com/openclaw/openclaw/pull/134281)). Thanks @obviyus.
+- fix(gateway): refresh model catalog after auth changes ([#134361](https://github.com/openclaw/openclaw/pull/134361)). Thanks @obviyus.
+- fix(ai): preserve Responses continuation across admitted tool arguments ([#134423](https://github.com/openclaw/openclaw/pull/134423)). Thanks @hartmark.
+- fix(ui): disclose model picker write scope ([#134473](https://github.com/openclaw/openclaw/pull/134473)). Thanks @fuller-stack-dev, @goslingmanagment, @Marvinthebored.
+- fix: avoid loading the agent runtime for provider auth selection ([#134626](https://github.com/openclaw/openclaw/pull/134626)).
+- fix(codex): stop interrupting active turns during quiet native work ([#134755](https://github.com/openclaw/openclaw/pull/134755)). Thanks @obviyus, @ernestrolfson-design.
+- fix: Model Setup writes leftover claude-cli key after Claude CLI activation ([#134779](https://github.com/openclaw/openclaw/pull/134779)). Thanks @leilei3167, @obviyus, @aaajiao.
+- fix(anthropic): retain Claude subprocess failure diagnostics ([#134794](https://github.com/openclaw/openclaw/pull/134794)).
+- feat(ui): streamline model provider defaults ([#134813](https://github.com/openclaw/openclaw/pull/134813)). Thanks @Patrick-Erichsen.
+- fix(gateway): reject model selections without an activatable harness ([#134837](https://github.com/openclaw/openclaw/pull/134837)). Thanks @steipete, @goslingmanagment.
+- fix: models status skips refresh with matching agent directory override ([#134862](https://github.com/openclaw/openclaw/pull/134862)). Thanks @Lendersmark.
+- fix(agents): stop local providers before Gateway shutdown ([#134890](https://github.com/openclaw/openclaw/pull/134890)). Thanks @MoerAI, @obviyus, @Deregtx.
+- fix(deepinfra): refresh estimates from native pricing ([#134893](https://github.com/openclaw/openclaw/pull/134893)).
+- fix: Anthropic refusals no longer resend requests ([#134980](https://github.com/openclaw/openclaw/pull/134980)). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
+- fix(models): retain externally authenticated providers in the model menu ([#135046](https://github.com/openclaw/openclaw/pull/135046)). Thanks @goslingmanagment.
+- fix: refresh model catalogs after auth and config changes ([#135063](https://github.com/openclaw/openclaw/pull/135063)). Thanks @elikampf.
+- fix(ai): honor Model Studio cache defaults and retention ([#135093](https://github.com/openclaw/openclaw/pull/135093)).
+- fix(models): keep local Ollama routes selectable ([#135095](https://github.com/openclaw/openclaw/pull/135095)). Thanks @obviyus, @BoatAngle.
+- fix(gateway): preserve provider details on chat error events ([#135102](https://github.com/openclaw/openclaw/pull/135102)). Thanks @steipete.
+- fix(ai): diagnose pre-output provider transport failures ([#135105](https://github.com/openclaw/openclaw/pull/135105)).
+- fix: show concise OAuth errors in Control UI ([#135112](https://github.com/openclaw/openclaw/pull/135112)). Thanks @shakkernerd.
+- fix: explain unavailable agent harnesses on failed turns ([#135118](https://github.com/openclaw/openclaw/pull/135118)). Thanks @fuller-stack-dev, @goslingmanagment.
+- fix: let claude-cli connect through PATH shims ([#135124](https://github.com/openclaw/openclaw/pull/135124)). Thanks @zhangguiping-xydt, @obviyus, @masatokawano.
+- fix(tts): inherit request timeouts for local CLI synthesis ([#135222](https://github.com/openclaw/openclaw/pull/135222)).
+- fix(google): auto-enable configured provider plugin ([#135239](https://github.com/openclaw/openclaw/pull/135239)). Thanks @Solvely-Colin.
+- fix: retain discovered models across hot reload ([#135353](https://github.com/openclaw/openclaw/pull/135353)). Thanks @goslingmanagment.
+- fix(auth): relogin repairs stale profile order after upgrade ([#135355](https://github.com/openclaw/openclaw/pull/135355)). Thanks @obviyus, @mattcbianco.
+- fix(auth): preserve custom provider SecretRefs in Doctor ([#135357](https://github.com/openclaw/openclaw/pull/135357)). Thanks @obviyus, @dannevang.
+- refactor(agents): share incomplete-turn visibility classification ([#135374](https://github.com/openclaw/openclaw/pull/135374)). Thanks @Marvinthebored, @obviyus.
+- fix: preserve Ultra across model runtime boundaries ([#135397](https://github.com/openclaw/openclaw/pull/135397)). Thanks @steipete.
+- fix(llama-cpp): discover models behind web app endpoints ([#135445](https://github.com/openclaw/openclaw/pull/135445)). Thanks @gaoanze888, @Bloodis94.
+- fix(anthropic): context usage is lost when a proxy omits message_delta usage ([#135467](https://github.com/openclaw/openclaw/pull/135467)). Thanks @Yigtwxx.
+- perf: resolve web fetch providers once in their owner ([#135504](https://github.com/openclaw/openclaw/pull/135504)).
+- fix(codex): stop using stale instructions after prompt-hook changes ([#135577](https://github.com/openclaw/openclaw/pull/135577)).
+- fix(status): keep authored context caps through runtime provider aliases ([#135580](https://github.com/openclaw/openclaw/pull/135580)). Thanks @VACInc.
+- feat(anthropic): support Fable 5.1 from shared model metadata ([#135638](https://github.com/openclaw/openclaw/pull/135638)).
+- fix(agents): route utility completions through the selected runtime ([#135711](https://github.com/openclaw/openclaw/pull/135711)). Thanks @goslingmanagment.
+- fix(auth): diagnose relocation conflicts and clear forced-login owners ([#135739](https://github.com/openclaw/openclaw/pull/135739)). Thanks @Deregtx, @cksagente-dot.
+- fix(anthropic-vertex): retain current Sonnet 5 pricing ([#135761](https://github.com/openclaw/openclaw/pull/135761)).
+- feat(xai): surface SuperGrok usage stats ([#135766](https://github.com/openclaw/openclaw/pull/135766)). Thanks @steipete.
+- fix(secrets): publish the durable auth order on a running gateway refresh ([#135847](https://github.com/openclaw/openclaw/pull/135847)). Thanks @josephbergvinson, @obviyus, @yetval.
+- fix(openai): restore OAuth audio transcription ([#135855](https://github.com/openclaw/openclaw/pull/135855)). Thanks @yungchentang, @kAIborg24.
+- fix(codex): hide node exec when no capable node is connected ([#136000](https://github.com/openclaw/openclaw/pull/136000)).
+- fix(agents): avoid unused discovery for read-only catalog queries ([#136020](https://github.com/openclaw/openclaw/pull/136020)). Thanks @609NFT, @LiuwqGit.
+- fix(codex): restore Ultra for configured native account models ([#136061](https://github.com/openclaw/openclaw/pull/136061)).
+- fix(cli): hide remote exec without an executable node ([#136067](https://github.com/openclaw/openclaw/pull/136067)).
+- fix(codex): align managed installs and release checks on 0.152.1 ([#136184](https://github.com/openclaw/openclaw/pull/136184)). Thanks @steipete.
+- fix(codex): let idle chats resume while other chats are running ([#136196](https://github.com/openclaw/openclaw/pull/136196)).
+- perf: Claude Code catalog refresh no longer re-scans the projects tree on every poll ([#136222](https://github.com/openclaw/openclaw/pull/136222)). Thanks @giangthb.
+- fix(agents): tolerate replaced thinking catalog owners (#127284) ([`bf599a7217`](https://github.com/openclaw/openclaw/commit/bf599a721784849e350c18ff703c9e75de939e0d)). Thanks @RomneyDa, @karkarl, @AndrewEAUS.
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Automations and Scheduling
+
+[Scheduled work](/automation/cron-jobs) now holds onto the route, deadline, and result that actually belong to the job. Codex app-server users can create automations with their existing authenticated connection, one-shot jobs run even when periodic heartbeats are disabled, and operators can opt in to skip missed recurring jobs after downtime.
+
+<AccordionGroup>
+
+<Accordion title="Scheduled work that survives restarts and real calendars">
+
+One-time retry times survive Gateway restarts, aliases remain scoped to the selected agent, and long or unlimited heartbeat runs honor their configured deadline instead of stopping at ten minutes. Expanded-year schedules respect their chosen time zone, quiet jobs can finish without an unwanted fallback announcement, and run history shows confirmed failure-alert outcomes without exposing unbounded diagnostics.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(cron): preserve legacy enabled state through schema migration ([#132868](https://github.com/openclaw/openclaw/pull/132868)). Thanks @CanReader, @obviyus.
+- fix(ui): preserve duration quantities across locales ([#133224](https://github.com/openclaw/openclaw/pull/133224)).
+- fix(cron): create jobs with configured Codex app-server auth ([#134525](https://github.com/openclaw/openclaw/pull/134525)). Thanks @sjf-oa.
+- fix(cron): kind change fails with "command env must be an object" when env is omitted ([#134639](https://github.com/openclaw/openclaw/pull/134639)). Thanks @solomonneas.
+- fix(cron): admit immediate main-session wakes when heartbeat is disabled ([#134648](https://github.com/openclaw/openclaw/pull/134648)). Thanks @sunlit-deng, @obviyus, @LowCode191.
+- fix: isolated cron add hides a fail-closed announce route ([#135003](https://github.com/openclaw/openclaw/pull/135003)). Thanks @ericcaiwx-star, @obviyus.
+- fix: keep scheduled model aliases scoped to the selected agent ([#135069](https://github.com/openclaw/openclaw/pull/135069)). Thanks @elikampf.
+- feat(cron): optionally skip missed recurring jobs at startup ([#135071](https://github.com/openclaw/openclaw/pull/135071)).
+- fix(cron): preserve one-shot retries during startup recovery ([#135083](https://github.com/openclaw/openclaw/pull/135083)). Thanks @rwinkelman, @obviyus, @meircohen.
+- fix(cron): release admission before continuation cleanup ([#135155](https://github.com/openclaw/openclaw/pull/135155)). Thanks @brettdaman, @obviyus.
+- fix(agents): keep agents_wait deadlines monotonic ([#135292](https://github.com/openclaw/openclaw/pull/135292)). Thanks @qingminglong, @steipete.
+- fix: persist settled cron failure-alert outcomes ([#135516](https://github.com/openclaw/openclaw/pull/135516)). Thanks @RayWangyangMa, @obviyus, @bassmediagroup.
+- fix(gateway): release continuation admission before final response ([#135517](https://github.com/openclaw/openclaw/pull/135517)). Thanks @jmewing, @obviyus, @goslingmanagment, @giangthb.
+- perf(cron): reuse collation within name-sorted job lists ([#135597](https://github.com/openclaw/openclaw/pull/135597)).
+- fix(cron): validate payload and trigger on legacy shorthand schedules ([#135829](https://github.com/openclaw/openclaw/pull/135829)). Thanks @teddytennant, @obviyus.
+- fix(heartbeat): show first-alert preamble once for isolated routes ([#135849](https://github.com/openclaw/openclaw/pull/135849)). Thanks @obviyus, @rwinkelman, @virtexvirtuoso.
+- fix(cron): preserve NO_REPLY after completed tool calls ([#135919](https://github.com/openclaw/openclaw/pull/135919)). Thanks @leilei3167, @obviyus, @Frank683456.
+- fix(heartbeat): honor configured timeout in cron watchdog ([#135925](https://github.com/openclaw/openclaw/pull/135925)). Thanks @xialonglee, @obviyus, @jaxonparrott.
+- fix(cron): honor time zones for expanded ISO dates ([#135973](https://github.com/openclaw/openclaw/pull/135973)).
+- fix(ui): open automation links beyond the loaded list page ([#136012](https://github.com/openclaw/openclaw/pull/136012)). Thanks @steipete.
+- fix(cron): paginate history after session visibility filtering ([#136043](https://github.com/openclaw/openclaw/pull/136043)). Thanks @steipete.
+- fix(backup): find managed schedules by declaration identity ([#136133](https://github.com/openclaw/openclaw/pull/136133)).
+- fix(heartbeat): bind scheduled replies to published runtime ([#136256](https://github.com/openclaw/openclaw/pull/136256)). Thanks @obviyus, @Famyoff.
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Browser and Computer Use
+
+Standalone browser agents can use the local browser, return complete screenshots, and recover after an interrupted capture. Existing-session attachments use a reviewed fixed Chrome MCP version, selected tabs retain valid commands through ordinary group changes, and Chrome endpoint arguments are checked against hostname policy before a connection begins.
+
+<AccordionGroup>
+
+<Accordion title="Browser and desktop control that keeps the right target">
+
+On the desktop side, paired macOS Peekaboo nodes now report successful typing and key actions as successful, reducing the chance an agent repeats input that already changed the screen. Windows handoff keeps the authenticated TightVNC viewer while moving between view-only and control, large computer-use responses use less peak memory on Mac, and small-screen settings and WebVNC text entry behave more reliably.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(browser): reject unsupported fill field keys ([#131400](https://github.com/openclaw/openclaw/pull/131400)). Thanks @LiuwqGit, @obviyus, @srb11e.
+- fix(exec): select capable nodes and report the execution target ([#131767](https://github.com/openclaw/openclaw/pull/131767)). Thanks @vyctorbrzezowski.
+- fix(macos): computer input no longer fails after execution ([#134689](https://github.com/openclaw/openclaw/pull/134689)). Thanks @gaoanze888, @wbstrbt.
+- fix(ui): retain desktop viewer through control handoff ([#134903](https://github.com/openclaw/openclaw/pull/134903)).
+- perf(cua-computer): bound fragmented MCP response copies ([#135094](https://github.com/openclaw/openclaw/pull/135094)).
+- fix: stale group updates revoke valid browser commands ([#135186](https://github.com/openclaw/openclaw/pull/135186)).
+- ci: balance Control UI browser checks ([#135210](https://github.com/openclaw/openclaw/pull/135210)).
+- fix(browser): avoid standalone routing errors and cropped screenshots ([#135315](https://github.com/openclaw/openclaw/pull/135315)).
+- fix(talk): keep internal consult prompts out of later model context ([#135423](https://github.com/openclaw/openclaw/pull/135423)). Thanks @Conan-Scott.
+- fix(cua): correct desktop frames, text input, and Settings sizing ([#135582](https://github.com/openclaw/openclaw/pull/135582)).
+- fix(browser): enforce CDP policy for Chrome MCP argument endpoints ([#135857](https://github.com/openclaw/openclaw/pull/135857)).
+- fix: preserve web search publication dates ([#136017](https://github.com/openclaw/openclaw/pull/136017)). Thanks @rogerallen1.
+- fix(browser): prevent unreviewed Chrome MCP upgrades ([#136121](https://github.com/openclaw/openclaw/pull/136121)). Thanks @steipete.
+- fix(agents): clarify UI presentation surfaces ([#136195](https://github.com/openclaw/openclaw/pull/136195)).
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Plugins and Integrations
+
+Plugin management now does a better job of preserving the operator's actual choice. Explicitly uninstalled managed provider plugins stay uninstalled after restart, channel setup and management retain the selected agent through discovery, and removing a missing or renamed plugin no longer erases another plugin's channel settings.
+
+<AccordionGroup>
+
+<Accordion title="Plugins that preserve ownership and state">
+
+Verified first-party plugins can install, update, repair, and re-enable without an unnecessary consent prompt, while unknown or changed capabilities still keep their review boundary. GitHub Actions dashboard widgets use the owning agent's authenticated access, OAuth-enabled HTTP and SSE MCP servers can receive the known request size they require, and source builds can move without leaving external plugin dependencies pointed at the old checkout.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(docker): build explicitly selected WhatsApp plugin ([#120660](https://github.com/openclaw/openclaw/pull/120660)). Thanks @fr-meyer.
+- feat(plugins): migrate renamed official plugins by legacy npm package name ([#130894](https://github.com/openclaw/openclaw/pull/130894)). Thanks @cxyhhhhh.
+- fix(ui): announce ClawHub search completion via a live region ([#133091](https://github.com/openclaw/openclaw/pull/133091)). Thanks @SunnyShu0925.
+- fix(plugins): avoid loading CLI-only code at startup ([#133105](https://github.com/openclaw/openclaw/pull/133105)). Thanks @ly85206559.
+- feat(github): connect personal accounts alongside the system account ([#133799](https://github.com/openclaw/openclaw/pull/133799)). Thanks @steipete.
+- fix(plugins): require consent for legacy updates ([#134172](https://github.com/openclaw/openclaw/pull/134172)). Thanks @RileyJJY, @beastyrabbit.
+- fix(exec): prevent native GitHub fallback after managed profile loss ([#134351](https://github.com/openclaw/openclaw/pull/134351)).
+- fix(plugins): recover orphan installs without weakening ownership ([#134590](https://github.com/openclaw/openclaw/pull/134590)). Thanks @MoerAI, @obviyus, @abacha.
+- fix(voice-call): report missing agent ownership during setup ([#134739](https://github.com/openclaw/openclaw/pull/134739)). Thanks @felixboenkost-droid.
+- fix(plugins): preserve channel settings during uninstall ([#134759](https://github.com/openclaw/openclaw/pull/134759)). Thanks @steipete, @MoerAI, @abacha.
+- fix(plugins): ignore build stamps in registry freshness ([#134780](https://github.com/openclaw/openclaw/pull/134780)). Thanks @RayWangyangMa, @obviyus, @axiom-ncis.
+- perf(plugins): reuse snapshot alias resolvers during startup ([#134812](https://github.com/openclaw/openclaw/pull/134812)).
+- docs: explain recovery from Homebrew op path changes ([#134832](https://github.com/openclaw/openclaw/pull/134832)). Thanks @steipete.
+- fix(voice-call): stream diagnostic logs with backpressure ([#134838](https://github.com/openclaw/openclaw/pull/134838)). Thanks @sunlit-deng.
+- fix(plugins): select Weixin package compatible with current SDK ([#134854](https://github.com/openclaw/openclaw/pull/134854)).
+- fix(ui): avoid duplicate plugin admin warning ([#134860](https://github.com/openclaw/openclaw/pull/134860)). Thanks @Patrick-Erichsen.
+- fix(plugins): preserve plugin load errors across retries ([#134874](https://github.com/openclaw/openclaw/pull/134874)). Thanks @0xCyda, @Lendersmark.
+- docs: clarify disabled plugin reinstall behavior ([#134875](https://github.com/openclaw/openclaw/pull/134875)).
+- fix(plugins): exempt verified first-party plugins from capability consent ([#134933](https://github.com/openclaw/openclaw/pull/134933)).
+- fix(plugin-sdk): harden SQLite WAL retry deadline ([#135019](https://github.com/openclaw/openclaw/pull/135019)). Thanks @xialonglee, @obviyus.
+- perf(web-search): defer bundled provider runtime imports ([#135073](https://github.com/openclaw/openclaw/pull/135073)).
+- fix(feishu): validate document API outcomes before reporting success ([#135106](https://github.com/openclaw/openclaw/pull/135106)).
+- fix: retire late plugin loads when the Gateway shuts down ([#135122](https://github.com/openclaw/openclaw/pull/135122)). Thanks @elikampf.
+- fix(plugins): preserve bundle capabilities in CLI inventory ([#135245](https://github.com/openclaw/openclaw/pull/135245)). Thanks @ssaade01, @tayoun.
+- perf(plugins): speed up plugin catalog management ([#135260](https://github.com/openclaw/openclaw/pull/135260)).
+- refactor(canvas): reuse canonical node CLI helpers ([#135303](https://github.com/openclaw/openclaw/pull/135303)).
+- fix: retain shipped plugin contracts and publish 2026.8.2 notes ([#135322](https://github.com/openclaw/openclaw/pull/135322)). Thanks @steipete.
+- fix(channels): omit explicitly disabled manifest accounts ([#135417](https://github.com/openclaw/openclaw/pull/135417)). Thanks @ly85206559.
+- fix(twitch): name the accessToken config key in setup errors ([#135421](https://github.com/openclaw/openclaw/pull/135421)). Thanks @ly85206559.
+- refactor(github): simplify publication and connection lifecycles ([#135428](https://github.com/openclaw/openclaw/pull/135428)). Thanks @steipete.
+- fix(channels): preserve selected agent during plugin discovery ([#135505](https://github.com/openclaw/openclaw/pull/135505)). Thanks @abacha, @Hansen1018.
+- fix: plugin uninstall persists across Gateway restart ([#135729](https://github.com/openclaw/openclaw/pull/135729)). Thanks @devzeroLL, @obviyus.
+- fix(dashboard): authenticate GitHub Actions data reads ([#135740](https://github.com/openclaw/openclaw/pull/135740)). Thanks @steipete.
+- fix(boards): replace widget records on put ([#135748](https://github.com/openclaw/openclaw/pull/135748)). Thanks @teddytennant, @obviyus.
+- Fix scoped ClawHub plugin dependency warnings during uninstall ([#135749](https://github.com/openclaw/openclaw/pull/135749)). Thanks @teddytennant, @obviyus.
+- fix(infra): reject dot segments in sanitized temp file names ([#135803](https://github.com/openclaw/openclaw/pull/135803)). Thanks @teddytennant.
+- fix(plugins): load typed JSX channel state checkers ([#135820](https://github.com/openclaw/openclaw/pull/135820)). Thanks @steipete.
+- fix(build): keep plugin dependencies after checkout relocation ([#135903](https://github.com/openclaw/openclaw/pull/135903)).
+- fix(ui): use bundled art for scoped plugin icons ([#135957](https://github.com/openclaw/openclaw/pull/135957)). Thanks @obviyus, @Grynn.
+- fix(plugins): stop interrupted service startup only once ([#135993](https://github.com/openclaw/openclaw/pull/135993)).
+- docs(plugin-sdk): correct retained migration paths and deadlines ([#136024](https://github.com/openclaw/openclaw/pull/136024)).
+- fix(sessions): allow strict transcript appends without storePath ([#136201](https://github.com/openclaw/openclaw/pull/136201)).
+- improve(github): publication options load without re-verifying GitHub credentials on every session switch ([#136223](https://github.com/openclaw/openclaw/pull/136223)).
+- fix(sessions): keep incognito creation in its explicit environment ([#136227](https://github.com/openclaw/openclaw/pull/136227)).
+- fix(mcp): size OAuth-authenticated request bodies ([#136234](https://github.com/openclaw/openclaw/pull/136234)). Thanks @LiuwqGit, @obviyus, @Volevanius.
+- fix(ui): align Workshop content width (#134871) ([`61404b6c2a`](https://github.com/openclaw/openclaw/commit/61404b6c2a91871b2a4f5819ca98b06a90077796)). Thanks @Patrick-Erichsen.
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Security and Privacy
+
+Approval now follows the authority that actually exists when work runs. Eligible MCP approvals can persist across Codex sessions and Gateway restarts, full-permission sessions stop asking repeatedly for an approval their policy already grants, and delegated agent creation stops if the requesting run loses authority before the new agent is created.
+
+<AccordionGroup>
+
+<Accordion title="Persistent approval without weakening stricter policy">
+
+Stricter session and server rules still win. Operators can block selected hosts across browser, fetch, and webhook SSRF checks, rotate or revoke scoped node tokens, require an expected current value before automation changes configuration, and receive one parseable Secrets CLI document on success or failure. Saved Codex reasoning remains hidden unless it was explicitly enabled, and credentials are redacted from pre-migration diagnostic snapshots.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(doctor): stop scanning sibling account state directories ([#122586](https://github.com/openclaw/openclaw/pull/122586)). Thanks @vincentkoc, @lidge-jun, @richard-scott.
+- fix(doctor): redact transcript archive failures ([#122628](https://github.com/openclaw/openclaw/pull/122628)). Thanks @sunlit-deng, @obviyus.
+- feat: reuse approvals for active Codex placements ([#132370](https://github.com/openclaw/openclaw/pull/132370)). Thanks @jalehman.
+- fix(cli): reject malformed approval grant lifetimes ([#133806](https://github.com/openclaw/openclaw/pull/133806)). Thanks @qingminglong.
+- fix: GitHub sign-in fails when anonymous API quota is exhausted ([#134724](https://github.com/openclaw/openclaw/pull/134724)).
+- fix(ios): omit deep-link URLs from logs ([#134738](https://github.com/openclaw/openclaw/pull/134738)). Thanks @eleqtrizit.
+- fix(copilot): authenticate azure byok proxy requests ([#134781](https://github.com/openclaw/openclaw/pull/134781)). Thanks @eleqtrizit.
+- fix(config): redact pre-migration snapshots in responses ([#134940](https://github.com/openclaw/openclaw/pull/134940)). Thanks @joemc1470.
+- feat(ssrf): add configured hostname blocklists ([#135097](https://github.com/openclaw/openclaw/pull/135097)).
+- fix(devices): allow authorized scoped node token management ([#135617](https://github.com/openclaw/openclaw/pull/135617)).
+- fix(sandbox): restore guest coding in private workspaces ([#135702](https://github.com/openclaw/openclaw/pull/135702)). Thanks @whyuds.
+- fix(codex): follow session posture for MCP tool approvals and make Allow Always stick ([#135812](https://github.com/openclaw/openclaw/pull/135812)).
+- fix(ui): hide saved Codex reasoning unless enabled ([#136008](https://github.com/openclaw/openclaw/pull/136008)).
+- feat(approvals): make Allow Always durable for MCP tools on OpenClaw-configured servers ([#136019](https://github.com/openclaw/openclaw/pull/136019)).
+- fix: stop agent creation after delegated authority closes ([#136090](https://github.com/openclaw/openclaw/pull/136090)).
+- feat(config): add conditional set expectations ([#136137](https://github.com/openclaw/openclaw/pull/136137)). Thanks @vincentkoc.
+- fix(cli): keep secrets JSON failures machine-readable ([#136142](https://github.com/openclaw/openclaw/pull/136142)). Thanks @qingminglong, @obviyus.
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Quality-of-Life Improvements
+
+OpenClaw does less repeated work between a request and its result. Large multi-agent installations keep health checks responsive, busy Gateways retain less session memory, concurrent long replies use substantially less tested CPU and memory, and routine agent shell commands start faster without changing approval or cancellation behavior.
+
+<AccordionGroup>
+
+<Accordion title="Less overhead in long conversations and busy Gateways">
+
+Model inventories, conversation resets, detached code blocks, logs, uploads, downloads, session listings, and browser assets all receive narrower memory or allocation reductions. Managed worktrees can live on another disk or folder and busy installations are no longer held to the old count ceiling when space permits, while everyday diagnostics, completion help, TTS, and presence reporting become quieter or clearer.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- docs: remove retired openai-codex from /login valid args ([#118045](https://github.com/openclaw/openclaw/pull/118045)). Thanks @AAliKKhan.
+- docs(showcase): fix 404 link for lite-mode skill ([#120645](https://github.com/openclaw/openclaw/pull/120645)). Thanks @firepinn.
+- docs: clarify node pairing storage lives on the paired-device record ([#122726](https://github.com/openclaw/openclaw/pull/122726)). Thanks @191612731-cloud, @vincentkoc.
+- docs: document built-in env default SecretRef alias ([#122730](https://github.com/openclaw/openclaw/pull/122730)). Thanks @191612731-cloud, @fujixm5.
+- docs(tasks): document timestamp audit finding ([#124672](https://github.com/openclaw/openclaw/pull/124672)). Thanks @qingminglong.
+- fix(shell-env): retry recovery after transient login-shell failures ([#125378](https://github.com/openclaw/openclaw/pull/125378)). Thanks @qdivan.
+- docs: document uv-managed python environments in exec ([#129930](https://github.com/openclaw/openclaw/pull/129930)). Thanks @ralphptorres.
+- fix(telemetry): bound update response reads ([#132492](https://github.com/openclaw/openclaw/pull/132492)). Thanks @RileyJJY.
+- fix(gateway): stop unpersistable session observer work ([#133220](https://github.com/openclaw/openclaw/pull/133220)). Thanks @SunnyShu0925, @ruel225.
+- fix(gateway): retry node wakes after clock rollback ([#133354](https://github.com/openclaw/openclaw/pull/133354)). Thanks @qingminglong.
+- fix(infra): make SSH tunnel stop await process reaping and join concurrent callers ([#133847](https://github.com/openclaw/openclaw/pull/133847)). Thanks @aniruddhaadak80.
+- refactor: avoid duplicate workspace Git initialization ([#134537](https://github.com/openclaw/openclaw/pull/134537)).
+- fix(subagents): avoid stale agents after lazy loading ([#134677](https://github.com/openclaw/openclaw/pull/134677)). Thanks @vincentkoc.
+- fix(docs): list channel dead-letter commands in CLI index ([#134711](https://github.com/openclaw/openclaw/pull/134711)). Thanks @qingminglong.
+- docs: route retired pages to current migration guidance ([#134712](https://github.com/openclaw/openclaw/pull/134712)).
+- fix: reduce memory spikes in catalogs, resets, and chat ([#134722](https://github.com/openclaw/openclaw/pull/134722)). Thanks @steipete.
+- fix(infra): expire stale presence after clock rollback ([#134737](https://github.com/openclaw/openclaw/pull/134737)). Thanks @lzhan011, @obviyus.
+- fix(tts): keep terminal command replies text-only ([#134802](https://github.com/openclaw/openclaw/pull/134802)). Thanks @najef1979-code.
+- perf(gateway): streamline doctor imports and schema construction ([#134807](https://github.com/openclaw/openclaw/pull/134807)).
+- perf(gateway): skip unused session snapshot and deletion reads ([#134814](https://github.com/openclaw/openclaw/pull/134814)). Thanks @steipete.
+- feat: configure a global managed worktree storage root ([#134872](https://github.com/openclaw/openclaw/pull/134872)).
+- fix: reduce retained Gateway and Activity memory ([#134891](https://github.com/openclaw/openclaw/pull/134891)). Thanks @petercheng.
+- perf(agents): scan session history backward without copies ([#134930](https://github.com/openclaw/openclaw/pull/134930)). Thanks @steipete.
+- fix(docs): prevent placeholder expansion from stalling translations ([#134934](https://github.com/openclaw/openclaw/pull/134934)). Thanks @steipete.
+- perf: reduce CodeMode latency and session lookup work ([#134935](https://github.com/openclaw/openclaw/pull/134935)).
+- perf: reduce memory spikes when reading HTTP response bodies ([#134954](https://github.com/openclaw/openclaw/pull/134954)).
+- perf: reuse owned provider response buffers ([#135014](https://github.com/openclaw/openclaw/pull/135014)).
+- perf: reduce CodeMode memory use between tool calls ([#135040](https://github.com/openclaw/openclaw/pull/135040)).
+- fix(cli): keep zsh subcommand descriptions literal ([#135114](https://github.com/openclaw/openclaw/pull/135114)). Thanks @walker1211.
+- perf(media): avoid intermediate multipart upload copies ([#135162](https://github.com/openclaw/openclaw/pull/135162)).
+- fix(gateway): make probe SSH tunnel abortable and handle SIGINT/SIGTERM ([#135182](https://github.com/openclaw/openclaw/pull/135182)). Thanks @aniruddhaadak80, @obviyus.
+- perf: avoid terminal replay stalls during bulk eviction ([#135183](https://github.com/openclaw/openclaw/pull/135183)).
+- perf: reduce memory used to decode command output ([#135189](https://github.com/openclaw/openclaw/pull/135189)). Thanks @steipete.
+- fix(cli): suggest config patch --file when shell strips JSON quotes ([#135203](https://github.com/openclaw/openclaw/pull/135203)). Thanks @SunnyShu0925.
+- perf(packaging): remove redundant npm install payload ([#135478](https://github.com/openclaw/openclaw/pull/135478)). Thanks @steipete.
+- perf(agents): reduce overhead for concurrent streaming replies ([#135751](https://github.com/openclaw/openclaw/pull/135751)).
+- fix(agents): keep large-roster gateway health responsive ([#135773](https://github.com/openclaw/openclaw/pull/135773)). Thanks @LiuwqGit, @609NFT, @obviyus.
+- docs: replace v2026.8.2 release notes ([#135805](https://github.com/openclaw/openclaw/pull/135805)). Thanks @hannesrudolph.
+- fix: requester sessions recover after settle-wake timeout ([#135854](https://github.com/openclaw/openclaw/pull/135854)). Thanks @obviyus, @nikolascostello, @pengzh1.
+- feat(worktrees): raise managed checkout limit to 100 ([#135885](https://github.com/openclaw/openclaw/pull/135885)).
+- improve: reduce memory and latency when truncating terminal text ([#135918](https://github.com/openclaw/openclaw/pull/135918)).
+- fix: reuse console styles and handle inherited subsystem names ([#135932](https://github.com/openclaw/openclaw/pull/135932)). Thanks @steipete.
+- refactor: keep Gateway session metadata reads lightweight ([#135976](https://github.com/openclaw/openclaw/pull/135976)).
+- fix(worktrees): stop rejecting sessions at the checkout count limit ([#135989](https://github.com/openclaw/openclaw/pull/135989)). Thanks @steipete.
+- fix: keep read-only diagnostics off SQLite writer lifecycle ([#136010](https://github.com/openclaw/openclaw/pull/136010)). Thanks @obviyus, @Grynn.
+- improve: avoid repeated work when formatting console logs ([#136028](https://github.com/openclaw/openclaw/pull/136028)).
+- fix: release completed log payloads during slow writes ([#136030](https://github.com/openclaw/openclaw/pull/136030)). Thanks @steipete.
+- perf(agents): speed up concurrent final-answer streaming ([#136041](https://github.com/openclaw/openclaw/pull/136041)).
+- fix: preserve console trace stacks without duplicate errors ([#136066](https://github.com/openclaw/openclaw/pull/136066)).
+- fix(cli): use Gateway ages and clean up heartbeat status ([#136093](https://github.com/openclaw/openclaw/pull/136093)). Thanks @jeffrey4341.
+- fix(gateway): bound retained Control UI asset memory ([#136108](https://github.com/openclaw/openclaw/pull/136108)). Thanks @vincentkoc.
+- fix(exec): reduce cold-start delays for shell commands ([#136124](https://github.com/openclaw/openclaw/pull/136124)). Thanks @steipete.
+- improve(gateway): reuse verified metadata during startup ([#136141](https://github.com/openclaw/openclaw/pull/136141)). Thanks @steipete.
+- improve(agents): reduce overhead while streaming long replies ([#136180](https://github.com/openclaw/openclaw/pull/136180)).
+- perf(ui): load side panel, workboard chip, and Lobsterdex styles with their owners ([#136186](https://github.com/openclaw/openclaw/pull/136186)). Thanks @steipete.
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Other Bug Fixes
+
+The long tail in this release is mostly about preserving the real state of work through errors, timeouts, retries, reconnects, and recovery. Gateway startup remains responsive under load, interrupted messages stay in agent context after restart, CLI-backed child results resume without replaying completed output, and failed cloud-session cleanup stays visible and retryable.
+
+<AccordionGroup>
+
+<Accordion title="Recovery that keeps the original result intact">
+
+Focused fixes cover session ordering, command exit status, attachment names and text, node selection, archive safety, tool-policy guidance, status and usage reporting, shutdown races, malformed provider responses, and bounded diagnostics. The common result is smaller but important. A failure is less likely to erase the useful result, claim success, target a default silently, or leave the next attempt stuck behind state that should already be finished.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- fix(plugins): report complete and accurate config errors ([#93842](https://github.com/openclaw/openclaw/pull/93842)). Thanks @bladin.
+- fix(gateway): honor Accept media-range precedence ([#118197](https://github.com/openclaw/openclaw/pull/118197)). Thanks @peterolkhov.
+- fix(gateway): reject invalid utcOffset in usage date interpretation ([#124568](https://github.com/openclaw/openclaw/pull/124568)). Thanks @zyw02.
+- fix(auto-reply): unauthorized native /compact returns no response ([#131408](https://github.com/openclaw/openclaw/pull/131408)). Thanks @igs-rogenlo.
+- fix(cli): emit the JSON failure envelope for mcp --json error paths ([#132379](https://github.com/openclaw/openclaw/pull/132379)). Thanks @wangmiao0668000666.
+- fix(agents): honor static denies in profile warnings ([#132623](https://github.com/openclaw/openclaw/pull/132623)). Thanks @sunlit-deng, @shbernal, @SuperMarioYL.
+- fix(agents): report discarded search stderr ([#132627](https://github.com/openclaw/openclaw/pull/132627)). Thanks @Alix-007, @gustav-bliss.
+- fix: status loses context usage after tool-only turns ([#134634](https://github.com/openclaw/openclaw/pull/134634)). Thanks @goslingmanagment, @dmsrg399.
+- fix(infra): keep presence bounded under entry pressure ([#134740](https://github.com/openclaw/openclaw/pull/134740)). Thanks @lzhan011.
+- fix(cli): reject a blank --session-id or --session-key instead of ignoring it ([#134797](https://github.com/openclaw/openclaw/pull/134797)). Thanks @marmar9615-cloud.
+- fix(buzz): retain lowest-id replaceable events on timestamp ties ([#134861](https://github.com/openclaw/openclaw/pull/134861)). Thanks @vincentkoc.
+- fix(status): show delivery queue warnings in detailed reports ([#134889](https://github.com/openclaw/openclaw/pull/134889)). Thanks @Lendersmark.
+- fix: avoid duplicate Git work during concurrent session starts ([#134912](https://github.com/openclaw/openclaw/pull/134912)).
+- fix(agents): settle yielded CLI session spawns ([#134974](https://github.com/openclaw/openclaw/pull/134974)). Thanks @VACInc, @aoclaw-glitch.
+- perf: release superseded channel avatar buffers ([#134978](https://github.com/openclaw/openclaw/pull/134978)).
+- fix(gateway): retain catalog runtime during session creation ([#135048](https://github.com/openclaw/openclaw/pull/135048)).
+- improve(media-core): drop "." and ".." from basenameFromAnyPath ([#135135](https://github.com/openclaw/openclaw/pull/135135)). Thanks @arpe1618.
+- fix(media): recognize UTF-8 attachments across sniff boundaries ([#135227](https://github.com/openclaw/openclaw/pull/135227)).
+- fix(media): preserve attachment types when streamed chunks are reused ([#135232](https://github.com/openclaw/openclaw/pull/135232)).
+- fix(cli): keep agent exec run errors when cleanup fails ([#135273](https://github.com/openclaw/openclaw/pull/135273)). Thanks @SebTardif.
+- fix(infra): ssh tunnel listener timeout no longer affected by clock skew ([#135281](https://github.com/openclaw/openclaw/pull/135281)). Thanks @xialonglee.
+- fix(gateway): show actual session-observer failure causes instead of empty error objects ([#135337](https://github.com/openclaw/openclaw/pull/135337)). Thanks @LiuwqGit, @Cobblestone-Digital1.
+- fix(snapshot): preserve Git backup failure diagnostics ([#135455](https://github.com/openclaw/openclaw/pull/135455)). Thanks @ly85206559, @obviyus.
+- fix: keep cloud sessions stopped and surface cleanup failures ([#135583](https://github.com/openclaw/openclaw/pull/135583)).
+- fix(sessions): reject a blank --store instead of selecting the default store ([#135742](https://github.com/openclaw/openclaw/pull/135742)). Thanks @marmar9615-cloud, @obviyus.
+- fix(logging): read the active file for configured log tails ([#135769](https://github.com/openclaw/openclaw/pull/135769)).
+- fix(gateway): stop reporting wait deadlines as Gateway draining ([#135797](https://github.com/openclaw/openclaw/pull/135797)).
+- fix(infra): drop empty PATHEXT entries from Windows extension lookup ([#135807](https://github.com/openclaw/openclaw/pull/135807)). Thanks @teddytennant.
+- fix(agents): report current failover counters in console logs ([#135844](https://github.com/openclaw/openclaw/pull/135844)).
+- fix(agents): record empty subagent completion ([#135846](https://github.com/openclaw/openclaw/pull/135846)). Thanks @jakestenger, @louisfy, @obviyus.
+- fix(cli): reject blank dead-letter account selectors ([#135848](https://github.com/openclaw/openclaw/pull/135848)). Thanks @masatohoshino, @obviyus.
+- fix(pr): restore retry guidance for GraphQL quota error variants ([#135873](https://github.com/openclaw/openclaw/pull/135873)).
+- fix(media): preserve inferred text and promptly reject downloads ([#135928](https://github.com/openclaw/openclaw/pull/135928)).
+- fix: keep recently connected nodes in list age filters ([#135936](https://github.com/openclaw/openclaw/pull/135936)).
+- fix(agents): keep interrupted user message in context after restart recovery ([#136023](https://github.com/openclaw/openclaw/pull/136023)). Thanks @leilei3167, @obviyus, @yetval.
+- fix(subagents): settle rejected requester wake ([#136033](https://github.com/openclaw/openclaw/pull/136033)). Thanks @obviyus, @Grynn.
+- fix(process): bind lifecycle and output activity to each admission ([#136053](https://github.com/openclaw/openclaw/pull/136053)). Thanks @steipete.
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+## Maintainer and Internal Changes
+
+This release also carries a large internal pass over test isolation, fixture cleanup, generated localization data, build caching, package verification, plugin publication, protocol typing, and the release pipeline itself. These changes do not add a separate user workflow, but they make the work used to validate and ship OpenClaw faster and harder to mistake for a pass when required evidence is missing.
+
+<AccordionGroup>
+
+<Accordion title="Build, test, and release foundations">
+
+CI distributes more work, reuses safe immutable inputs, preserves failed-attempt evidence, and reports skipped or crashed validation as a real failure. Native packaging, QA Lab, Testbox, plugin security scans, docs translation, localization refreshes, and repository maintenance receive similarly focused corrections and consolidation, with user-visible behavior intentionally unchanged unless another product section says otherwise.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Complete change list**
+
+- ci: skip docs sync & translate-trigger workflows in forks ([#70002](https://github.com/openclaw/openclaw/pull/70002)). Thanks @xudaiyanzi.
+- fix(scripts): stabilize Vitest shard timing keys ([#120105](https://github.com/openclaw/openclaw/pull/120105)). Thanks @qingminglong, @vincentkoc.
+- fix(ci): reject invalid shard plan concurrency values ([#120161](https://github.com/openclaw/openclaw/pull/120161)). Thanks @qingminglong.
+- fix(ci): reject invalid changed-scope arguments ([#120913](https://github.com/openclaw/openclaw/pull/120913)). Thanks @qingminglong.
+- [AI-assisted] docs(oauth): point login-flow pointer at the real oauth homes ([#125791](https://github.com/openclaw/openclaw/pull/125791)). Thanks @santhiprakash.
+- fix(release): isolate plugin security scanning ([#126887](https://github.com/openclaw/openclaw/pull/126887)). Thanks @vincentkoc, @RomneyDa.
+- fix: prevent Barnacle from closing core skill runtime PRs ([#131619](https://github.com/openclaw/openclaw/pull/131619)). Thanks @MertBasar0, @shojikumaru.
+- test(cron): cover stale-delivery one-shot retention (#131491) ([#131691](https://github.com/openclaw/openclaw/pull/131691)). Thanks @LiuwqGit, @steipete.
+- test(skills): use platform-safe symlink type in workspace-load fixtures ([#132199](https://github.com/openclaw/openclaw/pull/132199)). Thanks @africoding, @aniruddhaadak80, @Patrick-Erichsen.
+- fix(docs): ignore links inside fenced code ([#132727](https://github.com/openclaw/openclaw/pull/132727)). Thanks @qingminglong.
+- fix(ci): keep recent timings on main pushes ([#133778](https://github.com/openclaw/openclaw/pull/133778)). Thanks @qingminglong.
+- test(ci): await checkout fixture cleanup ([#133897](https://github.com/openclaw/openclaw/pull/133897)). Thanks @RomneyDa.
+- refactor(channels): simplify configured-channel presence ([#134362](https://github.com/openclaw/openclaw/pull/134362)).
+- test(release): scope Plugin SDK temp cleanup ([#134443](https://github.com/openclaw/openclaw/pull/134443)). Thanks @RomneyDa.
+- refactor(status): consolidate report formatting ownership ([#134466](https://github.com/openclaw/openclaw/pull/134466)). Thanks @steipete.
+- fix(release): use a frozen installer update baseline ([#134519](https://github.com/openclaw/openclaw/pull/134519)). Thanks @RomneyDa.
+- test(image): cover model selection through execution ([#134536](https://github.com/openclaw/openclaw/pull/134536)).
+- test(music): remove redundant registration coverage ([#134548](https://github.com/openclaw/openclaw/pull/134548)).
+- perf(plugins): transfer privately built metadata owner maps ([#134581](https://github.com/openclaw/openclaw/pull/134581)). Thanks @steipete.
+- refactor(browser): consolidate storage mutation parsing ([#134585](https://github.com/openclaw/openclaw/pull/134585)). Thanks @steipete.
+- perf(ci): reuse setup and declaration work ([#134593](https://github.com/openclaw/openclaw/pull/134593)).
+- refactor: keep Doctor plugin contracts lightweight ([#134601](https://github.com/openclaw/openclaw/pull/134601)).
+- refactor(process): consolidate command diagnostic tails ([#134607](https://github.com/openclaw/openclaw/pull/134607)). Thanks @steipete, @vincentkoc.
+- chore: prune Android screenshot source mirrors ([#134613](https://github.com/openclaw/openclaw/pull/134613)). Thanks @RomneyDa.
+- chore: prune live CLI backend source mirrors ([#134614](https://github.com/openclaw/openclaw/pull/134614)). Thanks @RomneyDa.
+- chore: remove redundant system-agent source mirror ([#134615](https://github.com/openclaw/openclaw/pull/134615)). Thanks @RomneyDa.
+- refactor(infra): share path existence policy ([#134630](https://github.com/openclaw/openclaw/pull/134630)). Thanks @vincentkoc.
+- refactor(context): reuse PNG encoder for context maps ([#134632](https://github.com/openclaw/openclaw/pull/134632)).
+- test(ui): remove duplicate task detail reset case ([#134637](https://github.com/openclaw/openclaw/pull/134637)).
+- test(gateway): share title-retention disk fixtures across isolated readers ([#134642](https://github.com/openclaw/openclaw/pull/134642)).
+- refactor(googlechat): share approval card text escaping ([#134643](https://github.com/openclaw/openclaw/pull/134643)). Thanks @vincentkoc.
+- chore(ui): refresh control ui locales ([#134645](https://github.com/openclaw/openclaw/pull/134645)).
+- test(tlon): exercise sender roles through the real monitor ([#134646](https://github.com/openclaw/openclaw/pull/134646)). Thanks @steipete.
+- refactor(paths): share canonical realpath fallback ([#134650](https://github.com/openclaw/openclaw/pull/134650)). Thanks @vincentkoc.
+- test(reef): signal inbox fixture entry and join cleanup ([#134652](https://github.com/openclaw/openclaw/pull/134652)). Thanks @steipete.
+- test(raft): observe bridge startup without polling ([#134656](https://github.com/openclaw/openclaw/pull/134656)).
+- test(googlechat): share bounded response fixtures and remove duplicate coverage ([#134661](https://github.com/openclaw/openclaw/pull/134661)).
+- refactor(plugins): centralize release cohort convergence ([#134664](https://github.com/openclaw/openclaw/pull/134664)). Thanks @jalehman, @r0ckvn, @Finn763.
+- fix(lint): report final failures after owned child cleanup ([#134668](https://github.com/openclaw/openclaw/pull/134668)).
+- test(ui): establish pointer state before clearing submenu highlight ([#134669](https://github.com/openclaw/openclaw/pull/134669)). Thanks @steipete.
+- test(realtime): await WebSocket receive callbacks directly ([#134671](https://github.com/openclaw/openclaw/pull/134671)).
+- chore(ui): refresh control ui locales ([#134672](https://github.com/openclaw/openclaw/pull/134672)).
+- perf(gateway): reduce repeated turn preparation work ([#134673](https://github.com/openclaw/openclaw/pull/134673)).
+- test(ui): remove duplicate thinking normalization case ([#134674](https://github.com/openclaw/openclaw/pull/134674)). Thanks @steipete.
+- test(doctor): load pairing diagnostics once per suite ([#134675](https://github.com/openclaw/openclaw/pull/134675)).
+- test(media): skip file setup for supplied playback probes ([#134676](https://github.com/openclaw/openclaw/pull/134676)).
+- fix(ui): keep mock preview avatars off the operator Gateway ([#134686](https://github.com/openclaw/openclaw/pull/134686)).
+- fix(test): preserve shard crash exit codes and failure reports ([#134688](https://github.com/openclaw/openclaw/pull/134688)).
+- refactor(policy): share evidence finding builder ([#134691](https://github.com/openclaw/openclaw/pull/134691)). Thanks @vincentkoc.
+- refactor: reuse selected auth snapshot paths ([#134693](https://github.com/openclaw/openclaw/pull/134693)).
+- improve: speed up full release verification ([#134694](https://github.com/openclaw/openclaw/pull/134694)).
+- refactor(delivery): share raw target-field guard ([#134695](https://github.com/openclaw/openclaw/pull/134695)). Thanks @vincentkoc.
+- test(macos): synchronize worker backpressure fixture ([#134702](https://github.com/openclaw/openclaw/pull/134702)). Thanks @steipete.
+- test(infra): reuse the dev-branch filesystem fixture ([#134707](https://github.com/openclaw/openclaw/pull/134707)).
+- fix(qa): reject forked-context passes without child history ([#134708](https://github.com/openclaw/openclaw/pull/134708)). Thanks @RomneyDa.
+- test(cli): reuse startup owners across each suite ([#134720](https://github.com/openclaw/openclaw/pull/134720)).
+- fix(ci): keep active Testbox commands alive past idle timeout ([#134725](https://github.com/openclaw/openclaw/pull/134725)).
+- test(browser): reuse immutable native-host fixtures ([#134728](https://github.com/openclaw/openclaw/pull/134728)).
+- test(media): share Rastermill metadata setup ([#134733](https://github.com/openclaw/openclaw/pull/134733)).
+- perf(build): reuse compiler-consumed declaration inputs ([#134734](https://github.com/openclaw/openclaw/pull/134734)).
+- fix(ci): provision Go for docs i18n Testbox ([#134745](https://github.com/openclaw/openclaw/pull/134745)). Thanks @vincentkoc.
+- perf(release): shorten full verification critical paths ([#134746](https://github.com/openclaw/openclaw/pull/134746)). Thanks @vincentkoc.
+- test(infra): scope Windows encoding module resets ([#134747](https://github.com/openclaw/openclaw/pull/134747)).
+- test(plugins): coordinate property probes without sleeps ([#134754](https://github.com/openclaw/openclaw/pull/134754)).
+- refactor(scripts): share SQLite reliability stderr formatting ([#134762](https://github.com/openclaw/openclaw/pull/134762)). Thanks @vincentkoc.
+- test(plugin-sdk): reuse QA facade graphs within suites ([#134763](https://github.com/openclaw/openclaw/pull/134763)). Thanks @steipete.
+- fix(pr): recover merges invoked from another checkout ([#134778](https://github.com/openclaw/openclaw/pull/134778)).
+- fix(release): preserve blockers across child retry job URLs ([#134782](https://github.com/openclaw/openclaw/pull/134782)).
+- test(agents): reuse the native extension loader owner ([#134792](https://github.com/openclaw/openclaw/pull/134792)). Thanks @steipete.
+- perf(test): avoid packaging checks for native Swift test edits ([#134793](https://github.com/openclaw/openclaw/pull/134793)).
+- test(release): reuse immutable registry fixture archives ([#134804](https://github.com/openclaw/openclaw/pull/134804)).
+- refactor(test): centralize Vitest include selection ([#134805](https://github.com/openclaw/openclaw/pull/134805)). Thanks @vincentkoc.
+- test(release): use a lightweight producer metadata fixture ([#134809](https://github.com/openclaw/openclaw/pull/134809)).
+- test(perf): consolidate startup parser CLI coverage ([#134811](https://github.com/openclaw/openclaw/pull/134811)). Thanks @steipete.
+- fix(release): preserve original attempts in reused validation ([#134820](https://github.com/openclaw/openclaw/pull/134820)).
+- refactor(scripts): share spawn output coercion ([#134821](https://github.com/openclaw/openclaw/pull/134821)). Thanks @vincentkoc.
+- chore(ui): refresh control ui locales ([#134822](https://github.com/openclaw/openclaw/pull/134822)).
+- perf(ci): shorten release verification tails ([#134824](https://github.com/openclaw/openclaw/pull/134824)).
+- test(hooks): reuse the Gmail diagnostics module graph ([#134825](https://github.com/openclaw/openclaw/pull/134825)).
+- fix(ci): native Windows Testbox rejects its session SSH key ([#134828](https://github.com/openclaw/openclaw/pull/134828)).
+- fix(packaging): preserve package markers and clean up smoke layouts ([#134835](https://github.com/openclaw/openclaw/pull/134835)). Thanks @steipete.
+- refactor(ui): unify mock preview state and request handling ([#134836](https://github.com/openclaw/openclaw/pull/134836)).
+- test(mac): skip discarded native fixture copies ([#134840](https://github.com/openclaw/openclaw/pull/134840)).
+- refactor: remove duplicated Claude model checks ([#134842](https://github.com/openclaw/openclaw/pull/134842)). Thanks @steipete.
+- refactor(memory-wiki): share person-page classification ([#134844](https://github.com/openclaw/openclaw/pull/134844)). Thanks @vincentkoc.
+- refactor(doctor): simplify agent migration traversal ([#134845](https://github.com/openclaw/openclaw/pull/134845)).
+- perf(ci): partition Mac tests and admit long jobs first ([#134847](https://github.com/openclaw/openclaw/pull/134847)). Thanks @vincentkoc.
+- fix(test): report one final failure per invocation ([#134850](https://github.com/openclaw/openclaw/pull/134850)).
+- test(mattermost): simplify retry and timeout fixtures ([#134852](https://github.com/openclaw/openclaw/pull/134852)).
+- test(macos): synchronize pending disable coverage ([#134856](https://github.com/openclaw/openclaw/pull/134856)). Thanks @vincentkoc.
+- fix(macos): keep worker packaging on the destination volume ([#134857](https://github.com/openclaw/openclaw/pull/134857)). Thanks @steipete.
+- test(whatsapp): own auth fixture cleanup and remove duplicate cases ([#134863](https://github.com/openclaw/openclaw/pull/134863)).
+- fix(release): restore evidence reuse and reconcile advisory ranges ([#134870](https://github.com/openclaw/openclaw/pull/134870)).
+- chore(ui): refresh control UI boot manifest ([#134876](https://github.com/openclaw/openclaw/pull/134876)). Thanks @vincentkoc.
+- docs(release): check production UI build before full validation ([#134877](https://github.com/openclaw/openclaw/pull/134877)).
+- test(video): require SSRF denial in transport cases ([#134879](https://github.com/openclaw/openclaw/pull/134879)).
+- test: remove redundant provider catalog setup ([#134881](https://github.com/openclaw/openclaw/pull/134881)).
+- chore(ui): refresh control ui locales ([#134882](https://github.com/openclaw/openclaw/pull/134882)).
+- test(channels): drive ingress poll windows with scoped clocks ([#134885](https://github.com/openclaw/openclaw/pull/134885)).
+- test(inworld): consolidate duplicate transport coverage ([#134894](https://github.com/openclaw/openclaw/pull/134894)).
+- refactor(migrate-hermes): share env reference normalization ([#134904](https://github.com/openclaw/openclaw/pull/134904)). Thanks @vincentkoc.
+- refactor(cli): consolidate hook requirement reports ([#134905](https://github.com/openclaw/openclaw/pull/134905)). Thanks @steipete.
+- refactor(terminal): consolidate table style metadata ([#134908](https://github.com/openclaw/openclaw/pull/134908)). Thanks @steipete.
+- test(foundry): coordinate concurrent refreshes without sleeps ([#134909](https://github.com/openclaw/openclaw/pull/134909)).
+- refactor(markdown): share span clipping logic ([#134910](https://github.com/openclaw/openclaw/pull/134910)). Thanks @steipete.
+- refactor: reduce repeated work during turn preparation ([#134921](https://github.com/openclaw/openclaw/pull/134921)). Thanks @steipete.
+- fix(maintainers): require completed ClawSweeper review ([#134926](https://github.com/openclaw/openclaw/pull/134926)). Thanks @vincentkoc.
+- fix(ci): keep native Windows Testbox alive during SSH ([#134927](https://github.com/openclaw/openclaw/pull/134927)).
+- test(sandbox): reuse SSH upload fixtures and await child startup ([#134928](https://github.com/openclaw/openclaw/pull/134928)).
+- docs: update v2026.8.1 human-readable release notes ([#134929](https://github.com/openclaw/openclaw/pull/134929)). Thanks @hannesrudolph.
+- test(agents): await ask_user RPC startup without polling ([#134936](https://github.com/openclaw/openclaw/pull/134936)).
+- fix(macos): bind exec approval fixtures to the canonical cwd owner ([#134937](https://github.com/openclaw/openclaw/pull/134937)).
+- fix(qa): preserve Doctor health discovery in packaged fixtures ([#134944](https://github.com/openclaw/openclaw/pull/134944)).
+- refactor(channels): share lazy runtime forwarding ([#134945](https://github.com/openclaw/openclaw/pull/134945)).
+- refactor(status): share terminal report context ([#134946](https://github.com/openclaw/openclaw/pull/134946)).
+- refactor(diagnostics): remove duplicate metric inventory ([#134947](https://github.com/openclaw/openclaw/pull/134947)).
+- refactor(qa): derive suite types from their canonical declarations ([#134948](https://github.com/openclaw/openclaw/pull/134948)).
+- test(realtime): reuse canonical terminal fixture promise helpers ([#134949](https://github.com/openclaw/openclaw/pull/134949)).
+- chore(ui): refresh control ui locales ([#134950](https://github.com/openclaw/openclaw/pull/134950)).
+- refactor(browser): share tab id validation ([#134958](https://github.com/openclaw/openclaw/pull/134958)). Thanks @vincentkoc.
+- test(oc-path): own CLI fixtures and registration cleanup ([#134961](https://github.com/openclaw/openclaw/pull/134961)).
+- refactor(ui): share markdown link boundary checks ([#134962](https://github.com/openclaw/openclaw/pull/134962)). Thanks @vincentkoc.
+- refactor(line): share media and control card construction ([#134964](https://github.com/openclaw/openclaw/pull/134964)).
+- refactor(markdown): share token style and block transitions ([#134965](https://github.com/openclaw/openclaw/pull/134965)).
+- ci: shorten beta release qualification ([#134966](https://github.com/openclaw/openclaw/pull/134966)).
+- fix(macos): give shell timeout fixtures a startup-tolerant deadline ([#134969](https://github.com/openclaw/openclaw/pull/134969)). Thanks @steipete.
+- test(msteams): remove copied store and own state fixture cleanup ([#134973](https://github.com/openclaw/openclaw/pull/134973)).
+- refactor(mattermost): share wildcard callback host check ([#134977](https://github.com/openclaw/openclaw/pull/134977)). Thanks @vincentkoc.
+- perf(logging): avoid intermediate timestamp objects ([#134979](https://github.com/openclaw/openclaw/pull/134979)).
+- test(google-meet): unify repeated CLI output cases ([#134981](https://github.com/openclaw/openclaw/pull/134981)).
+- fix(ci): route Swift metadata changes to their owner tests ([#134983](https://github.com/openclaw/openclaw/pull/134983)). Thanks @steipete.
+- refactor(process): reuse canonical tool result envelopes ([#134984](https://github.com/openclaw/openclaw/pull/134984)). Thanks @steipete.
+- test(install): reuse sealed payload across corruption cases ([#134986](https://github.com/openclaw/openclaw/pull/134986)).
+- perf: reuse validators for rebuilt tool schemas ([#134988](https://github.com/openclaw/openclaw/pull/134988)).
+- test(install): use shell command fixtures for baseline selection ([#134991](https://github.com/openclaw/openclaw/pull/134991)).
+- refactor(memory-wiki): inline gateway source sync ([#134992](https://github.com/openclaw/openclaw/pull/134992)). Thanks @vincentkoc.
+- perf: release superseded message-tool catalogs ([#134998](https://github.com/openclaw/openclaw/pull/134998)).
+- test(ui): use native CRC32 for the large paste fixture ([#135001](https://github.com/openclaw/openclaw/pull/135001)).
+- test(infra): consolidate abortable sleep timing coverage ([#135004](https://github.com/openclaw/openclaw/pull/135004)).
+- refactor(feishu): share API success assertion ([#135005](https://github.com/openclaw/openclaw/pull/135005)). Thanks @vincentkoc.
+- perf(infra): reuse the current process start identity ([#135007](https://github.com/openclaw/openclaw/pull/135007)).
+- test(pr): scope Git identity to maintenance fixture lifetime ([#135011](https://github.com/openclaw/openclaw/pull/135011)). Thanks @steipete.
+- refactor(matrix): remove runtime getter aliases ([#135012](https://github.com/openclaw/openclaw/pull/135012)). Thanks @vincentkoc.
+- fix(release): continue advisory checks after resource-specific denials ([#135015](https://github.com/openclaw/openclaw/pull/135015)).
+- test(ci): assert retry delay without waiting in timing fixture ([#135020](https://github.com/openclaw/openclaw/pull/135020)). Thanks @steipete.
+- fix(ui): prevent silent E2E builds from timing out ([#135025](https://github.com/openclaw/openclaw/pull/135025)).
+- fix(qa): preserve nested suite ownership and share progress transitions ([#135027](https://github.com/openclaw/openclaw/pull/135027)).
+- refactor(heartbeat): centralize skipped stage outcomes ([#135029](https://github.com/openclaw/openclaw/pull/135029)). Thanks @steipete.
+- refactor(feishu): centralize document table patch actions ([#135030](https://github.com/openclaw/openclaw/pull/135030)).
+- refactor(android): unify Talk directive alias parsing ([#135033](https://github.com/openclaw/openclaw/pull/135033)).
+- perf(agents): reuse normalized stream tool-call facts ([#135034](https://github.com/openclaw/openclaw/pull/135034)).
+- ci: shorten command test jobs and avoid unused runtime builds ([#135039](https://github.com/openclaw/openclaw/pull/135039)).
+- refactor(memory-lancedb): reuse canonical text result envelopes ([#135043](https://github.com/openclaw/openclaw/pull/135043)).
+- refactor(commands): share structured action argument formatting ([#135047](https://github.com/openclaw/openclaw/pull/135047)).
+- chore(ui): refresh control ui locales ([#135050](https://github.com/openclaw/openclaw/pull/135050)).
+- refactor(slack): share channel list page request ([#135059](https://github.com/openclaw/openclaw/pull/135059)). Thanks @vincentkoc.
+- refactor(discord): share concrete select menu construction ([#135064](https://github.com/openclaw/openclaw/pull/135064)).
+- refactor(feishu): unify Drive comment preparation and paging ([#135065](https://github.com/openclaw/openclaw/pull/135065)).
+- refactor(memory-wiki): share tool registration and result adapters ([#135066](https://github.com/openclaw/openclaw/pull/135066)).
+- refactor(slack): share rich-text fallback rendering ([#135072](https://github.com/openclaw/openclaw/pull/135072)). Thanks @steipete.
+- test: isolate static provider catalog assertions ([#135074](https://github.com/openclaw/openclaw/pull/135074)).
+- fix(ci): settle draft setup before measuring composer renders ([#135075](https://github.com/openclaw/openclaw/pull/135075)). Thanks @steipete.
+- fix(ci): report full release decisions sooner ([#135076](https://github.com/openclaw/openclaw/pull/135076)).
+- refactor(qa): unify suite summary verdict accounting ([#135078](https://github.com/openclaw/openclaw/pull/135078)). Thanks @steipete.
+- refactor(qa): share mock assistant streaming event construction ([#135090](https://github.com/openclaw/openclaw/pull/135090)). Thanks @steipete.
+- perf(models): avoid redundant catalog sanitization ([#135091](https://github.com/openclaw/openclaw/pull/135091)).
+- refactor(firecrawl): consolidate executable search providers ([#135099](https://github.com/openclaw/openclaw/pull/135099)).
+- refactor(whatsapp): share text and media dispatch preparation ([#135100](https://github.com/openclaw/openclaw/pull/135100)).
+- test(ui): serve static avatar fixtures without screenshots ([#135101](https://github.com/openclaw/openclaw/pull/135101)).
+- perf(pdf): avoid unused document encodings and buffer copies ([#135107](https://github.com/openclaw/openclaw/pull/135107)).
+- ci: run Swift release builds and tests in parallel ([#135108](https://github.com/openclaw/openclaw/pull/135108)).
+- refactor(deps): centralize dependency spec policy ([#135110](https://github.com/openclaw/openclaw/pull/135110)). Thanks @vincentkoc.
+- fix(release): fail closed on unrelated Docker not-found errors ([#135113](https://github.com/openclaw/openclaw/pull/135113)). Thanks @vincentkoc.
+- perf(browser): index bounded request history by ID ([#135116](https://github.com/openclaw/openclaw/pull/135116)).
+- test: retain bounded live provider failure diagnostics ([#135120](https://github.com/openclaw/openclaw/pull/135120)). Thanks @steipete.
+- perf(gateway): omit redundant canonical snapshot aliases ([#135121](https://github.com/openclaw/openclaw/pull/135121)).
+- fix(ci): stop skipping lint on changed root tests ([#135123](https://github.com/openclaw/openclaw/pull/135123)).
+- refactor(talk): share Apple voice configuration helpers ([#135125](https://github.com/openclaw/openclaw/pull/135125)).
+- refactor(policy): share channel deny rule guard ([#135126](https://github.com/openclaw/openclaw/pull/135126)). Thanks @vincentkoc.
+- ci: skip full history for release artifact consumers ([#135128](https://github.com/openclaw/openclaw/pull/135128)).
+- docs: defer changelog edits until release time ([#135136](https://github.com/openclaw/openclaw/pull/135136)).
+- test: preserve update fixture plugin and temporary-file ownership ([#135141](https://github.com/openclaw/openclaw/pull/135141)).
+- refactor(schema): consolidate JSON Schema child traversal ([#135145](https://github.com/openclaw/openclaw/pull/135145)).
+- test(doctor): exit memory probe after result flush ([#135146](https://github.com/openclaw/openclaw/pull/135146)). Thanks @vincentkoc.
+- refactor(agents): remove dead private tool-warning state ([#135148](https://github.com/openclaw/openclaw/pull/135148)).
+- refactor(release): share JSON key sorter ([#135157](https://github.com/openclaw/openclaw/pull/135157)). Thanks @vincentkoc.
+- refactor(qa): share evidence builder execution context ([#135158](https://github.com/openclaw/openclaw/pull/135158)). Thanks @steipete.
+- refactor(perplexity): unify search runtime configuration resolution ([#135159](https://github.com/openclaw/openclaw/pull/135159)).
+- refactor(qa): share Mantis report rendering and summary fields ([#135160](https://github.com/openclaw/openclaw/pull/135160)).
+- test(llama-cpp): avoid hard-link archive fixture races ([#135165](https://github.com/openclaw/openclaw/pull/135165)).
+- perf(plugins): build only the requested provider index ([#135169](https://github.com/openclaw/openclaw/pull/135169)).
+- ci: isolate source-launching command tests ([#135170](https://github.com/openclaw/openclaw/pull/135170)). Thanks @steipete.
+- perf(state): reduce repeated schema reads during database opens ([#135172](https://github.com/openclaw/openclaw/pull/135172)).
+- refactor(cron): derive output types from protocol schema ([#135174](https://github.com/openclaw/openclaw/pull/135174)).
+- chore(ui): refresh control ui locales ([#135201](https://github.com/openclaw/openclaw/pull/135201)).
+- perf: skip empty tool-result planning branches ([#135204](https://github.com/openclaw/openclaw/pull/135204)). Thanks @steipete.
+- refactor(packaging): reuse canonical Docker CLI flag parser ([#135207](https://github.com/openclaw/openclaw/pull/135207)). Thanks @steipete.
+- perf(replies): reduce work when preparing explicit replies ([#135208](https://github.com/openclaw/openclaw/pull/135208)).
+- perf: reuse accepted tool-result transcript snapshots ([#135220](https://github.com/openclaw/openclaw/pull/135220)).
+- ci: isolate artifact writers and overlap verification ([#135226](https://github.com/openclaw/openclaw/pull/135226)). Thanks @steipete.
+- refactor(ios): carry Watch inbound events through one owner ([#135235](https://github.com/openclaw/openclaw/pull/135235)). Thanks @steipete.
+- fix(release): publish frozen 2026.8.2 with approved Codex pin ([#135246](https://github.com/openclaw/openclaw/pull/135246)). Thanks @steipete.
+- refactor(twitch): consolidate inbound and outbound sending ([#135254](https://github.com/openclaw/openclaw/pull/135254)).
+- refactor(google-meet): derive shared meeting types from the canonical owner ([#135257](https://github.com/openclaw/openclaw/pull/135257)).
+- refactor(msteams): share bounded Graph pagination ([#135258](https://github.com/openclaw/openclaw/pull/135258)).
+- refactor(openai): avoid redundant image auth lookup ([#135259](https://github.com/openclaw/openclaw/pull/135259)). Thanks @steipete.
+- refactor(mobile): share version script argument parsing ([#135264](https://github.com/openclaw/openclaw/pull/135264)).
+- refactor(ui): reuse protocol-owned model and checkpoint types ([#135265](https://github.com/openclaw/openclaw/pull/135265)).
+- ci: preserve compiler caches across helper checkouts ([#135269](https://github.com/openclaw/openclaw/pull/135269)).
+- refactor(testing): share grouped report argument parsing ([#135271](https://github.com/openclaw/openclaw/pull/135271)). Thanks @steipete.
+- refactor(plugins): remove unused web runtime facades ([#135274](https://github.com/openclaw/openclaw/pull/135274)).
+- refactor(gateway): derive session projections from protocol types ([#135275](https://github.com/openclaw/openclaw/pull/135275)).
+- refactor(claws): centralize failure output at the CLI owner ([#135284](https://github.com/openclaw/openclaw/pull/135284)).
+- refactor(codex): reuse command display sanitization ([#135285](https://github.com/openclaw/openclaw/pull/135285)). Thanks @steipete.
+- ci: bind shard timings to test membership ([#135288](https://github.com/openclaw/openclaw/pull/135288)).
+- fix: publish verified plugin npm artifacts without rebuilding ([#135289](https://github.com/openclaw/openclaw/pull/135289)).
+- refactor(build): compose shared profile phases ([#135294](https://github.com/openclaw/openclaw/pull/135294)).
+- ci: distribute lint and reuse native SDK declarations ([#135302](https://github.com/openclaw/openclaw/pull/135302)).
+- refactor(gateway): prepare Control UI encoding preferences once ([#135304](https://github.com/openclaw/openclaw/pull/135304)).
+- refactor(plugins): share effective catalog model projection ([#135306](https://github.com/openclaw/openclaw/pull/135306)). Thanks @steipete.
+- refactor(media): avoid PNG checksum buffer copies ([#135313](https://github.com/openclaw/openclaw/pull/135313)).
+- refactor(policy): remove unused CLI runtime plumbing ([#135317](https://github.com/openclaw/openclaw/pull/135317)).
+- refactor(cli): share message payload projections ([#135319](https://github.com/openclaw/openclaw/pull/135319)). Thanks @steipete.
+- refactor(agents): release tool catalogs with their runs ([#135321](https://github.com/openclaw/openclaw/pull/135321)).
+- fix: unblock trusted plugin publication config loading ([#135323](https://github.com/openclaw/openclaw/pull/135323)).
+- refactor(qa): share standard live transport CLI composition ([#135325](https://github.com/openclaw/openclaw/pull/135325)). Thanks @steipete.
+- refactor(mattermost): remove duplicate native send flow ([#135336](https://github.com/openclaw/openclaw/pull/135336)).
+- Restore protocol declaration builds ([#135360](https://github.com/openclaw/openclaw/pull/135360)).
+- test(cua): synchronize transport and recording fixtures ([#135363](https://github.com/openclaw/openclaw/pull/135363)).
+- perf(release): shorten preflight and publication ([#135367](https://github.com/openclaw/openclaw/pull/135367)). Thanks @steipete.
+- fix: bind ClawHub publication source to the authorized commit ([#135368](https://github.com/openclaw/openclaw/pull/135368)).
+- refactor(agents): reuse MCP metadata during inventory reads ([#135369](https://github.com/openclaw/openclaw/pull/135369)).
+- refactor(logging): reduce work for ordinary log records ([#135375](https://github.com/openclaw/openclaw/pull/135375)).
+- refactor(media): centralize generic image hook ownership ([#135386](https://github.com/openclaw/openclaw/pull/135386)). Thanks @steipete.
+- perf(secrets): reuse prepared provider auth environment candidates ([#135390](https://github.com/openclaw/openclaw/pull/135390)).
+- refactor(agents): keep refusal display independent of runtime policy ([#135391](https://github.com/openclaw/openclaw/pull/135391)). Thanks @Marvinthebored, @obviyus.
+- refactor: simplify transcript reads and recovery state ([#135392](https://github.com/openclaw/openclaw/pull/135392)).
+- fix(pr): finish merge receipts when main advances ([#135396](https://github.com/openclaw/openclaw/pull/135396)).
+- refactor(http): avoid discarded body buffers ([#135405](https://github.com/openclaw/openclaw/pull/135405)).
+- fix(cli): make the auth-login test's isTTY override actually optional ([#135407](https://github.com/openclaw/openclaw/pull/135407)). Thanks @itsuzef.
+- refactor(text): avoid full-string encoding for bounded prefixes ([#135412](https://github.com/openclaw/openclaw/pull/135412)).
+- fix(plugins): detect native loading regressions in tests ([#135425](https://github.com/openclaw/openclaw/pull/135425)).
+- fix(test): keep test wrappers responsive during shutdown ([#135439](https://github.com/openclaw/openclaw/pull/135439)). Thanks @steipete.
+- ci: shorten preflight and rebalance isolated tooling ([#135440](https://github.com/openclaw/openclaw/pull/135440)).
+- perf(agents): avoid cloning credentials for presence checks ([#135464](https://github.com/openclaw/openclaw/pull/135464)). Thanks @steipete.
+- perf: reuse measured widths while wrapping terminal tables ([#135473](https://github.com/openclaw/openclaw/pull/135473)).
+- chore(ui): refresh control ui locales ([#135474](https://github.com/openclaw/openclaw/pull/135474)).
+- perf: avoid copying outbound node duplex fragments ([#135475](https://github.com/openclaw/openclaw/pull/135475)).
+- perf: reuse sorted ranges while rendering context maps ([#135476](https://github.com/openclaw/openclaw/pull/135476)).
+- perf: remove unused Gateway metadata scope hashing ([#135477](https://github.com/openclaw/openclaw/pull/135477)). Thanks @steipete.
+- fix: keep state-dir Gateway CI proof reliable under load ([#135495](https://github.com/openclaw/openclaw/pull/135495)). Thanks @lzhan011.
+- refactor(migrate): consolidate selection handling ([#135497](https://github.com/openclaw/openclaw/pull/135497)).
+- fix(pr): preserve ignored files and skip redundant prepare transitions ([#135500](https://github.com/openclaw/openclaw/pull/135500)).
+- fix(test): prevent concurrent macOS fixtures from starving child cleanup ([#135501](https://github.com/openclaw/openclaw/pull/135501)).
+- perf(security): avoid unnecessary Unicode marker folding ([#135514](https://github.com/openclaw/openclaw/pull/135514)).
+- chore(ui): refresh control ui locales ([#135529](https://github.com/openclaw/openclaw/pull/135529)).
+- ci: scope declaration caches to generator inputs ([#135559](https://github.com/openclaw/openclaw/pull/135559)).
+- test(infra): reuse commit-resolution setup ([#135560](https://github.com/openclaw/openclaw/pull/135560)).
+- fix: Docker upgrade survivor stops before package update ([#135561](https://github.com/openclaw/openclaw/pull/135561)). Thanks @fuller-stack-dev.
+- test(tooling): reuse packed artifact identity fixture ([#135572](https://github.com/openclaw/openclaw/pull/135572)).
+- test(node): reuse immutable worker bundle archive ([#135579](https://github.com/openclaw/openclaw/pull/135579)).
+- ci: refit shard weights within existing runner caps ([#135585](https://github.com/openclaw/openclaw/pull/135585)).
+- test(tooling): share immutable pnpm launcher fixtures ([#135586](https://github.com/openclaw/openclaw/pull/135586)).
+- test(cli): await version diagnostic completion ([#135594](https://github.com/openclaw/openclaw/pull/135594)).
+- docs: move v2026.8.1 beta note to footnote ([#135595](https://github.com/openclaw/openclaw/pull/135595)). Thanks @hannesrudolph.
+- refactor(plugins): simplify discovery, setup, and update reporting ([#135598](https://github.com/openclaw/openclaw/pull/135598)). Thanks @abacha, @Bloodis94, @Hansen1018.
+- fix(macos): resume notarization without rebuilding signed artifacts ([#135601](https://github.com/openclaw/openclaw/pull/135601)).
+- perf(cli): avoid materializing unused process output ([#135602](https://github.com/openclaw/openclaw/pull/135602)).
+- test(cli): consolidate root help fast-path coverage ([#135605](https://github.com/openclaw/openclaw/pull/135605)).
+- perf(agents): remove redundant finalize-hook message copy ([#135607](https://github.com/openclaw/openclaw/pull/135607)).
+- fix(test): empty named-file runs incorrectly pass by default ([#135609](https://github.com/openclaw/openclaw/pull/135609)).
+- test(tooling): centralize PR wrapper fixture identities ([#135611](https://github.com/openclaw/openclaw/pull/135611)).
+- test(skills): simplify library wire proof assertions ([#135616](https://github.com/openclaw/openclaw/pull/135616)). Thanks @steipete.
+- feat: recover an explicitly approved replacement PR head ([#135622](https://github.com/openclaw/openclaw/pull/135622)).
+- test(file-transfer): reuse directory archive runtime ([#135624](https://github.com/openclaw/openclaw/pull/135624)). Thanks @steipete.
+- perf: avoid transient executable-header buffers ([#135625](https://github.com/openclaw/openclaw/pull/135625)).
+- perf: let context memory own tool-set snapshots ([#135626](https://github.com/openclaw/openclaw/pull/135626)).
+- improve(release): prepare publication artifacts during validation ([#135639](https://github.com/openclaw/openclaw/pull/135639)).
+- test(tooling): share immutable GitHub CLI fixture commands ([#135640](https://github.com/openclaw/openclaw/pull/135640)).
+- test(ai): reuse immutable oversized stream chunks ([#135643](https://github.com/openclaw/openclaw/pull/135643)).
+- test: avoid leaked concurrent node configuration workers ([#135644](https://github.com/openclaw/openclaw/pull/135644)).
+- fix(test): preserve retained inputs across nested Vitest cleanup ([#135647](https://github.com/openclaw/openclaw/pull/135647)).
+- test(infra): reuse maintenance warning runtime ([#135651](https://github.com/openclaw/openclaw/pull/135651)).
+- fix(pr): distinguish quota failures from authentication errors ([#135657](https://github.com/openclaw/openclaw/pull/135657)).
+- test(media): scope QR temporary files to their test ([#135662](https://github.com/openclaw/openclaw/pull/135662)).
+- test(plugins): align artifact fixtures with build policy ([#135667](https://github.com/openclaw/openclaw/pull/135667)). Thanks @vincentkoc.
+- chore(ui): refresh control ui locales ([#135669](https://github.com/openclaw/openclaw/pull/135669)).
+- test(browser): consolidate proxy file rejection coverage ([#135672](https://github.com/openclaw/openclaw/pull/135672)).
+- refactor(skills): reuse full catalog rendering ([#135674](https://github.com/openclaw/openclaw/pull/135674)). Thanks @steipete.
+- chore(release): publish macOS 2026.8.2 appcast ([#135680](https://github.com/openclaw/openclaw/pull/135680)).
+- test(tooling): join signal fixture process groups before cleanup ([#135685](https://github.com/openclaw/openclaw/pull/135685)).
+- fix(release): generate stable appcasts with macOS Bash ([#135687](https://github.com/openclaw/openclaw/pull/135687)).
+- test(bedrock): consolidate missing-credential selection coverage ([#135698](https://github.com/openclaw/openclaw/pull/135698)).
+- test(google): centralize auth fixture environment cleanup ([#135703](https://github.com/openclaw/openclaw/pull/135703)).
+- test(hooks): reuse immutable import URL fixtures ([#135712](https://github.com/openclaw/openclaw/pull/135712)).
+- test(plugins): cover startup consent convergence ([#135718](https://github.com/openclaw/openclaw/pull/135718)). Thanks @ge0el, @boramyleng.
+- test(agents): reuse deferred gates in terminal lifecycle tests ([#135719](https://github.com/openclaw/openclaw/pull/135719)).
+- test(gateway): close fixture peers after failed assertions ([#135721](https://github.com/openclaw/openclaw/pull/135721)). Thanks @steipete.
+- chore(ui): refresh control ui locales ([#135723](https://github.com/openclaw/openclaw/pull/135723)).
+- fix(ui): keep standalone previews off external connections and sibling caches ([#135724](https://github.com/openclaw/openclaw/pull/135724)). Thanks @steipete.
+- perf(markdown): reduce temporary reply-formatting allocations ([#135725](https://github.com/openclaw/openclaw/pull/135725)).
+- fix(deps): reduce source install filesystem churn with isolated linking ([#135728](https://github.com/openclaw/openclaw/pull/135728)).
+- test(ui): reuse notice runtime and stabilize capability navigation ([#135733](https://github.com/openclaw/openclaw/pull/135733)).
+- ci: reuse unchanged declaration groups ([#135735](https://github.com/openclaw/openclaw/pull/135735)).
+- test(vault): unify resolver wire fixture ownership ([#135741](https://github.com/openclaw/openclaw/pull/135741)).
+- test(voice-call): stop auth tunnel after failed assertions ([#135752](https://github.com/openclaw/openclaw/pull/135752)).
+- improve: build macOS release architectures concurrently ([#135753](https://github.com/openclaw/openclaw/pull/135753)). Thanks @steipete.
+- chore(ui): refresh control ui locales ([#135756](https://github.com/openclaw/openclaw/pull/135756)).
+- test: consolidate live model Docker wrapper guards ([#135758](https://github.com/openclaw/openclaw/pull/135758)). Thanks @RomneyDa.
+- test: consolidate Codex live harness guards ([#135759](https://github.com/openclaw/openclaw/pull/135759)). Thanks @RomneyDa.
+- test: prune Telegram live Docker source mirrors ([#135760](https://github.com/openclaw/openclaw/pull/135760)). Thanks @RomneyDa.
+- test(tooling): centralize PR wrapper fixture cleanup ([#135763](https://github.com/openclaw/openclaw/pull/135763)).
+- perf(test): preserve exact unit selection for CI ([#135772](https://github.com/openclaw/openclaw/pull/135772)).
+- test(memory): join LanceDB fixture work before cleanup ([#135781](https://github.com/openclaw/openclaw/pull/135781)).
+- test(ios): reuse immutable IPA validator tools ([#135784](https://github.com/openclaw/openclaw/pull/135784)).
+- ci: share setup for short plugin fallback jobs ([#135787](https://github.com/openclaw/openclaw/pull/135787)).
+- test(infra): await Web Push sends before fixture cleanup ([#135792](https://github.com/openclaw/openclaw/pull/135792)).
+- refactor: simplify upgrade and triage tests ([#135799](https://github.com/openclaw/openclaw/pull/135799)).
+- test(plugins): unify E2E child shutdown ownership ([#135804](https://github.com/openclaw/openclaw/pull/135804)).
+- refactor(gateway): speed up Control UI asset retention ([#135806](https://github.com/openclaw/openclaw/pull/135806)).
+- test(diffs): unify plugin registration fixtures ([#135810](https://github.com/openclaw/openclaw/pull/135810)).
+- ci: keep split test families in separate jobs ([#135816](https://github.com/openclaw/openclaw/pull/135816)).
+- test(irc): observe socket and ingress completion events ([#135817](https://github.com/openclaw/openclaw/pull/135817)).
+- refactor(gateway): remove unused node subscription methods ([#135818](https://github.com/openclaw/openclaw/pull/135818)).
+- docs: add release contribution counts ([#135822](https://github.com/openclaw/openclaw/pull/135822)). Thanks @hannesrudolph.
+- test(gateway): register title runtime backend in fixtures ([#135823](https://github.com/openclaw/openclaw/pull/135823)).
+- improve(release): reduce Docker cache export overhead ([#135832](https://github.com/openclaw/openclaw/pull/135832)).
+- refactor(agents): simplify failed-turn settlement and Codex fixtures ([#135833](https://github.com/openclaw/openclaw/pull/135833)).
+- refactor(scripts): simplify managed command completion ([#135850](https://github.com/openclaw/openclaw/pull/135850)).
+- perf: simplify Control UI history and config processing ([#135851](https://github.com/openclaw/openclaw/pull/135851)).
+- refactor(google-meet): centralize browser route preparation ([#135869](https://github.com/openclaw/openclaw/pull/135869)).
+- ci: warm transform caches during collection ([#135875](https://github.com/openclaw/openclaw/pull/135875)).
+- improve(docker): shorten release image preparation ([#135877](https://github.com/openclaw/openclaw/pull/135877)). Thanks @steipete.
+- fix(test): prevent canceled fixtures from outliving test cleanup ([#135883](https://github.com/openclaw/openclaw/pull/135883)).
+- fix(tooling): allow reviewed squash merge messages ([#135888](https://github.com/openclaw/openclaw/pull/135888)).
+- test: avoid waiting for delegated approval expiry ([#135891](https://github.com/openclaw/openclaw/pull/135891)).
+- improve: reduce memory used to capture large command output ([#135894](https://github.com/openclaw/openclaw/pull/135894)).
+- improve: avoid repeated JSON copies of Code Mode text results ([#135898](https://github.com/openclaw/openclaw/pull/135898)).
+- fix(release): include sparse release context helper ([#135902](https://github.com/openclaw/openclaw/pull/135902)). Thanks @RomneyDa.
+- refactor(infra): reuse macOS version probes across startup consumers ([#135911](https://github.com/openclaw/openclaw/pull/135911)).
+- refactor(claws): speed up lifecycle E2E checks ([#135915](https://github.com/openclaw/openclaw/pull/135915)).
+- refactor(ui): simplify startup worker presentation ([#135916](https://github.com/openclaw/openclaw/pull/135916)).
+- improve: reduce repeated Gateway method inventory allocations ([#135931](https://github.com/openclaw/openclaw/pull/135931)).
+- Reject oversized QA uploads without crashing or stranding shutdown ([#135938](https://github.com/openclaw/openclaw/pull/135938)).
+- chore(ui): refresh control ui locales ([#135939](https://github.com/openclaw/openclaw/pull/135939)).
+- test: reuse performance fixture snapshot metadata ([#135940](https://github.com/openclaw/openclaw/pull/135940)).
+- improve: defer update recovery modules until an update starts ([#135942](https://github.com/openclaw/openclaw/pull/135942)).
+- test(codex): keep sandbox exec-server suites inside the isolated state home ([#135943](https://github.com/openclaw/openclaw/pull/135943)).
+- improve: reduce allocations when rendering attributed Markdown ([#135950](https://github.com/openclaw/openclaw/pull/135950)).
+- test(ui): advance disclosure scroll reconciliation with browser clock ([#135952](https://github.com/openclaw/openclaw/pull/135952)).
+- improve: avoid full plugin scans for known contribution owners ([#135953](https://github.com/openclaw/openclaw/pull/135953)). Thanks @steipete.
+- refactor(agents): centralize model accounting at stream ingress ([#135956](https://github.com/openclaw/openclaw/pull/135956)).
+- improve(release): shorten verification preparation ([#135960](https://github.com/openclaw/openclaw/pull/135960)).
+- improve(ui): avoid unused bundle builds in standalone E2E runs ([#135962](https://github.com/openclaw/openclaw/pull/135962)). Thanks @steipete.
+- test(ui): fix chat pane metadata listener fixtures ([#135965](https://github.com/openclaw/openclaw/pull/135965)).
+- test: reuse compiled cron ownership workers ([#135967](https://github.com/openclaw/openclaw/pull/135967)).
+- test: reuse prepared CLI in lifecycle E2E suites ([#135971](https://github.com/openclaw/openclaw/pull/135971)).
+- refactor(gateway): streamline Control UI manifest validation ([#135972](https://github.com/openclaw/openclaw/pull/135972)).
+- improve: prepare file log fields once per record ([#135974](https://github.com/openclaw/openclaw/pull/135974)).
+- fix(release): prevent FRV tooling checkout omissions ([#135983](https://github.com/openclaw/openclaw/pull/135983)). Thanks @vincentkoc.
+- improve: avoid a redundant copy when building the base config schema ([#135986](https://github.com/openclaw/openclaw/pull/135986)).
+- refactor: remove memory test dependency indirection ([#135994](https://github.com/openclaw/openclaw/pull/135994)).
+- fix(qa): finish tool progress from completed result status ([#135995](https://github.com/openclaw/openclaw/pull/135995)). Thanks @steipete.
+- improve: avoid redundant provider catalog model copies ([#135998](https://github.com/openclaw/openclaw/pull/135998)).
+- fix(qa): preserve failed Anthropic completions and partial output ([#136001](https://github.com/openclaw/openclaw/pull/136001)).
+- test(google-meet): complete finite fake process streams ([#136003](https://github.com/openclaw/openclaw/pull/136003)).
+- fix(release): report missing FRV child dispatches ([#136004](https://github.com/openclaw/openclaw/pull/136004)). Thanks @vincentkoc.
+- test(android): localize composer state expectations ([#136007](https://github.com/openclaw/openclaw/pull/136007)). Thanks @vincentkoc.
+- improve: avoid line arrays when stripping reasoning preambles ([#136014](https://github.com/openclaw/openclaw/pull/136014)).
+- test(feishu): scope shared fixtures and join failed downloads ([#136027](https://github.com/openclaw/openclaw/pull/136027)). Thanks @steipete.
+- refactor: remove disposable plugin metadata test fixtures ([#136031](https://github.com/openclaw/openclaw/pull/136031)).
+- test: batch npm fixture packing by install scenario ([#136044](https://github.com/openclaw/openclaw/pull/136044)).
+- fix(release): tolerate historical npm preflight targets ([#136054](https://github.com/openclaw/openclaw/pull/136054)). Thanks @vincentkoc.
+- test(msteams): batch pre-existing retention fixture rows ([#136055](https://github.com/openclaw/openclaw/pull/136055)).
+- refactor(gateway): preserve required agent selection fields ([#136056](https://github.com/openclaw/openclaw/pull/136056)). Thanks @RomneyDa.
+- fix(test): prevent cyclic subprocess errors from breaking cleanup ([#136057](https://github.com/openclaw/openclaw/pull/136057)).
+- fix(qa): honor nonstreaming Responses contracts ([#136062](https://github.com/openclaw/openclaw/pull/136062)). Thanks @steipete.
+- perf: reuse prepared plugin metadata normalizers ([#136063](https://github.com/openclaw/openclaw/pull/136063)).
+- refactor(plugin-sdk): share session visibility types ([#136065](https://github.com/openclaw/openclaw/pull/136065)). Thanks @RomneyDa.
+- refactor(cron): derive run history type from wire schema ([#136075](https://github.com/openclaw/openclaw/pull/136075)). Thanks @RomneyDa.
+- refactor(agents): type sessions yield stream contract ([#136077](https://github.com/openclaw/openclaw/pull/136077)). Thanks @RomneyDa.
+- perf: project model catalog runtime capabilities once ([#136080](https://github.com/openclaw/openclaw/pull/136080)). Thanks @steipete.
+- fix(ci): recover native locale refresh from malformed translations ([#136086](https://github.com/openclaw/openclaw/pull/136086)). Thanks @vincentkoc.
+- perf: avoid materializing text and media for presence checks ([#136099](https://github.com/openclaw/openclaw/pull/136099)). Thanks @steipete.
+- test(ui): share browser lifetime across isolated contexts ([#136101](https://github.com/openclaw/openclaw/pull/136101)).
+- fix(qa): accept string content in Responses messages ([#136109](https://github.com/openclaw/openclaw/pull/136109)). Thanks @steipete.
+- fix(qa): retain bootstrap diagnostics after timeouts ([#136111](https://github.com/openclaw/openclaw/pull/136111)). Thanks @steipete.
+- fix(release): reuse prepared artifacts on failed-job retries ([#136112](https://github.com/openclaw/openclaw/pull/136112)).
+- improve: reduce Linux CI fixture process scans ([#136114](https://github.com/openclaw/openclaw/pull/136114)).
+- refactor(ui): consolidate shared session menu rendering ([#136119](https://github.com/openclaw/openclaw/pull/136119)).
+- fix(ci): run browser checks for harness-only changes ([#136125](https://github.com/openclaw/openclaw/pull/136125)).
+- fix(ci): validate frozen releases with target capabilities ([#136127](https://github.com/openclaw/openclaw/pull/136127)). Thanks @vincentkoc.
+- fix(qa): format IPv6 listener URLs at their owners ([#136132](https://github.com/openclaw/openclaw/pull/136132)).
+- fix(release): validate numbered draft changelogs ([#136134](https://github.com/openclaw/openclaw/pull/136134)). Thanks @steipete.
+- fix(test): keep mixed UI directory runs scoped ([#136136](https://github.com/openclaw/openclaw/pull/136136)).
+- test(ui): unify shared fixture cleanup ownership ([#136150](https://github.com/openclaw/openclaw/pull/136150)).
+- fix(e2e): prevent macOS tooling from breaking Linux upgrade proofs ([#136152](https://github.com/openclaw/openclaw/pull/136152)).
+- perf: reuse captured model-catalog visibility state ([#136162](https://github.com/openclaw/openclaw/pull/136162)).
+- fix(i18n): avoid duplicate Android locale resources ([#136164](https://github.com/openclaw/openclaw/pull/136164)). Thanks @vincentkoc.
+- fix(qa): keep Crabline crypto available in bundled builds ([#136166](https://github.com/openclaw/openclaw/pull/136166)).
+- fix(qa): emit complete Responses stream lifecycle ([#136167](https://github.com/openclaw/openclaw/pull/136167)).
+- test(ui): close all Board fixture resources ([#136182](https://github.com/openclaw/openclaw/pull/136182)).
+- fix(ci): reject skipped jobs selected for validation ([#136187](https://github.com/openclaw/openclaw/pull/136187)). Thanks @MohammedAlkindi.
+- chore(ui): refresh control ui locales ([#136191](https://github.com/openclaw/openclaw/pull/136191)).
+- refactor(android): remove retired voice UI and unify command ownership ([#136192](https://github.com/openclaw/openclaw/pull/136192)).
+- perf(test): narrow direct reference searches to tests ([#136193](https://github.com/openclaw/openclaw/pull/136193)).
+- perf(test): reuse session branch fixture history ([#136209](https://github.com/openclaw/openclaw/pull/136209)). Thanks @steipete.
+- refactor(ui): simplify shared message rendering ([#136216](https://github.com/openclaw/openclaw/pull/136216)).
+- fix(ci): fetch security scan history during authenticated checkout ([#136232](https://github.com/openclaw/openclaw/pull/136232)). Thanks @steipete.
+- test(security): share trust audit fixture lifetime ([#136243](https://github.com/openclaw/openclaw/pull/136243)).
+- perf(test): use prepared entry in Gateway QA fixtures ([#136245](https://github.com/openclaw/openclaw/pull/136245)).
+- test(agents): tighten rotation fixtures and simplify catalog mocks ([#136254](https://github.com/openclaw/openclaw/pull/136254)).
+- docs(ios): cut 2026.8.11 release notes ([`753853a7d9`](https://github.com/openclaw/openclaw/commit/753853a7d93ef392c363624714edf186c7ad5dcd)). Thanks @joshavant.
+- chore(release): prepare 2026.9.1 artifacts ([`431d778f54`](https://github.com/openclaw/openclaw/commit/431d778f545386a812912b80bc6f75aa7a449dd4)).
+- test(release): normalize installer fixture control flow ([`d3deb20a78`](https://github.com/openclaw/openclaw/commit/d3deb20a78e3c4c10997d9df022500e6799f52fa)).
+
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -12,6 +12,7 @@ without making you scan the raw changelog first.
 
 ## Releases
 
+- [v2026.9.1](/releases/2026.9.1) - Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and less repeated work in long conversations and large installations.
 - [v2026.8.2](/releases/2026.8.2) - Home beside your work, a Linux desktop companion, background sessions, safer upgrades, dependable replies and voice, and four new themes.
 - [v2026.8.1](/releases/2026.8.1) - A rebuilt web experience, simpler
   onboarding, stronger memory and session continuity, and a very large


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where readers looking for the v2026.9.1 product story would have to reconstruct it from the raw release history instead of having one curated, source-linked docs page.

## Why This Change Was Made

This adds an evidence-backed v2026.9.1 release page and links it from the release index. The page follows the existing v2026.8.1 and v2026.8.2 structure, uses the fixed release taxonomy, keeps maintainer work separate from the reader-facing story, and accounts for the complete frozen range from v2026.8.2 through `d3deb20a78e3c4c10997d9df022500e6799f52fa`.

## User Impact

Readers can understand the main v2026.9.1 changes in plain language, follow the relevant documentation, and expand source lists for complete PR, direct-commit, and contributor provenance.

## Evidence

- Completed and validated 928/928 release units with zero pending, active, or failed analysis work.
- Verified 922 pull-request links and 6 direct commits in the page, with no missing or extra release units.
- Verified release scale of 922 pull requests, 6 direct commits, and 241 contributors under the established credit exclusions.
- Independent full-page semantic review: `APPROVED_FOR_HUMAN_REVIEW`.
- `git diff --check`
- Single-page MDX compile with `@mdx-js/mdx`
- `npm run docs:build:preview`

Canonical OpenClaw was not modified. This PR does not publish or merge anything by itself.
