### PR TITLE
fix: skip locale commit when source.json is missing

### DIFF
--- a/.github/scripts/i18n/commit_locale_artifact.py
+++ b/.github/scripts/i18n/commit_locale_artifact.py
@@ -70,11 +70,15 @@ def remote_source_sha() -> str:
 
 def ensure_base_current(base_source_sha: str, locale: str) -> bool:
     current_source_sha = remote_source_sha()
-    if current_source_sha and current_source_sha != base_source_sha:
+    if not current_source_sha or current_source_sha != base_source_sha:
         # Artifact application already did stale-page filtering against latest
-        # main. If main moves again during validation/push, rerun this locale
-        # rather than commit against an unvalidated source base.
-        print(f"Source moved from {base_source_sha} to {current_source_sha}; skipping {locale} translation commit.")
+        # main. If main moves again during validation/push, or source.json is
+        # missing/unreadable, skip rather than commit against an unvalidated
+        # source base.
+        if current_source_sha:
+            print(f"Source moved from {base_source_sha} to {current_source_sha}; skipping {locale} translation commit.")
+        else:
+            print(f"Source metadata missing or unreadable; skipping {locale} translation commit.")
         write_output("committed", "false")
         return False
     return True

--- a/.github/scripts/i18n/tests/test_i18n_scripts.py
+++ b/.github/scripts/i18n/tests/test_i18n_scripts.py
@@ -2121,6 +2121,65 @@ class I18NScriptTests(unittest.TestCase):
             self.assertEqual("# Hindi\n", run_git(repo, "show", "origin/main:docs/hi/index.md"))
             self.assertNotIn("docs/.i18n/hi.tm.jsonl", run_git(repo, "ls-tree", "-r", "--name-only", "origin/main"))
 
+    def test_ensure_base_current_treats_empty_remote_sha_as_stale(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "github_output"
+            stdout = io.StringIO()
+            with patch.object(commit_locale_artifact, "remote_source_sha", return_value=""), patch.dict(os.environ, {"GITHUB_OUTPUT": str(output)}), redirect_stdout(stdout):
+                current = commit_locale_artifact.ensure_base_current("source-a", "fr")
+            self.assertFalse(current)
+            self.assertIn("committed=false", output.read_text(encoding="utf-8"))
+            self.assertIn("missing or unreadable", stdout.getvalue())
+
+    def test_commit_locale_skips_push_when_origin_source_json_is_unreadable(self) -> None:
+        cases = {
+            "missing": None,
+            "invalid": "{not-json\n",
+            "empty_sha": json.dumps({"repository": "openclaw/openclaw", "sha": ""}) + "\n",
+            "missing_sha": json.dumps({"repository": "openclaw/openclaw"}) + "\n",
+        }
+        for name, source_body in cases.items():
+            with self.subTest(name):
+                with tempfile.TemporaryDirectory() as tmp:
+                    tmp_path = Path(tmp)
+                    origin = tmp_path / "origin.git"
+                    subprocess.run(["git", "init", "--bare", str(origin)], check=True, text=True, stdout=subprocess.PIPE)
+                    repo = tmp_path / "repo"
+                    repo.mkdir()
+                    init_repo(repo)
+                    (repo / ".openclaw-sync").mkdir()
+                    if source_body is None:
+                        (repo / ".openclaw-sync/keep").write_text("x\n", encoding="utf-8")
+                    else:
+                        (repo / ".openclaw-sync/source.json").write_text(source_body, encoding="utf-8")
+                    (repo / "docs").mkdir()
+                    (repo / "docs/index.md").write_text("# Index\n", encoding="utf-8")
+                    run_git(repo, "add", ".")
+                    run_git(repo, "commit", "-m", "initial")
+                    run_git(repo, "remote", "add", "origin", str(origin))
+                    run_git(repo, "push", "-u", "origin", "main")
+
+                    (repo / "docs/hi").mkdir(parents=True)
+                    (repo / "docs/hi/index.md").write_text("# Hindi\n", encoding="utf-8")
+                    artifact = repo / ".openclaw-sync/i18n-artifacts/hi-s0of1"
+                    artifact.mkdir(parents=True)
+                    (artifact / "changed-files.txt").write_text("docs/hi/index.md\n", encoding="utf-8")
+                    (artifact / "deleted-files.txt").write_text("", encoding="utf-8")
+
+                    stdout = io.StringIO()
+                    with chdir(repo), redirect_stdout(stdout):
+                        committed = commit_locale_artifact.commit_locale(
+                            "hi",
+                            "source-a",
+                            1,
+                            artifact_role="canary",
+                            artifact_dir=str(artifact),
+                        )
+
+                    self.assertFalse(committed)
+                    self.assertIn("missing or unreadable", stdout.getvalue())
+                    self.assertNotIn("docs/hi/index.md", run_git(repo, "ls-tree", "-r", "--name-only", "origin/main"))
+
     def test_canary_commit_scope_rejects_unrelated_locale_deletes_not_in_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a locale translation commit could still push to `main` when `origin/main` had no readable `.openclaw-sync/source.json`. `remote_source_sha()` returns an empty string on `git show` failure, invalid JSON, or a missing `sha` field. `ensure_base_current` only skipped when that SHA was non-empty and different, so a missing or broken metadata file failed open.

## Why This Change Was Made

Empty remote source SHA is now treated as stale, the same way the aggregate finalizer already skips when source metadata is unreadable. The locale commit writes `committed=false` and does not push. A matching readable SHA still publishes. Sibling R2 work in #161, #163, and #164 is unchanged.

## User Impact

A translation worker no longer publishes locale pages against an unknown or missing source snapshot. Operators see a skip (`Source metadata missing or unreadable`) instead of a successful push that can land translations for the wrong docs tree. The existing `Fail uncommitted locale refresh` step still fails the job so the run is not reported as published.

## Evidence

terminal output from live `python3` against the production `commit_locale_artifact.py` path.

The old guard lets an empty SHA through:

```console
$ python3 -c "current=''; base='source-a'; print('old_skip', bool(current and current != base)); print('new_skip', bool(not current or current != base))"
old_skip False
new_skip True
```

Before the patch, `commit_locale` pushed `docs/hi/index.md` to `origin/main` when source.json was missing, invalid, empty-`sha`, or missing the `sha` field. The control-plane suite on that unfixed script reported `AssertionError: True is not false` for `committed` in all four cases.

After the patch, the same live driver imports the production script and runs `commit_locale` against a real git origin:

```console
$ python3 C:\Users\sebta\AppData\Local\Temp\docs-f005-live-proof.py C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f005
script=C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f005\.github\scripts\i18n\commit_locale_artifact.py
CASE missing
  remote_source_sha=''
  ensure_base_current=False
  commit_locale=False
  origin_has_locale=False
CASE invalid
  remote_source_sha=''
  ensure_base_current=False
  commit_locale=False
  origin_has_locale=False
CASE empty_sha
  remote_source_sha=''
  ensure_base_current=False
  commit_locale=False
  origin_has_locale=False
CASE valid
  remote_source_sha='source-a'
  ensure_base_current=True
  commit_locale=True
  origin_has_locale=True
```

This empty-SHA fail-open has been present since https://github.com/openclaw/docs/pull/63 (2026-06-26). The aggregate finalizer already skips unreadable source metadata in `translate-finalize-reusable.yml`. Related i18n commit control: https://github.com/openclaw/docs/pull/62 , https://github.com/openclaw/docs/pull/68 .

## Real behavior proof

- **Behavior or issue addressed:** A missing or invalid `origin/main` `.openclaw-sync/source.json` still allowed the locale worker to push translation files to `main`.
- **Real environment tested:** Windows 11, Python 3.13.15, repo checkout at C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f005 on branch fix/empty-source-json-stale. The driver creates a bare origin plus a working clone and calls the production script.
- **Exact steps or command run after this patch:** python3 C:\Users\sebta\AppData\Local\Temp\docs-f005-live-proof.py C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f005
- **Evidence after fix:** terminal output above. missing, invalid, and empty_sha cases print `commit_locale=False` and `origin_has_locale=False`. The valid matching SHA still prints `commit_locale=True` and `origin_has_locale=True`.
- **Observed result after fix:** Locale push is skipped when remote source metadata cannot be read. A readable matching SHA still publishes. The worker writes `committed=false` so the existing uncommitted-refresh step can fail the job.
- **What was not tested:** A live GitHub Actions translation run against openclaw/docs `main`. This change only affects the empty/unreadable SHA path; a later source SHA move still uses the existing skip message.
