### PR TITLE
build(i18n): update translation CLI toolchain

### DIFF
--- a/.github/scripts/i18n/toolchain.json
+++ b/.github/scripts/i18n/toolchain.json
@@ -1,4 +1,4 @@
 {
-  "codex_cli": "0.146.1",
+  "codex_cli": "0.153.3",
   "go_version": "1.26"
 }


### PR DESCRIPTION
The docs translation workflow pinned a CLI release that predates the native metadata used by the current private translation configuration. This updates the centrally owned toolchain pin so future translation jobs use the supported CLI contract without exposing private routing details in workflow inputs, source, or logs.

Validation:

- Ran the pinned CLI through the real docs translation engine against a frozen IRC reference page.
- Verified translated content, source metadata, protected tokens, localized links, privacy scanning, and MDX parsing.
- Confirmed the existing workflow resolves this pin from the central toolchain file and needs no coupled workflow change.
- Codex autoreview: clean at P2 (0.99 confidence).
