### PR TITLE
fix(r2): reject empty remote manifests before scoped upload

### DIFF
--- a/scripts/docs-site/r2-upload.mjs
+++ b/scripts/docs-site/r2-upload.mjs
@@ -210,23 +210,31 @@ function writeUploadManifest(localManifest, currentRemoteManifest, entries) {
 async function getRemoteManifest() {
   if (remoteManifestPath) {
     const file = path.isAbsolute(remoteManifestPath) ? remoteManifestPath : path.join(root, remoteManifestPath);
-    const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
-    return {
-      ...parsed,
-      manifestSource: "file",
-      status: "hit",
-    };
+    return remoteManifestHit(JSON.parse(fs.readFileSync(file, "utf8")), "file");
   }
   if (dryRun) return { entries: [], source: "dry-run", status: "missing" };
   const response = await signedFetchWithRetry("GET", remoteManifestKey);
   if (response.status === 404) return { entries: [], source: "r2", status: "missing" };
   if (!response.ok) throw new Error(`GET manifest failed: ${response.status} ${await response.text()}`);
   const text = await response.text();
+  let parsed;
   try {
-    return { ...JSON.parse(text), manifestSource: "r2", status: "hit" };
+    parsed = JSON.parse(text);
   } catch (error) {
     throw new Error(`GET manifest returned invalid JSON; refusing to reupload the full docs tree: ${error.message}`);
   }
+  return remoteManifestHit(parsed, "r2");
+}
+
+function remoteManifestHit(parsed, source) {
+  if (!Array.isArray(parsed?.entries)) {
+    throw new Error("remote manifest must contain an entries array; refusing to reupload the full docs tree");
+  }
+  return {
+    ...parsed,
+    manifestSource: source,
+    status: "hit",
+  };
 }
 
 async function createUploadPlan(entries, remoteEntriesByKey) {

--- a/scripts/docs-site/r2-upload.test.mjs
+++ b/scripts/docs-site/r2-upload.test.mjs
@@ -181,3 +181,92 @@ test("shell scope selects both physical and virtual redirect objects for metadat
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(puts(result.stdout), local.map((entry) => entry.key).sort());
 });
+
+function localeEntries(template) {
+  return [
+    { ...template, key: "de/page" },
+    { ...template, key: "de/page/index.html" },
+    { ...template, key: "de/page.md" },
+  ];
+}
+
+test("empty object remote manifest is not a hit and does not write a merged manifest", (t) => {
+  const f = uploadFixture(t);
+  const local = localeEntries(f.local[0]);
+  write(f.root, "dist/local.json", JSON.stringify(manifest(local)));
+  write(f.root, "dist/remote.json", "{}\n");
+  const mergedPath = path.join(f.root, "dist/docs-r2-manifest.locale.merged.json");
+  const result = run(f.root, "r2-upload.mjs", {
+    R2_UPLOAD_DRY_RUN: "1", R2_UPLOAD_MANIFEST_PATH: "dist/local.json",
+    R2_UPLOAD_REMOTE_MANIFEST_PATH: "dist/remote.json",
+    R2_UPLOAD_SCOPE: "locale", R2_UPLOAD_LOCALE: "de",
+  });
+  assert.notEqual(result.status, 0, result.stdout);
+  assert.match(`${result.stderr}\n${result.stdout}`, /entries array/i);
+  assert.equal(fs.existsSync(mergedPath), false);
+});
+
+test("valid remote manifest with empty entries array remains a hit", (t) => {
+  const f = uploadFixture(t);
+  const result = dryUpload(f.root, f.local, []);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /r2 remote manifest: hit from file \(0 entries\)/);
+});
+
+test("dry-run without a remote manifest path stays missing", (t) => {
+  const f = uploadFixture(t);
+  write(f.root, "dist/local.json", JSON.stringify(manifest(f.local)));
+  const result = run(f.root, "r2-upload.mjs", {
+    R2_UPLOAD_DRY_RUN: "1", R2_UPLOAD_MANIFEST_PATH: "dist/local.json",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /r2 remote manifest: missing from dry-run \(0 entries\)/);
+});
+
+for (const body of ["null", "[]"]) {
+  test(`remote manifest HTTP 200 body ${body} fails closed`, (t) => {
+    const f = uploadFixture(t);
+    write(f.root, "dist/local.json", JSON.stringify(manifest(f.local)));
+    write(f.root, "mock-fetch.mjs", `
+globalThis.fetch = async (input, init) => {
+  const url = new URL(input);
+  const key = decodeURIComponent(url.pathname.slice("/synthetic-bucket/".length));
+  if (init.method === "GET" && key === ".openclaw-docs-r2-manifest.json") {
+    return new Response(${JSON.stringify(body)}, { status: 200 });
+  }
+  return new Response(null, { status: 200 });
+};
+`);
+    const result = run(f.root, "r2-upload.mjs", {
+      R2_UPLOAD_MANIFEST_PATH: "dist/local.json", R2_UPLOAD_RETRIES: "0",
+      OPENCLAW_R2_S3_ENDPOINT: "https://synthetic-r2.invalid",
+      CLOUDFLARE_R2_BUCKET: "synthetic-bucket", OPENCLAW_R2_ACCESS_KEY_ID: "synthetic-access",
+      OPENCLAW_R2_SECRET_ACCESS_KEY: "synthetic-secret",
+    }, [path.join(f.root, "mock-fetch.mjs")]);
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(`${result.stderr}\n${result.stdout}`, /entries array|invalid JSON/i);
+  });
+}
+
+test("HTTP 404 remote manifest stays missing with empty entries", (t) => {
+  const f = uploadFixture(t);
+  write(f.root, "dist/local.json", JSON.stringify(manifest(f.local)));
+  write(f.root, "mock-fetch.mjs", `
+globalThis.fetch = async (input, init) => {
+  const url = new URL(input);
+  const key = decodeURIComponent(url.pathname.slice("/synthetic-bucket/".length));
+  if (init.method === "GET" && key === ".openclaw-docs-r2-manifest.json") {
+    return new Response("Not Found", { status: 404 });
+  }
+  return new Response(null, { status: 200 });
+};
+`);
+  const result = run(f.root, "r2-upload.mjs", {
+    R2_UPLOAD_MANIFEST_PATH: "dist/local.json", R2_UPLOAD_RETRIES: "0", R2_DELETE_ORPHANS: "0",
+    OPENCLAW_R2_S3_ENDPOINT: "https://synthetic-r2.invalid",
+    CLOUDFLARE_R2_BUCKET: "synthetic-bucket", OPENCLAW_R2_ACCESS_KEY_ID: "synthetic-access",
+    OPENCLAW_R2_SECRET_ACCESS_KEY: "synthetic-secret",
+  }, [path.join(f.root, "mock-fetch.mjs")]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /r2 remote manifest: missing from r2 \(0 entries\)/);
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a docs publish that received a 200 remote manifest of `{}`, `null`, or a JSON array would treat that body as a cache hit. A later locale or page scoped upload then rewrote the remote catalog from that empty set, dropping objects that were not in the current scope.

## Why This Change Was Made

`getRemoteManifest()` already refuses invalid JSON. It did not require `entries` to be an array before stamping `status: "hit"`. Both the R2 GET path and the local file-path path now require `Array.isArray(parsed.entries)`. Dry-run with no remote file and HTTP 404 stay `status: "missing"` with empty entries. A valid `{ version: 1, entries: [], objectCount: 0 }` remains a hit.

## User Impact

Scoped docs publishes no longer replace the remote R2 catalog with a partial tree when the previous manifest body is empty or the wrong JSON shape. Operators see a fail-closed error instead of a successful upload that deleted unpublished locales.

## Evidence

terminal output from running `scripts/docs-site/r2-upload.mjs` through a small node driver against the unfixed tree, then the patched file.

Before, a file-path remote body of `{}` during `R2_UPLOAD_SCOPE=locale` completed as a hit and wrote `dist/docs-r2-manifest.locale.merged.json`:

```console
$ node r2-empty-manifest-driver.mjs
===== FILE {} scoped locale dry-run =====
status=0
stdout:
r2 remote manifest: hit from file (0 entries)
r2 upload scope: locale (1/1 manifest entries, partial=true)
r2 object cache: 0/1 hits, 1 misses; hit sources: none; miss reasons: missing=1
r2 upload plan: 1/1 changed objects, 0 deleted objects
r2 dry-run put: de/page
r2 dry-run put: .openclaw-docs-r2-manifest.json
r2 upload ok: 1 changed objects, 0 deleted objects plus .openclaw-docs-r2-manifest.json
merged_exists=true
```

An HTTP 200 body of `{}` from the synthetic R2 endpoint also completed as a hit:

```console
===== FETCH 200 {} =====
status=0
stdout:
r2 remote manifest: hit from r2 (0 entries)
r2 upload ok: 1 changed objects, 0 deleted objects plus .openclaw-docs-r2-manifest.json
```

After the patch, the same driver refuses both empty shapes and still accepts a valid empty `entries` array:

```console
===== FILE {} scoped locale dry-run =====
status=1
stderr:
Error: remote manifest must contain an entries array; refusing to reupload the full docs tree
merged_exists=false

===== FETCH 200 {} =====
status=1
Error: remote manifest must contain an entries array; refusing to reupload the full docs tree

===== FETCH 200 valid empty entries =====
status=0
r2 remote manifest: hit from r2 (0 entries)
r2 upload ok: 1 changed objects, 0 deleted objects plus .openclaw-docs-r2-manifest.json
```

`node --check scripts/docs-site/r2-upload.mjs` exits 0.

The hit-without-shape-check has been present since the R2 publish path landed in d6e2734f7 (2026-05-07). File-path hits were added in 40cd8f45f (2026-05-16). Related publish work: https://github.com/openclaw/docs/pull/74 , https://github.com/openclaw/docs/pull/139 , https://github.com/openclaw/docs/pull/143 .

## Real behavior proof

- **Behavior or issue addressed:** A 200 remote manifest of `{}`, `null`, or a JSON array was treated as a hit, so a scoped upload rewrote the remote catalog from an empty entry set.
- **Real environment tested:** Windows 11, Node v24.19.0, repo checkout at C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f001 on branch fix/r2-empty-manifest-hit, synthetic R2 endpoint https://synthetic-r2.invalid plus a file-path remote manifest.
- **Exact steps or command run after this patch:** node C:\Users\sebta\AppData\Local\Temp\r2-empty-manifest-driver.mjs C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f001 . The driver writes a one-entry local manifest, then runs scripts/docs-site/r2-upload.mjs for a file-path `{}` with R2_UPLOAD_SCOPE=locale, an HTTP 200 `{}`, and an HTTP 200 `{ version: 1, entries: [], objectCount: 0 }`.
- **Evidence after fix:** terminal output above. File-path `{}` and HTTP 200 `{}` exit 1 with remote manifest must contain an entries array; refusing to reupload the full docs tree. The valid empty entries array stays a hit and completes the upload plan.
- **Observed result after fix:** Empty or wrong-shape remote bodies no longer stamp status hit. The locale-scoped run does not write docs-r2-manifest.locale.merged.json. A real empty catalog (entries: []) still publishes.
- **What was not tested:** A live Cloudflare R2 bucket with production credentials. Invalid JSON text still uses the existing parse error path and was not re-exercised here.
