### PR TITLE
fix: abort stalled signed R2 fetches

### DIFF
--- a/scripts/docs-site/r2-upload.mjs
+++ b/scripts/docs-site/r2-upload.mjs
@@ -19,7 +19,7 @@ const sessionToken = process.env.OPENCLAW_R2_SESSION_TOKEN || process.env.AWS_SE
 const region = process.env.OPENCLAW_R2_REGION || "auto";
 const service = "s3";
 const retryAttempts = Number.parseInt(process.env.R2_UPLOAD_RETRIES || "5", 10);
-const fetchTimeoutMs = Number.parseInt(process.env.R2_UPLOAD_FETCH_TIMEOUT_MS || "30000", 10);
+const fetchTimeoutMs = Number(process.env.R2_UPLOAD_FETCH_TIMEOUT_MS || "30000");
 const deleteOrphans = process.env.R2_DELETE_ORPHANS !== "0";
 const deleteBucketOrphans = process.env.R2_DELETE_BUCKET_ORPHANS !== "0";
 const fullRefresh = process.env.R2_UPLOAD_FORCE === "1" || process.env.R2_UPLOAD_FULL_REFRESH === "1";
@@ -39,7 +39,10 @@ const protectedKeys = new Set([
 
 if (!Number.isFinite(concurrency) || concurrency < 1) throw new Error("R2_UPLOAD_CONCURRENCY must be a positive integer");
 if (!Number.isFinite(refreshConcurrency) || refreshConcurrency < 1) throw new Error("R2_REFRESH_CONCURRENCY must be a positive integer");
-if (!Number.isFinite(fetchTimeoutMs) || fetchTimeoutMs < 1) throw new Error("R2_UPLOAD_FETCH_TIMEOUT_MS must be a positive integer");
+// Larger delays overflow Node timers and can become one-millisecond timeouts.
+if (!Number.isInteger(fetchTimeoutMs) || fetchTimeoutMs < 1 || fetchTimeoutMs > 2_147_483_647) {
+  throw new Error("R2_UPLOAD_FETCH_TIMEOUT_MS must be an integer between 1 and 2147483647 milliseconds");
+}
 if (!fs.existsSync(manifestPath)) throw new Error(`${path.relative(root, manifestPath) || manifestPath} does not exist; run the matching build step first`);
 if (!dryRun && !endpoint) throw new Error("OPENCLAW_R2_S3_ENDPOINT or CLOUDFLARE_ACCOUNT_ID is required");
 if (!dryRun && !accessKeyId) throw new Error("OPENCLAW_R2_ACCESS_KEY_ID or AWS_ACCESS_KEY_ID is required");

--- a/scripts/docs-site/r2-upload.mjs
+++ b/scripts/docs-site/r2-upload.mjs
@@ -19,6 +19,7 @@ const sessionToken = process.env.OPENCLAW_R2_SESSION_TOKEN || process.env.AWS_SE
 const region = process.env.OPENCLAW_R2_REGION || "auto";
 const service = "s3";
 const retryAttempts = Number.parseInt(process.env.R2_UPLOAD_RETRIES || "5", 10);
+const fetchTimeoutMs = Number.parseInt(process.env.R2_UPLOAD_FETCH_TIMEOUT_MS || "30000", 10);
 const deleteOrphans = process.env.R2_DELETE_ORPHANS !== "0";
 const deleteBucketOrphans = process.env.R2_DELETE_BUCKET_ORPHANS !== "0";
 const fullRefresh = process.env.R2_UPLOAD_FORCE === "1" || process.env.R2_UPLOAD_FULL_REFRESH === "1";
@@ -38,6 +39,7 @@ const protectedKeys = new Set([
 
 if (!Number.isFinite(concurrency) || concurrency < 1) throw new Error("R2_UPLOAD_CONCURRENCY must be a positive integer");
 if (!Number.isFinite(refreshConcurrency) || refreshConcurrency < 1) throw new Error("R2_REFRESH_CONCURRENCY must be a positive integer");
+if (!Number.isFinite(fetchTimeoutMs) || fetchTimeoutMs < 1) throw new Error("R2_UPLOAD_FETCH_TIMEOUT_MS must be a positive integer");
 if (!fs.existsSync(manifestPath)) throw new Error(`${path.relative(root, manifestPath) || manifestPath} does not exist; run the matching build step first`);
 if (!dryRun && !endpoint) throw new Error("OPENCLAW_R2_S3_ENDPOINT or CLOUDFLARE_ACCOUNT_ID is required");
 if (!dryRun && !accessKeyId) throw new Error("OPENCLAW_R2_ACCESS_KEY_ID or AWS_ACCESS_KEY_ID is required");
@@ -493,11 +495,11 @@ async function deleteObject(entry) {
   if (!response.ok) throw new Error(`R2 delete failed for ${entry.key}: ${response.status} ${await response.text()}`);
 }
 
-async function signedFetchWithRetry(method, key, body, headers = {}, query = {}) {
+async function signedFetchWithRetry(method, key, body, headers = {}, query = {}, options = {}) {
   let lastError;
   for (let attempt = 0; attempt <= retryAttempts; attempt++) {
     try {
-      const response = await signedFetch(method, key, body, headers, query);
+      const response = await signedFetch(method, key, body, headers, query, options);
       if (!isRetryableStatus(response.status) || attempt === retryAttempts) return response;
       lastError = new Error(`HTTP ${response.status}`);
       await response.arrayBuffer().catch(() => {});
@@ -510,7 +512,7 @@ async function signedFetchWithRetry(method, key, body, headers = {}, query = {})
   throw lastError;
 }
 
-async function signedFetch(method, key, body, headers = {}, query = {}) {
+async function signedFetch(method, key, body, headers = {}, query = {}, options = {}) {
   const encodedKey = key ? `/${encodeS3Key(key)}` : "";
   const url = new URL(`${endpoint.replace(/\/$/, "")}/${bucket}${encodedKey}`);
   const canonicalQuery = canonicalQueryString(query);
@@ -550,7 +552,16 @@ async function signedFetch(method, key, body, headers = {}, query = {}) {
     body,
     headers: { ...normalizedHeaders, authorization },
     method,
+    signal: resolveFetchSignal(options.signal),
   });
+}
+
+function resolveFetchSignal(callerSignal) {
+  const timeoutSignal = AbortSignal.timeout(fetchTimeoutMs);
+  if (!callerSignal) return timeoutSignal;
+  return typeof AbortSignal.any === "function"
+    ? AbortSignal.any([callerSignal, timeoutSignal])
+    : callerSignal;
 }
 
 function isRetryableStatus(status) {

--- a/scripts/docs-site/r2-upload.test.mjs
+++ b/scripts/docs-site/r2-upload.test.mjs
@@ -63,6 +63,16 @@ const syntheticR2 = {
   OPENCLAW_R2_SECRET_ACCESS_KEY: "synthetic-secret",
 };
 
+for (const value of ["30s", "1.5", "0", "-1", "Infinity", "2147483648"]) {
+  test(`R2 upload rejects invalid timeout ${value} before making a request`, (t) => {
+    const root = fetchUploadRoot(t);
+    const result = run(root, "r2-upload.mjs", { ...syntheticR2, R2_UPLOAD_FETCH_TIMEOUT_MS: value });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /R2_UPLOAD_FETCH_TIMEOUT_MS must be an integer between/);
+    assert.doesNotMatch(result.stderr, /Unexpected outbound fetch/);
+  });
+}
+
 test("manifest diff detects metadata additions, changes and removals with identical HTML hashes", (t) => {
   const f = uploadFixture(t);
   const result = dryUpload(f.root, f.local, f.old);

--- a/scripts/docs-site/r2-upload.test.mjs
+++ b/scripts/docs-site/r2-upload.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fixture, servesMarkdown, pipeline, run, write } from "./test-helpers/redirect-fixture.mjs";
@@ -37,6 +38,30 @@ function puts(output) {
   return [...output.matchAll(/^r2 dry-run put: (.+)$/gm)].map((match) => match[1])
     .filter((key) => key !== ".openclaw-docs-r2-manifest.json").sort();
 }
+
+function fetchUploadRoot(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-r2-fetch-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  write(root, "no-network.mjs", 'globalThis.fetch = () => { throw new Error("Unexpected outbound fetch"); };\n');
+  const body = "<html>ok</html>";
+  write(root, "files/page.html", body);
+  const local = [{
+    key: "page", sourceKey: "page", file: "files/page.html", size: Buffer.byteLength(body),
+    contentType: "text/html; charset=utf-8", cacheControl: "public, max-age=60",
+    sha256: crypto.createHash("sha256").update(body).digest("hex"),
+    md5: crypto.createHash("md5").update(body).digest("hex"),
+  }];
+  write(root, "dist/local.json", JSON.stringify(manifest(local)));
+  write(root, "dist/remote.json", JSON.stringify(manifest(local)));
+  return root;
+}
+
+const syntheticR2 = {
+  R2_UPLOAD_MANIFEST_PATH: "dist/local.json", R2_UPLOAD_REMOTE_MANIFEST_PATH: "dist/remote.json",
+  R2_DELETE_ORPHANS: "0", R2_UPLOAD_RETRIES: "0", OPENCLAW_R2_S3_ENDPOINT: "https://synthetic-r2.invalid",
+  CLOUDFLARE_R2_BUCKET: "synthetic-bucket", OPENCLAW_R2_ACCESS_KEY_ID: "synthetic-access",
+  OPENCLAW_R2_SECRET_ACCESS_KEY: "synthetic-secret",
+};
 
 test("manifest diff detects metadata additions, changes and removals with identical HTML hashes", (t) => {
   const f = uploadFixture(t);
@@ -168,6 +193,67 @@ test("translation page/locale scopes own affected aliases and compatibility pref
   });
   assert.equal(fallback.status, 0, fallback.stderr);
   assert.deepEqual(puts(fallback.stdout), expected.filter((key) => !key.startsWith("de/target")));
+});
+
+test("signedFetch attaches an AbortSignal so a stalled R2 socket can time out", (t) => {
+  const root = fetchUploadRoot(t);
+  write(root, "mock-fetch.mjs", `
+import fs from "node:fs";
+const calls = [];
+globalThis.fetch = async (input, init = {}) => {
+  const url = new URL(input);
+  const key = decodeURIComponent(url.pathname.slice("/synthetic-bucket/".length));
+  calls.push({
+    method: init.method,
+    key,
+    hasSignal: Boolean(init.signal),
+    signalAborted: Boolean(init.signal?.aborted),
+    signalName: init.signal?.constructor?.name ?? null,
+  });
+  fs.writeFileSync("calls.json", JSON.stringify(calls));
+  return new Response(null, { status: 200 });
+};
+`);
+  const result = run(root, "r2-upload.mjs", syntheticR2, [path.join(root, "mock-fetch.mjs")]);
+  assert.equal(result.status, 0, result.stderr);
+  const calls = JSON.parse(fs.readFileSync(path.join(root, "calls.json"), "utf8"));
+  assert.ok(calls.length > 0, "signedFetch must call fetch at least once");
+  for (const call of calls) {
+    assert.equal(call.hasSignal, true, `${call.method} ${call.key} missing AbortSignal`);
+    assert.equal(call.signalName, "AbortSignal", `${call.method} ${call.key}`);
+    assert.equal(call.signalAborted, false, `${call.method} ${call.key} started already aborted`);
+  }
+});
+
+test("signedFetch aborts a hung R2 fetch so retries are not stuck on a stalled socket", (t) => {
+  const root = fetchUploadRoot(t);
+  write(root, "mock-fetch.mjs", `
+globalThis.fetch = (_input, init = {}) => new Promise((_resolve, reject) => {
+  const signal = init.signal;
+  const keepAlive = setTimeout(() => {}, 60_000);
+  const abort = () => {
+    clearTimeout(keepAlive);
+    const error = new Error("The operation was aborted");
+    error.name = "AbortError";
+    reject(error);
+  };
+  if (!signal) return;
+  if (signal.aborted) {
+    abort();
+    return;
+  }
+  signal.addEventListener("abort", abort, { once: true });
+});
+`);
+  const started = Date.now();
+  const result = run(root, "r2-upload.mjs", {
+    ...syntheticR2, R2_UPLOAD_FETCH_TIMEOUT_MS: "80",
+  }, [path.join(root, "mock-fetch.mjs")], { timeout: 4000 });
+  const elapsed = Date.now() - started;
+  assert.notEqual(result.status, null, `hung fetch was killed after ${elapsed}ms instead of aborting`);
+  assert.notEqual(result.status, 0, result.stdout);
+  assert.match(result.stderr, /abort/i);
+  assert.ok(elapsed < 2000, `hung fetch ran ${elapsed}ms without aborting`);
 });
 
 test("shell scope selects both physical and virtual redirect objects for metadata-only changes", (t) => {

--- a/scripts/docs-site/test-helpers/redirect-fixture.mjs
+++ b/scripts/docs-site/test-helpers/redirect-fixture.mjs
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import worker from "../../../workers/docs-router.ts";
 
 export const repo = fileURLToPath(new URL("../../../", import.meta.url));
@@ -14,16 +14,17 @@ export function write(root, name, content) {
   fs.writeFileSync(file, content);
 }
 
-export function run(root, script, env = {}, imports = []) {
+export function run(root, script, env = {}, imports = [], options = {}) {
   return spawnSync(process.execPath, [
-    "--import", path.join(root, "no-network.mjs"),
-    ...imports.flatMap((file) => ["--import", file]),
+    "--import", pathToFileURL(path.join(root, "no-network.mjs")).href,
+    ...imports.flatMap((file) => ["--import", pathToFileURL(file).href]),
     path.join(repo, "scripts/docs-site", script),
   ], {
     cwd: root,
     env: { PATH: process.env.PATH, ...env },
     encoding: "utf8",
     maxBuffer: 8 * 1024 * 1024,
+    timeout: options.timeout,
   });
 }
 
@@ -32,7 +33,14 @@ export function fixture(t, redirects = [], sources = {}, basePath = "") {
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   write(root, "no-network.mjs", 'globalThis.fetch = () => { throw new Error("Unexpected outbound fetch"); };\n');
   fs.mkdirSync(path.join(root, "scripts"));
-  fs.symlinkSync(path.join(repo, "scripts/docs-site"), path.join(root, "scripts/docs-site"), "dir");
+  const docsSite = path.join(repo, "scripts/docs-site");
+  const fixtureDocsSite = path.join(root, "scripts/docs-site");
+  try {
+    fs.symlinkSync(docsSite, fixtureDocsSite, "dir");
+  } catch (error) {
+    if (error.code !== "EPERM") throw error;
+    fs.symlinkSync(docsSite, fixtureDocsSite, "junction");
+  }
   write(root, "docs/docs.json", JSON.stringify({
     name: "Redirect fixture",
     navigation: { languages: ["en", "de", "fr"].map((language) => ({ language, tabs: [] })) },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a docs R2 publish that hit a stalled socket would hang until the GitHub runner hit its job limit. `signedFetch` completed only after a response or a thrown error, so `signedFetchWithRetry` never ran while the TCP connection sat idle.

## Why This Change Was Made

Every signed R2 `fetch` now carries `AbortSignal.timeout`. The default budget is 30000ms and can be raised with `R2_UPLOAD_FETCH_TIMEOUT_MS`. If a caller already passes a signal, that signal is honored and combined with the timeout. Empty-manifest handling from #161 is unchanged.

## User Impact

Docs publish jobs fail closed on a stalled R2 request and retry, instead of occupying a runner until the workflow times out. Operators can raise the per-request budget when a large object needs more than 30 seconds.

## Evidence

terminal output from running `scripts/docs-site/r2-upload.mjs` against the unfixed tree, then the same script after the patch.

Before, a successful PUT to the synthetic R2 endpoint had no abort signal, and a hung PUT never reached the retry loop:

```console
$ node --check scripts/docs-site/r2-upload.mjs
(exit 0)

AssertionError [ERR_ASSERTION]: PUT .openclaw-docs-r2-manifest.json missing AbortSignal
false !== true

Warning: Detected unsettled top-level await at file:///C:/Users/sebta/.grok/tmp/pr-gate-batch/docs-f002/scripts/docs-site/r2-upload.mjs:81
await putObject({
```

After the patch, the same driver attaches an AbortSignal on the successful PUT and aborts a hung request inside the 80ms budget:

```console
$ node C:\Users\sebta\AppData\Local\Temp\r2-fetch-abort-driver.mjs C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f002
===== SIGNAL on successful PUT =====
status=0
signal=null
elapsed_ms=73
stdout:
r2 remote manifest: hit from file (1 entries)
r2 upload scope: all (1/1 manifest entries, partial=false)
r2 object cache: 1/1 hits, 0 misses; hit sources: manifest=1; miss reasons: none
r2 upload plan: 0/1 changed objects, 0 deleted objects (0 from manifest, 0 bucket-orphaned, fullRefresh=false, putAll=false, dryRun=false, bucketOrphanSweep=true) for synthetic-bucket
r2 upload ok: 0 changed objects, 0 deleted objects plus .openclaw-docs-r2-manifest.json
calls=[{"method":"PUT","key":".openclaw-docs-r2-manifest.json","hasSignal":true,"signalName":"AbortSignal"}]

===== HUNG fetch with 80ms budget =====
status=1
signal=null
elapsed_ms=141
stdout:
r2 remote manifest: hit from file (1 entries)
r2 upload scope: all (1/1 manifest entries, partial=false)
r2 object cache: 1/1 hits, 0 misses; hit sources: manifest=1; miss reasons: none
r2 upload plan: 0/1 changed objects, 0 deleted objects (0 from manifest, 0 bucket-orphaned, fullRefresh=false, putAll=false, dryRun=false, bucketOrphanSweep=true) for synthetic-bucket
stderr:
Error [AbortError]: The operation was aborted
    at Timeout._onTimeout (node:internal/abort_controller:208:7)
    at listOnTimeout (node:internal/timers:635:17)
    at process.processTimers (node:internal/timers:571:7)
```

`node --check scripts/docs-site/r2-upload.mjs` exits 0.

The missing abort signal has been present since the R2 publish path landed. Sibling empty-manifest work is #161 and is not changed here.

## Real behavior proof

- **Behavior or issue addressed:** A stalled signed R2 fetch never timed out, so retries could not start and a docs publish job could hang for the rest of the runner lifetime.
- **Real environment tested:** Windows 11, Node v24.19.0, repo checkout at C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f002 on branch fix/r2-fetch-abort, synthetic R2 endpoint https://synthetic-r2.invalid plus a file-path remote manifest.
- **Exact steps or command run after this patch:** node C:\Users\sebta\AppData\Local\Temp\r2-fetch-abort-driver.mjs C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f002 . The driver writes a one-entry local manifest, then runs scripts/docs-site/r2-upload.mjs for a successful PUT (records whether fetch received a signal) and a hung PUT with R2_UPLOAD_FETCH_TIMEOUT_MS=80.
- **Evidence after fix:** terminal output above. The successful PUT records hasSignal=true and signalName=AbortSignal. The hung request exits 1 after 141ms with Error [AbortError]: The operation was aborted from AbortSignal.timeout, instead of sitting on an unsettled top-level await.
- **Observed result after fix:** signed R2 fetches now carry a timeout signal. A hung socket reaches signedFetchWithRetry as an abort error instead of occupying the process until the job is killed.
- **What was not tested:** A live Cloudflare R2 bucket with production credentials. Large object uploads that need more than the 30s default should set R2_UPLOAD_FETCH_TIMEOUT_MS; that operator path was not run against a real bucket.
