### PR TITLE
fix: render each documentation locale only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Fix redundant locale rendering by excluding locale-owned roots from English page collection, including accidental localized `AGENTS.md` pages and duplicate locale-root Markdown exports.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Source of truth lives in [`openclaw/openclaw`](https://github.com/openclaw/openc
 ## Static site build
 
 - `npm run docs:build` renders the mirrored Mintlify-flavored docs into `dist/docs-site`.
+- English collection excludes top-level roots owned by published locales; each locale renders its own sources once, while nested or unrecognized directory names remain ordinary English paths.
 - `npm run docs:build:cloudflare` is the legacy Worker Static Assets fallback build.
 - `npm run docs:build:r2` renders the full unpruned site and prepares `dist/docs-r2-manifest.json` for R2 upload.
 - `npm run docs:r2:upload` uploads only changed R2 objects, reports cache hits/misses, and refuses to turn a broken remote manifest read into a full-tree reupload.

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -127,10 +127,13 @@ function parseOptionalPositiveInt(value, name) {
 
 function collectPages(localeList) {
   const result = [];
+  const localeRoots = new Set(localeList.filter((locale) => !locale.root).map((locale) => locale.code));
   for (const locale of localeList) {
     const base = locale.root ? docsDir : path.join(docsDir, locale.code);
     for (const file of walkDocs(base)) {
       const rel = path.relative(base, file).replaceAll(path.sep, "/");
+      // Only the English owner excludes foreign roots; walkDocs remains an all-source traversal.
+      if (locale.root && localeRoots.has(rel.split("/")[0])) continue;
       if (ignoredDocFiles.has(rel)) continue;
       const raw = fs.readFileSync(file, "utf8");
       const parsed = parseFrontmatter(raw);

--- a/scripts/docs-site/dotted-pages.test.mjs
+++ b/scripts/docs-site/dotted-pages.test.mjs
@@ -106,8 +106,8 @@ for (const base of ["", "/manual"]) {
     assert.equal(p.entries.get("collision.v2").customMetadata, undefined);
     assert.equal(p.entries.get("release.v2").contentType, "text/html; charset=utf-8");
     assert.equal(p.entries.get("release.v2/index.html").contentType, "text/html; charset=utf-8");
-    // The builder's English pass also emits de.md; use that existing source.
-    await servesMarkdown(p, "/de", "/de.md", { accept: "text/markdown" });
+    await servesMarkdown(p, "/de/index.md", "/de/index.md");
+    assert.equal(p.entries.has("de.md"), false);
     if (base) assert.equal((await p.request(`${base}/release.v2`, { accept: "text/markdown" })).status, 404);
   });
 }

--- a/scripts/docs-site/locale-collection-owner.test.mjs
+++ b/scripts/docs-site/locale-collection-owner.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fixture, write } from "./test-helpers/redirect-fixture.mjs";
+
+const origin = "https://docs.openclaw.ai";
+const english = {
+  "index.md": "# English home\n",
+  "target.mdx": "# English target\n\n## Part\nTarget body\n",
+  "fallback.md": "# English fallback\n",
+  "guide/de/topic.mdx": "# Nested German name\n",
+  "guide/ja/topic.md": "# Nested Japanese name\n",
+  "guide/eo/topic.md": "# Nested custom locale name\n",
+  "unknown/topic.md": "# Unknown root\n",
+  "ja/topic.md": "# Unmapped root name\n",
+};
+const translations = {
+  "de/index.md": "# Deutsch\n",
+  "de/target.mdx": "# Deutsches Ziel\n\n[Translated](/target#part)\n\n[Fallback](/fallback)\n\n[Explicit fallback](/de/fallback)\n",
+  "de/guide/de/topic.md": "# Verschachtelt\n",
+  "ja-JP/index.mdx": "# 日本語\n",
+  "ja-JP/target.md": "# 日本語の対象\n",
+  "fr/index.md": "# Français\n",
+  "fr/target.mdx": "# Cible française\n",
+  "eo/index.md": "# Esperanto\n",
+  "eo/target.mdx": "# Celo\n",
+};
+const englishRoutes = ["/", "/target", "/fallback", "/guide/de/topic", "/guide/ja/topic", "/guide/eo/topic", "/unknown/topic", "/ja/topic"];
+const localeRoutes = ["/de", "/de/target", "/de/guide/de/topic", "/ja-JP", "/ja-JP/target", "/fr", "/fr/target", "/eo", "/eo/target"];
+const nav = (language, tab, pages) => ({ language, tabs: [{ tab, groups: [{ group: tab, pages }] }] });
+
+for (const base of ["", "/manual"]) {
+  test(`builder gives each locale its own sources with base ${base || "(root)"}`, (t) => {
+    const f = fixture(t, [], { ...english, ...translations }, base);
+    write(f.root, "docs/docs.json", JSON.stringify({
+      name: "Locale ownership fixture",
+      navigation: { languages: [
+        nav("en", "English navigation", ["index", "target", "fallback", "guide/de/topic"]),
+        nav("de", "Deutsche Navigation", ["de/index", "de/target", "de/fallback", { group: "Nested", pages: ["de/guide/de/topic"] }]),
+        nav("ja", "日本語ナビ", ["ja-JP/index", "ja-JP/target"]),
+        nav("eo", "Esperanta navigado", ["eo/index", "eo/target"]),
+        nav("es", "Absent locale", ["index", "target"]),
+        // French is discovered from the tree and inherits the first navigation.
+      ] },
+      redirects: [
+        { source: "/old", destination: "/target#part" },
+        { source: "/missing-translation", destination: "/fallback" },
+        { source: "/de/explicit", destination: "/de/target#part" },
+        { source: "/es/explicit", destination: "/es/target" },
+        { source: "/old-root", destination: "/" },
+      ],
+    }));
+    for (const prefix of ["", "de/", "eo/"]) {
+      for (const rel of ["AGENTS.md", ".i18n/hidden.md", ".generated/hidden.mdx", "assets/hidden.md", ".hidden/page.md"]) {
+        write(f.root, `docs/${prefix}${rel}`, "# Ignored source\n");
+      }
+    }
+
+    // Full mode exercises collection-derived indexes and redirects, not just the
+    // surviving files after duplicate HTML writes have overwritten one another.
+    const built = f.build({ DOCS_SITE_ARTIFACT_MODE: "full" });
+    assert.equal(built.status, 0, built.stderr);
+    assert.equal(Number(built.stdout.match(/built (\d+) pages/)?.[1]), 18, built.stdout);
+
+    const site = path.join(f.root, "dist/docs-site");
+    const read = (rel) => fs.readFileSync(path.join(site, rel), "utf8");
+    const html = (route) => read(`${route === "/" ? "" : route.slice(1) + "/"}index.html`);
+    const sitemapRoutes = [...read("sitemap.xml").matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => new URL(m[1]).pathname);
+    assert.deepEqual(sitemapRoutes.sort(), [...englishRoutes, ...localeRoutes].sort());
+    const llmsRoutes = [...read("llms.txt").split("## Documentation Index\n")[1].matchAll(/\]\(([^)]+)\)/g)].map((m) => new URL(m[1]).pathname);
+    assert.deepEqual(llmsRoutes.sort(), [...englishRoutes].sort());
+    assert.equal(read("llms.txt"), read(".well-known/llms.txt"));
+
+    for (const [source, content] of Object.entries({ ...english, ...translations })) {
+      assert.equal(read(source.replace(/\.mdx$/, ".md")), content, source);
+    }
+    for (const route of englishRoutes) assert.match(html(route), /<html lang="en"/);
+    for (const route of localeRoutes) {
+      const locale = route.split("/")[1];
+      assert.ok(html(route).includes(`<html lang="${locale}"`), route);
+      assert.ok(html(route).includes(`<link rel="canonical" href="${origin}${route}">`), route);
+    }
+    const german = html("/de/target");
+    const sidebar = german.match(/<aside class="sidebar">([\s\S]*?)<\/aside>/)[1];
+    assert.ok(sidebar.includes("Deutsche Navigation"));
+    assert.ok(sidebar.includes(`class="nav-link active" href="${base}/de/target"`));
+    assert.ok(sidebar.includes(`href="${base}/de/guide/de/topic"`));
+    assert.ok(!sidebar.includes("English fallback"), "untranslated entries stay out of locale navigation");
+    assert.ok(html("/fr/target").includes(`class="nav-link active" href="${base}/fr/target"`));
+    assert.ok(html("/eo/target").includes("Esperanta navigado"));
+    assert.ok(german.includes(`href="${base}/de/target#part">Translated</a>`));
+    assert.ok(german.includes(`href="${base}/fallback">Fallback</a>`));
+    assert.ok(german.includes(`href="${base}/fallback">Explicit fallback</a>`));
+    assert.ok(html("/fallback").includes(`href="${base}/de/" data-locale-option`), "picker falls back to locale home");
+    assert.ok(!german.includes("Español"), "an absent configured tree is not a published locale");
+    assert.ok(german.includes(`hreflang="en" href="${origin}/target"`));
+    assert.ok(german.includes(`hreflang="ja-JP" href="${origin}/ja-JP/target"`));
+    assert.ok(german.includes(`hreflang="eo" href="${origin}/eo/target"`));
+    assert.match(html("/__elements"), /noindex,nofollow/);
+
+    for (const rel of ["AGENTS/index.html", "de/AGENTS/index.html", "eo/AGENTS.md", "de.md", "fr.md", "ja-JP.md", "eo.md", "es/index.html", "de/fallback/index.html", "assets/hidden/index.html", "de/.i18n/hidden.md"]) {
+      assert.equal(fs.existsSync(path.join(site, rel)), false, rel);
+    }
+    const redirects = JSON.parse(fs.readFileSync(path.join(f.root, "dist/docs-markdown-redirects.json"), "utf8"));
+    for (const prefix of [...new Set(["", "/docs", base])]) {
+      for (const [alias, destination, markdown] of [
+        ["/old", "/target#part", "/target.md#part"],
+        ["/de/old", "/de/target#part", "/de/target.md#part"],
+        ["/eo/old", "/eo/target#part", "/eo/target.md#part"],
+        ["/de/explicit", "/de/target#part", "/de/target.md#part"],
+        ["/es/explicit", "/target", "/target.md"],
+        ["/de/missing-translation", "/fallback", "/fallback.md"],
+        ["/de/old-root", "/de", "/de/index.md"],
+      ]) {
+        assert.ok(html(prefix + alias).includes(`location.replace(${JSON.stringify(base + destination)})`), prefix + alias);
+        assert.equal(redirects[`${prefix}${alias}/index.html`.slice(1)], markdown);
+      }
+    }
+    for (const target of Object.values(redirects)) {
+      assert.ok(fs.existsSync(path.join(site, new URL(target, origin).pathname)), target);
+    }
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full documentation builds rendered every translated page twice: once as English and again with its actual locale. The later HTML write hid the duplicate work, so a build reported 29,122 pages while Pagefind indexed 14,953 unique documents. The English pass also incorrectly published 20 locale-root `AGENTS.md` instruction files.

## Why This Change Was Made

Exclude roots owned by published locales at the English collection boundary, before reading or parsing their files. Each locale remains responsible for its own sources. The shared all-source walker is unchanged; there is no output deduplication workaround. Configured and discovered locales are respected, while nested language-like directories and unrecognized roots remain ordinary English paths.

## User Impact

Full builds render each document once with the correct locale ownership. Navigation, language selection, untranslated English fallback, canonical Markdown exports, and localized redirects remain intact. Accidental `/<locale>.md` objects are removed; their canonical `/<locale>/index.md` exports remain. Locale instruction files are no longer published as documentation.

## Evidence

The original corpus reconciles as 765 English documents + twice 14,168 translations + 20 incorrectly included instruction files + one hidden fixture. Full validation on main snapshot `007614fa2` with this fix produced:

- 14,934 built pages = 14,933 documents + the intentionally hidden component fixture.
- Pagefind indexes 14,933 documents across all 21 languages, with zero duplicate owners.
- The shared source inventory remains 14,954 paths; all translated-document counts are unchanged.
- Exact Markdown source bytes and HTML language were checked for all 14,933 documents, and HTML/Markdown targets were verified for all 11,326 redirects.
- The new real-builder regression fails against the original collector (`29 !== 18`) and passes with the fix for both root and `/manual` hosting. It covers mapped/discovered/custom locales, absent locale trees, nested locale-like paths, ignored files, navigation, fallback, hreflang, source exports, and redirects.
- `npm test`: 120/120 passed.
- `make docs-check`: full build, Pagefind, local R2 preparation, and smoke checks passed.
- `npm run docs:visual`: passed.

The upstream source-code index uses its existing skipped state in the isolated local worktree because no upstream source checkout is present; its regression passes. No mirrored docs were hand-edited. This PR changes only collection ownership, its regressions, and release/documentation notes.
