### PR TITLE
fix(i18n): keep translation model selection private

### DIFF
--- a/.github/scripts/i18n/build_pending_manifest.py
+++ b/.github/scripts/i18n/build_pending_manifest.py
@@ -4,8 +4,8 @@
 Definition:
   This script mirrors the pending-doc selection logic from
   translate-locale-reusable.yml. It discovers source docs, excludes generated
-  and locale docs, compares source hashes in incremental mode, and writes the
-  shard-specific pending file consumed by docs-i18n.
+  and locale docs, compares source hashes and retired model metadata in
+  incremental mode, and writes the shard-specific pending file consumed by docs-i18n.
 
 Parameters:
   --docs-root: Docs directory. Default: docs.
@@ -37,6 +37,7 @@ from translation_plan import is_locale_dir
 
 
 SOURCE_HASH_RE = re.compile(r"^x-i18n:\n(?:[ \t]+.*\n)*?[ \t]+source_hash: ([0-9a-f]{64})$", re.M)
+MODEL_METADATA_RE = re.compile(r"^x-i18n:\n(?:[ \t]+.*\n)*?[ \t]+(?:model|provider):", re.M)
 
 
 @dataclass(frozen=True)
@@ -48,14 +49,16 @@ class PendingResult:
     shard_files: list[Path]
 
 
-def stored_source_hash(path: Path) -> str:
+def translation_matches_source(path: Path, source_hash: str) -> bool:
     if not path.exists():
-        return ""
+        return False
     text = path.read_text(encoding="utf-8", errors="ignore")
-    match = SOURCE_HASH_RE.search(text)
-    if not match:
-        return ""
-    return match.group(1).strip()
+    frontmatter, separator, _ = text[4:].partition("\n---")
+    if not text.startswith("---\n") or not separator:
+        return False
+    # Same-source pages still need regeneration to remove retired routing metadata.
+    match = SOURCE_HASH_RE.search(frontmatter)
+    return bool(match and match.group(1) == source_hash and not MODEL_METADATA_RE.search(frontmatter))
 
 
 def validate_shard(index_value: str, total_value: str) -> tuple[int, int]:
@@ -122,7 +125,7 @@ def build_pending_manifest(
         all_files.append(path.resolve())
         locale_path = docs_root / locale / rel
         source_hash = hashlib.sha256(path.read_bytes()).hexdigest()
-        if mode == "full" or stored_source_hash(locale_path) != source_hash:
+        if mode == "full" or not translation_matches_source(locale_path, source_hash):
             pending_files.append(path.resolve())
 
     pending_files = sorted(pending_files)

--- a/.github/scripts/i18n/provider_preflight.py
+++ b/.github/scripts/i18n/provider_preflight.py
@@ -10,6 +10,7 @@ Definition:
 Parameters:
   --provider: Translation provider. Default: OPENCLAW_DOCS_I18N_PROVIDER/openai.
   --model: Model name to validate. Default: OPENCLAW_DOCS_I18N_MODEL.
+  --fallback-model: Used only for an unavailable primary model. Default: OPENCLAW_DOCS_I18N_FALLBACK_MODEL.
   --timeout-seconds: HTTP timeout. Default: 30.
   --status-code and --response-file: Test-only inputs for local classification.
 
@@ -53,34 +54,32 @@ def append_output(values: dict[str, str]) -> None:
             fh.write(f"{key}={value}\n")
 
 
-def parse_error_code(body: str) -> str:
+def parse_error(body: str) -> dict:
     try:
         data = json.loads(body)
     except json.JSONDecodeError:
-        return ""
-    error = data.get("error")
-    if isinstance(error, dict):
-        code = error.get("code") or error.get("type") or ""
-        return str(code)
-    return ""
+        return {}
+    error = data.get("error") if isinstance(data, dict) else None
+    return error if isinstance(error, dict) else {}
 
 
 def classify_response(status_code: int, body: str) -> tuple[bool, str, str]:
-    code = parse_error_code(body)
+    error = parse_error(body)
+    code = error.get("code") or error.get("type")
     if 200 <= status_code < 300:
         return True, "ok", "provider preflight ok"
     if code == "insufficient_quota":
         return False, "quota_exhausted", "OpenAI reported insufficient quota for the translation key"
     if status_code == 401:
         return False, "invalid_key", "OpenAI rejected the translation API key"
+    if code == "model_not_found" or (status_code in (403, 404) and error.get("param") == "model"):
+        return False, "model_unavailable", "OpenAI cannot serve the requested translation model"
     if status_code == 403:
         return False, "model_access_denied", "OpenAI denied access to the requested translation model"
     if status_code == 404:
         return False, "model_not_found", "OpenAI could not find the requested translation model"
     if status_code == 429:
         return False, "rate_limited", "OpenAI rate-limited the translation preflight"
-    if "model" in code and "not" in code:
-        return False, "model_not_found", "OpenAI could not find the requested translation model"
     return False, "provider_error", f"OpenAI preflight failed with HTTP {status_code}"
 
 
@@ -109,8 +108,8 @@ def openai_probe_request(model: str, api_key: str, timeout_seconds: int) -> ApiR
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
         return ApiResponse(status_code=exc.code, body=body)
-    except urllib.error.URLError as exc:
-        raise SystemExit(f"provider_error: OpenAI preflight network failure: {exc}") from exc
+    except (urllib.error.URLError, TimeoutError):
+        raise SystemExit("provider_error: OpenAI preflight network failure") from None
 
 
 def load_test_response(status_code: int | None, response_file: Path | None) -> ApiResponse | None:
@@ -125,6 +124,7 @@ def provider_preflight(
     model: str,
     timeout_seconds: int,
     test_response: ApiResponse | None = None,
+    fallback_model: str = "",
 ) -> str:
     if provider != "openai":
         append_output({"provider_preflight": "failed", "failure_class": "unsupported_provider"})
@@ -140,10 +140,16 @@ def provider_preflight(
 
     response = test_response or openai_probe_request(model, api_key, timeout_seconds)
     ok, failure_class, message = classify_response(response.status_code, response.body)
-    append_output({"provider_preflight": "ok" if ok else "failed", "failure_class": "" if ok else failure_class})
+    model_slot = "primary"
+    if not ok and failure_class == "model_unavailable" and fallback_model and fallback_model != model:
+        print("Primary translation model unavailable; checking configured fallback.")
+        model_slot = "fallback"
+        response = openai_probe_request(fallback_model, api_key, timeout_seconds)
+        ok, failure_class, message = classify_response(response.status_code, response.body)
+    append_output({"provider_preflight": "ok" if ok else "failed", "failure_class": "" if ok else failure_class, "model_slot": model_slot if ok else ""})
     if not ok:
         raise SystemExit(f"{failure_class}: {message}")
-    print(f"provider preflight ok: provider={provider} model={model}")
+    print("provider preflight ok")
     return failure_class
 
 
@@ -161,6 +167,7 @@ Examples:
     )
     parser.add_argument("--provider", default=os.environ.get("OPENCLAW_DOCS_I18N_PROVIDER", "openai"))
     parser.add_argument("--model", default=os.environ.get("OPENCLAW_DOCS_I18N_MODEL", ""))
+    parser.add_argument("--fallback-model", default=os.environ.get("OPENCLAW_DOCS_I18N_FALLBACK_MODEL", ""))
     parser.add_argument("--timeout-seconds", default=30, type=int)
     parser.add_argument("--status-code", type=int, help="Test-only HTTP status to classify instead of calling the provider.")
     parser.add_argument("--response-file", type=Path, help="Test-only provider response body for --status-code.")
@@ -170,7 +177,7 @@ Examples:
 def main() -> None:
     args = parse_args()
     test_response = load_test_response(args.status_code, args.response_file)
-    provider_preflight(args.provider, args.model, args.timeout_seconds, test_response)
+    provider_preflight(args.provider, args.model, args.timeout_seconds, test_response, args.fallback_model)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/i18n/tests/test_i18n_scripts.py
+++ b/.github/scripts/i18n/tests/test_i18n_scripts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import io
 import json
 import os
 import re
@@ -10,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -889,6 +890,37 @@ class I18NScriptTests(unittest.TestCase):
         payload = json.loads(request.data)
         self.assertEqual(200, response.status_code)
         self.assertGreaterEqual(payload["max_output_tokens"], 16)
+
+    def test_provider_preflight_private_selection_and_availability_fallback(self) -> None:
+        cases = [
+            (200, {}, ["private-primary"], "primary"),
+            (404, {"code": "model_not_found"}, ["private-primary", "private-fallback"], "fallback"),
+            (403, {"param": "model", "code": "permission_denied"}, ["private-primary", "private-fallback"], "fallback"),
+            (401, {}, ["private-primary"], None),
+            (403, {"code": "permission_denied"}, ["private-primary"], None),
+            (404, {}, ["private-primary"], None),
+            (429, {"code": "insufficient_quota"}, ["private-primary"], None),
+            (500, {}, ["private-primary"], None),
+        ]
+        for status, error, expected_models, slot in cases:
+            with self.subTest(status=status, error=error), tempfile.TemporaryDirectory() as tmp:
+                output = Path(tmp) / "output"
+                body = json.dumps({"error": {**error, "message": "private-primary private-fallback"}})
+                responses = [provider_preflight.ApiResponse(status, body), provider_preflight.ApiResponse(200, "{}")]
+                stdout = io.StringIO()
+                with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key", "GITHUB_OUTPUT": str(output)}), patch.object(provider_preflight, "openai_probe_request", side_effect=responses) as probe, redirect_stdout(stdout):
+                    if slot:
+                        provider_preflight.provider_preflight("openai", "private-primary", 30, fallback_model="private-fallback")
+                    else:
+                        with self.assertRaises(SystemExit) as failure:
+                            provider_preflight.provider_preflight("openai", "private-primary", 30, fallback_model="private-fallback")
+                        stdout.write(str(failure.exception))
+                self.assertEqual(expected_models, [call.args[0] for call in probe.call_args_list])
+                public_output = stdout.getvalue() + output.read_text()
+                for identifier in ("private-primary", "private-fallback"):
+                    self.assertNotIn(identifier, public_output)
+                if slot:
+                    self.assertIn(f"model_slot={slot}", output.read_text())
 
     def test_read_source_metadata_validates_requested_sha_and_outputs_fields(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/i18n/tests/test_i18n_scripts.py
+++ b/.github/scripts/i18n/tests/test_i18n_scripts.py
@@ -1009,24 +1009,30 @@ class I18NScriptTests(unittest.TestCase):
             shutil.copytree(FIXTURES / "pending-docs" / "docs", tmp_path / "docs")
             source = tmp_path / "docs/index.md"
             digest = hashlib.sha256(source.read_bytes()).hexdigest()
-            (tmp_path / "docs/fr/index.md").write_text(
-                f"---\nx-i18n:\n  source_hash: {digest}\n---\n\n# Index FR\n",
-                encoding="utf-8",
-            )
-
-            result = pending.build_pending_manifest(
-                docs_root=tmp_path / "docs",
-                openclaw_sync_dir=tmp_path / ".openclaw-sync",
-                locale="fr",
-                locale_slug="fr",
-                mode="incremental",
-                shard_index=0,
-                shard_total=1,
-            )
-
-            self.assertEqual(2, result.all_count)
-            self.assertEqual(1, result.total_pending_count)
-            self.assertTrue(result.shard_files[0].as_posix().endswith("/docs/guide/setup.mdx"))
+            for metadata, body, needs_refresh in (
+                ("", "# Index FR\n", False),
+                ("  model: retired-model\n", "# Index FR\n", True),
+                ("  provider: retired-provider\n", "# Index FR\n", True),
+                ("", "# Index FR\n```yaml\nx-i18n:\n  model: example\n```\n", False),
+            ):
+                with self.subTest(metadata=metadata, body=body):
+                    (tmp_path / "docs/fr/index.md").write_text(
+                        f"---\nx-i18n:\n  source_hash: {digest}\n{metadata}---\n\n{body}",
+                        encoding="utf-8",
+                    )
+                    result = pending.build_pending_manifest(
+                        docs_root=tmp_path / "docs",
+                        openclaw_sync_dir=tmp_path / ".openclaw-sync",
+                        locale="fr",
+                        locale_slug="fr",
+                        mode="incremental",
+                        shard_index=0,
+                        shard_total=1,
+                    )
+                    expected = ["guide/setup.mdx", "index.md"] if needs_refresh else ["guide/setup.mdx"]
+                    self.assertEqual(2, result.all_count)
+                    self.assertEqual(len(expected), result.total_pending_count)
+                    self.assertEqual(expected, [file.relative_to((tmp_path / "docs").resolve()).as_posix() for file in result.shard_files])
 
     def test_pending_manifest_excludes_supported_locale_dirs_without_marker(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -220,7 +220,8 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
           OPENCLAW_DOCS_I18N_PROVIDER: openai
-          OPENCLAW_DOCS_I18N_MODEL: gpt-5.6
+          OPENCLAW_DOCS_I18N_MODEL: ${{ secrets.OPENCLAW_I18N_MODEL }}
+          OPENCLAW_DOCS_I18N_FALLBACK_MODEL: ${{ secrets.OPENCLAW_I18N_FALLBACK_MODEL }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/translate-incremental.yml
+++ b/.github/workflows/translate-incremental.yml
@@ -162,7 +162,8 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
           OPENCLAW_DOCS_I18N_PROVIDER: openai
-          OPENCLAW_DOCS_I18N_MODEL: gpt-5.6
+          OPENCLAW_DOCS_I18N_MODEL: ${{ secrets.OPENCLAW_I18N_MODEL }}
+          OPENCLAW_DOCS_I18N_FALLBACK_MODEL: ${{ secrets.OPENCLAW_I18N_FALLBACK_MODEL }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/translate-locale-reusable.yml
+++ b/.github/workflows/translate-locale-reusable.yml
@@ -182,7 +182,8 @@ jobs:
           MODE: ${{ inputs.mode }}
           OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
           OPENCLAW_DOCS_I18N_PROVIDER: openai
-          OPENCLAW_DOCS_I18N_MODEL: gpt-5.6
+          OPENCLAW_DOCS_I18N_MODEL: ${{ secrets.OPENCLAW_I18N_MODEL }}
+          OPENCLAW_DOCS_I18N_FALLBACK_MODEL: ${{ secrets.OPENCLAW_I18N_FALLBACK_MODEL }}
           OPENCLAW_DOCS_I18N_PROMPT_TIMEOUT: 10m
           # Owned by source/scripts/docs-i18n; diagnostics opt in per canary.
           OPENCLAW_DOCS_I18N_LOG_REJECTED_BODY: ${{ inputs.log_rejected_body && '1' || '0' }}
@@ -279,9 +280,19 @@ jobs:
           python "${I18N_SCRIPT_DIR}/mdx_repair_scope.py" snapshot \
             --baseline "${RUNNER_TEMP}/${LOCALE}.repair-baseline.txt"
 
+      - name: Select available repair model
+        id: repair_model
+        if: steps.stale.outputs.skip != 'true' && steps.translate_docs.outcome == 'success' && steps.mdx_check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_AGENT_OPENAI_API_KEY || secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
+          OPENCLAW_DOCS_I18N_MODEL: ${{ secrets.OPENCLAW_I18N_MODEL }}
+          OPENCLAW_DOCS_I18N_FALLBACK_MODEL: ${{ secrets.OPENCLAW_I18N_FALLBACK_MODEL }}
+        run: python "${I18N_SCRIPT_DIR}/provider_preflight.py"
+
       - name: Repair translated MDX
         id: mdx_repair
-        if: steps.stale.outputs.skip != 'true' && steps.translate_docs.outcome == 'success' && steps.mdx_check.outcome == 'failure'
+        if: steps.repair_model.outcome == 'success'
         continue-on-error: true
         uses: openai/codex-action@v1
         env:
@@ -289,7 +300,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENCLAW_DOCS_AGENT_OPENAI_API_KEY || secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
           prompt-file: .openclaw-sync/docs-mdx-repair.md
-          model: gpt-5.6
+          model: ${{ steps.repair_model.outputs.model_slot == 'fallback' && secrets.OPENCLAW_I18N_FALLBACK_MODEL || secrets.OPENCLAW_I18N_MODEL }}
           effort: xhigh
           sandbox: workspace-write
           safety-strategy: drop-sudo

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -37,6 +37,12 @@ Manual and weekly runs do not wait by default.
 
 ## Incremental translation
 
+### Private model configuration
+
+Store the primary model in the GitHub Actions secret `OPENCLAW_I18N_MODEL` and the optional fallback in `OPENCLAW_I18N_FALLBACK_MODEL`. Both translation coordinators and translated-MDX repair use these secrets. Do not put model identifiers in repository variables, workflow inputs, or committed files.
+
+The provider preflight checks the primary first and tries the fallback only when the API identifies the requested model as unavailable. Authentication, quota, rate-limit, network, and unrelated request failures remain visible failures. Public preflight output contains only the result and the selected `primary` or `fallback` role, never an identifier. The source repository's translation engine also handles model retirement during a running shard and omits model identity from generated translation metadata.
+
 Each translated page stores `x-i18n.source_hash`. Locale jobs compare the current English page hash with the stored locale hash.
 
 Normal runs translate only:

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -41,7 +41,7 @@ Manual and weekly runs do not wait by default.
 
 Store the primary model in the GitHub Actions secret `OPENCLAW_I18N_MODEL` and the optional fallback in `OPENCLAW_I18N_FALLBACK_MODEL`. Both translation coordinators and translated-MDX repair use these secrets. Do not put model identifiers in repository variables, workflow inputs, or committed files.
 
-The provider preflight checks the primary first and tries the fallback only when the API identifies the requested model as unavailable. Authentication, quota, rate-limit, network, and unrelated request failures remain visible failures. Public preflight output contains only the result and the selected `primary` or `fallback` role, never an identifier. The source repository's translation engine also handles model retirement during a running shard and omits model identity from generated translation metadata.
+The provider preflight checks the primary first and tries the fallback only when the API identifies the requested model as unavailable. Authentication, quota, rate-limit, network, and unrelated request failures remain visible failures. Public preflight output contains only the result and the selected `primary` or `fallback` role, never an identifier. The source repository's translation engine also handles model retirement during a running shard and omits model identity from generated translation metadata. Incremental planning queues unchanged pages that still contain retired model/provider metadata so the source engine can regenerate them without those fields.
 
 Each translated page stores `x-i18n.source_hash`. Locale jobs compare the current English page hash with the stored locale hash.
 


### PR DESCRIPTION
## What Problem This Solves

The docs translation workflows hardcoded their model, and provider preflight printed that identifier in public logs. They could not continue with a configured replacement after model retirement. Unchanged locale pages could also retain retired model/provider metadata indefinitely.

## Why This Change Was Made

Read primary and fallback selections from GitHub Actions secrets across full and incremental translation and MDX repair. Preflight emits only safe status and primary/fallback roles, and uses the fallback only for confirmed model-unavailability responses. Authentication, quota, rate-limit, network, and unrelated failures do not switch models.

Incremental planning queues same-source pages that still contain retired model/provider frontmatter. The source engine owns regeneration, mid-shard fallback, and model-free generated metadata; the engine landed in openclaw/openclaw#137882 at `13f017b67c9ec71387ab747f397c1e54549edb09`. The rollout verified the docs mirror contained that revision before starting full translation. Metadata examples in the document body do not invalidate an otherwise current translation.

## User Impact

Translation model choices remain private, and configured replacement models can take over when the primary becomes unavailable. The maintainer explicitly requested the primary/fallback configuration, and both model secrets were provisioned in the source and publish repositories before rollout. Translation prompts and concurrency budgets are unchanged.

## Evidence

- Live primary and forced model-unavailability fallback probes passed using the existing translation key. No model identifiers or raw response bodies were logged. The source engine also translated a real German docs page with the pinned CLI; MDX/protected-attribute validation passed and generated metadata/logs contained no configured identifiers.
- Provider-preflight regression cases cover successful primary/fallback selection, public-output privacy, and non-fallback authentication/quota/network responses.
- The legacy-page regression fails on the previous selector and passes after the repair. All 10 pending-manifest tests pass, including current-page reuse, legacy model/provider metadata, body examples, shard selection, and canary selection.
- Workflow shell syntax and full-run budget checks pass (9 peak workers).
- Structured Codex autoreview passed before both commits at its configured P0 threshold.
- The final head passed all 115 control-plane tests in [GitHub CI](https://github.com/openclaw/docs/actions/runs/33836853544), including the legacy-page follow-up. CodeQL, workflow shell validation, and the docs preview are green.

- The [full-run Spanish canary](https://github.com/openclaw/docs/actions/runs/33846364401/job/100939721718) translated the source page on its first attempt. MDX validation passed without model-driven repair, all 12 fenced examples were preserved exactly, and the downloaded log/artifact contained no configured model identifiers. Full batches are running; publication is still pending.

Production growth is confined to availability fallback, private repair selection, and the existing incremental freshness decision. No new runtime state or database schema is introduced.


## Named Follow-up

**Preserve source heading fragments in localized docs.** Translation retains English link fragments such as `#setup`, while the renderer derives heading IDs and compatibility aliases from localized heading text. Existing published translations have the same gap; this is not introduced by the model-selection change. For example, the Spanish Discord page links to `#follow-users-in-voice` while its heading uses a localized ID. Track the anchor repair separately from the active full translation run; it does not call for changing translation prompts or concurrency.
