### PR TITLE
fix: bound docs live-smoke fetches and job time

### DIFF
--- a/.github/workflows/docs-live-smoke.yml
+++ b/.github/workflows/docs-live-smoke.yml
@@ -22,6 +22,7 @@ jobs:
   smoke:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - name: Check out
         uses: actions/checkout@v7.0.1
@@ -116,6 +117,7 @@ jobs:
                 "cache-control": "no-cache",
                 pragma: "no-cache",
               },
+              signal: AbortSignal.timeout(30_000),
             });
             if (!response.ok) {
               throw new Error(`${path}: HTTP ${response.status}`);
@@ -140,6 +142,7 @@ jobs:
                 "cache-control": "no-cache",
                 pragma: "no-cache",
               },
+              signal: AbortSignal.timeout(30_000),
             });
             if (!response.ok) throw new Error(`${path}: markdown HTTP ${response.status}`);
             const text = await response.text();
@@ -158,6 +161,7 @@ jobs:
                 "cache-control": "no-cache",
                 pragma: "no-cache",
               },
+              signal: AbortSignal.timeout(30_000),
             });
             if (!response.ok) throw new Error(`${path}: text HTTP ${response.status}`);
             const text = await response.text();
@@ -178,6 +182,7 @@ jobs:
                 "cache-control": "no-cache",
                 pragma: "no-cache",
               },
+              signal: AbortSignal.timeout(30_000),
             });
             if (!response.ok) throw new Error(`/api/search: HTTP ${response.status}`);
             const contentType = response.headers.get("content-type") ?? "";
@@ -202,6 +207,7 @@ jobs:
                 "content-type": "application/json",
                 pragma: "no-cache",
               },
+              signal: AbortSignal.timeout(30_000),
               body: JSON.stringify({
                 jsonrpc: "2.0",
                 id: 1,
@@ -227,6 +233,7 @@ jobs:
                 "cache-control": "no-cache",
                 pragma: "no-cache",
               },
+              signal: AbortSignal.timeout(30_000),
             });
             if (!response.ok) throw new Error(`${path}: header HTTP ${response.status}`);
             const value = response.headers.get(name) ?? "";
@@ -266,6 +273,7 @@ jobs:
   sample:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out main
         uses: actions/checkout@v7.0.1

--- a/scripts/docs-site/docs-live-smoke-workflow.test.mjs
+++ b/scripts/docs-site/docs-live-smoke-workflow.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const workflowPath = fileURLToPath(
+  new URL("../../.github/workflows/docs-live-smoke.yml", import.meta.url),
+);
+
+function loadWorkflow() {
+  return fs.readFileSync(workflowPath, "utf8");
+}
+
+function jobBlocks(source) {
+  const jobsIdx = source.search(/^jobs:\s*$/m);
+  assert.ok(jobsIdx >= 0, "workflow must declare jobs");
+  const jobsSection = source.slice(jobsIdx);
+  const matches = [...jobsSection.matchAll(/^  ([A-Za-z][\w-]*)\s*:\s*$/gm)];
+  assert.ok(matches.length > 0, "workflow must declare at least one job");
+  return matches.map((match, index) => {
+    const start = match.index;
+    const end = index + 1 < matches.length ? matches[index + 1].index : jobsSection.length;
+    return { name: match[1], body: jobsSection.slice(start, end) };
+  });
+}
+
+function extractFetchCalls(source) {
+  const calls = [];
+  const needle = "await fetch(";
+  let from = 0;
+  while (from < source.length) {
+    const start = source.indexOf(needle, from);
+    if (start === -1) {
+      break;
+    }
+    let i = start + needle.length;
+    let depth = 1;
+    let quote = null;
+    while (i < source.length && depth > 0) {
+      const ch = source[i];
+      if (quote) {
+        if (ch === "\\") {
+          i += 2;
+          continue;
+        }
+        if (ch === quote) {
+          quote = null;
+        }
+      } else if (ch === '"' || ch === "'" || ch === "`") {
+        quote = ch;
+      } else if (ch === "(") {
+        depth += 1;
+      } else if (ch === ")") {
+        depth -= 1;
+      }
+      i += 1;
+    }
+    calls.push(source.slice(start, i));
+    from = i;
+  }
+  return calls;
+}
+
+test("every docs-live-smoke job has timeout-minutes", () => {
+  const jobs = jobBlocks(loadWorkflow());
+  assert.ok(
+    jobs.length >= 2,
+    `expected smoke and sample jobs, got ${jobs.map((job) => job.name).join(",")}`,
+  );
+  for (const job of jobs) {
+    const timeout = job.body.match(/^\s+timeout-minutes:\s+(\d+)\s*$/m);
+    assert.ok(timeout, `${job.name} is missing timeout-minutes`);
+    assert.ok(Number(timeout[1]) > 0, `${job.name} timeout-minutes must be positive`);
+  }
+});
+
+test("every inline live fetch uses AbortSignal.timeout", () => {
+  const fetches = extractFetchCalls(loadWorkflow());
+  assert.ok(fetches.length >= 6, `expected at least 6 live fetches, found ${fetches.length}`);
+  for (const call of fetches) {
+    assert.match(
+      call,
+      /signal:\s*AbortSignal\.timeout\(\s*\d[\d_]*\s*\)/,
+      `fetch is missing AbortSignal.timeout:\n${call}`,
+    );
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Docs Live Smoke could occupy a GitHub runner until the six-hour default when a live docs page stopped responding. The dispatch `smoke` job and the scheduled `sample` job had no `timeout-minutes`. Six of the seven inline `fetch` calls also had no `AbortSignal`, so a stalled TCP connection never failed and the retry loop never moved on.

## Why This Change Was Made

Both jobs now set `timeout-minutes` (`25` on `smoke` so the existing 20-minute retry window plus setup can finish, `15` on `sample`). Every inline live `fetch` now passes `AbortSignal.timeout`. Dispatch probes use 30000ms. The scheduled sampler already used 15000ms and keeps that budget. Empty-manifest handling from #161 and signed R2 abort from #163 are unchanged.

## User Impact

A hung docs.openclaw.ai probe now fails in 30 seconds (or 15 seconds on the sampler) and the job is killed by 25 minutes at the latest, instead of holding a runner for up to six hours. Operators still get the same page, markdown, search, and header assertions when the site is healthy.

## Evidence

Live `node` reading `.github/workflows/docs-live-smoke.yml`. The reader walks `jobs:` and every `await fetch(` call. It was first run against `origin/main` (`579119ccc`) with the production workflow left in place, then against the patched file.

Before, both jobs report `timeout: null` and six of seven fetches report `hasAbort: false`:

```console
$ node C:\Users\sebta\AppData\Local\Temp\docs-f003-live-read.mjs C:\Users\sebta\AppData\Local\Temp\docs-f003-main-live-smoke.yml
{
  "workflowPath": "C:\\Users\\sebta\\AppData\\Local\\Temp\\docs-f003-main-live-smoke.yml",
  "jobs": [
    { "name": "smoke", "timeout": null },
    { "name": "sample", "timeout": null }
  ],
  "fetches": [
    { "preview": "await fetch(url, { headers: { \"cache-control\": \"no-cache\", pragma: \"no-cache\", }", "hasAbort": false, "abortMs": null },
    { "preview": "await fetch(url, { headers: { accept: \"text/markdown\", \"cache-control\": \"no-cach", "hasAbort": false, "abortMs": null },
    { "preview": "await fetch(url, { headers: { \"cache-control\": \"no-cache\", pragma: \"no-cache\", }", "hasAbort": false, "abortMs": null },
    { "preview": "await fetch(url, { headers: { accept: \"application/json\", \"cache-control\": \"no-c", "hasAbort": false, "abortMs": null },
    { "preview": "await fetch(new URL(\"/mcp\", baseUrl), { method: \"POST\", headers: { accept: \"appl", "hasAbort": false, "abortMs": null },
    { "preview": "await fetch(new URL(path, baseUrl), { method: \"HEAD\", headers: { \"cache-control\"", "hasAbort": false, "abortMs": null },
    { "preview": "await fetch(url, { headers: { \"cache-control\": \"no-cache\", pragma: \"no-cache\", }", "hasAbort": true, "abortMs": 15000 }
  ]
}
```

The new workflow reader test failed on that same unfixed file (`smoke is missing timeout-minutes`, then `fetch is missing AbortSignal.timeout` on the first dispatch `assertPage` call).

After the patch, the same reader reports timeouts on both jobs and abort budgets on every fetch:

```console
$ node C:\Users\sebta\AppData\Local\Temp\docs-f003-live-read.mjs .github/workflows/docs-live-smoke.yml
{
  "workflowPath": ".github/workflows/docs-live-smoke.yml",
  "jobs": [
    { "name": "smoke", "timeout": 25 },
    { "name": "sample", "timeout": 15 }
  ],
  "fetches": [
    { "hasAbort": true, "abortMs": 30000 },
    { "hasAbort": true, "abortMs": 30000 },
    { "hasAbort": true, "abortMs": 30000 },
    { "hasAbort": true, "abortMs": 30000 },
    { "hasAbort": true, "abortMs": 30000 },
    { "hasAbort": true, "abortMs": 30000 },
    { "hasAbort": true, "abortMs": 15000 }
  ]
}

$ node --test scripts/docs-site/docs-live-smoke-workflow.test.mjs
✔ every docs-live-smoke job has timeout-minutes
✔ every inline live fetch uses AbortSignal.timeout
ℹ tests 2
ℹ pass 2
ℹ fail 0
```

`r2-upload.mjs` is not in this diff. Sibling work is #161 and #163.

## Real behavior proof

- **Behavior or issue addressed:** Docs Live Smoke had no job timeout, and six dispatch fetches had no abort signal, so a hung live page could occupy a runner until the six-hour GitHub default.
- **Real environment tested:** Windows 11, Node v24.19.0, repo checkout at C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f003 on branch fix/live-smoke-abort, reading origin/main's docs-live-smoke.yml and then the patched file in the same worktree.
- **Exact steps or command run after this patch:** node C:\Users\sebta\AppData\Local\Temp\docs-f003-live-read.mjs C:\Users\sebta\AppData\Local\Temp\docs-f003-main-live-smoke.yml (git show origin/main:.github/workflows/docs-live-smoke.yml). Then the same reader on .github/workflows/docs-live-smoke.yml, then node --test scripts/docs-site/docs-live-smoke-workflow.test.mjs.
- **Evidence after fix:** terminal output above. smoke.timeout is 25, sample.timeout is 15, and all seven await fetch calls report hasAbort true (30000ms on the six dispatch probes, 15000ms on the existing sampler).
- **Observed result after fix:** A stalled live probe now has a 30-second AbortSignal (15 seconds on the sampler). The runner is also bounded by timeout-minutes instead of the six-hour default.
- **What was not tested:** A live workflow_dispatch against https://docs.openclaw.ai. This change only bounds the existing probes; it does not alter which pages are checked.
