### PR TITLE
fix: add timeout-minutes to remaining workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ jobs:
   analyze:
     name: analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,7 @@ jobs:
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Mark stale unassigned issues and pull requests
         uses: actions/stale@v11.0.0

--- a/.github/workflows/translate-finalize-reusable.yml
+++ b/.github/workflows/translate-finalize-reusable.yml
@@ -29,6 +29,7 @@ jobs:
   finalize:
     name: Commit successful locale artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     concurrency:
       group: docs-i18n-finalize
       cancel-in-progress: false

--- a/.github/workflows/translate-incremental.yml
+++ b/.github/workflows/translate-incremental.yml
@@ -54,6 +54,7 @@ jobs:
     name: Debounce and pick source
     needs: validate-workflow-shell
     runs-on: ubuntu-latest
+    timeout-minutes: 70
     outputs:
       mode: ${{ steps.prepare.outputs.mode }}
       publish_ref: ${{ steps.prepare.outputs.publish_ref }}
@@ -84,6 +85,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.should_translate == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       locale_count: ${{ steps.plan.outputs.locale_count }}
       source_doc_count: ${{ steps.plan.outputs.source_doc_count }}
@@ -154,6 +156,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.should_translate == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/translate-shell-check-reusable.yml
+++ b/.github/workflows/translate-shell-check-reusable.yml
@@ -14,6 +14,7 @@ jobs:
   check:
     name: Check workflow shell blocks
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/update-skills.yml
+++ b/.github/workflows/update-skills.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/scripts/docs-site/workflow-timeouts.test.mjs
+++ b/scripts/docs-site/workflow-timeouts.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const workflowsDir = fileURLToPath(new URL("../../.github/workflows/", import.meta.url));
+
+const TARGETS = {
+  "update-skills.yml": ["update"],
+  "translate-incremental.yml": [
+    "validate-workflow-shell",
+    "prepare",
+    "plan",
+    "translate",
+    "provider-preflight",
+    "finalize",
+  ],
+  "stale.yml": ["stale"],
+  "codeql.yml": ["analyze"],
+};
+
+// prepare sleeps the default 3600s cooldown. GitHub rejects timeout-minutes on
+// jobs that only `uses:` a reusable workflow; those jobs are bounded in the callee.
+const MIN_TIMEOUT = {
+  "translate-incremental.yml": {
+    prepare: 61,
+  },
+};
+
+function loadWorkflow(name) {
+  return fs.readFileSync(path.join(workflowsDir, name), "utf8");
+}
+
+function jobBlocks(source) {
+  const jobsIdx = source.search(/^jobs:\s*$/m);
+  assert.ok(jobsIdx >= 0, "workflow must declare jobs");
+  const jobsSection = source.slice(jobsIdx);
+  const matches = [...jobsSection.matchAll(/^  ([A-Za-z][\w-]*)\s*:\s*$/gm)];
+  assert.ok(matches.length > 0, "workflow must declare at least one job");
+  return matches.map((match, index) => {
+    const start = match.index;
+    const end = index + 1 < matches.length ? matches[index + 1].index : jobsSection.length;
+    return { name: match[1], body: jobsSection.slice(start, end) };
+  });
+}
+
+function jobTimeout(body) {
+  const timeout = body.match(/^\s+timeout-minutes:\s+(\d+)\s*$/m);
+  return timeout ? Number(timeout[1]) : null;
+}
+
+test("every job in the four remaining workflows has timeout-minutes", () => {
+  for (const [name, expected] of Object.entries(TARGETS)) {
+    const jobs = jobBlocks(loadWorkflow(name));
+    assert.deepEqual(
+      jobs.map((job) => job.name),
+      expected,
+      `${name} job list drifted`,
+    );
+    for (const job of jobs) {
+      const minutes = jobTimeout(job.body);
+      // Caller jobs have `uses:` and no `runs-on`. Step-level `uses:` on local jobs
+      // must not be treated as a reusable-workflow call.
+      const isReusableCall = /^\s{4}uses:\s/m.test(job.body) && !/^\s{4}runs-on:/m.test(job.body);
+      if (isReusableCall) {
+        assert.equal(
+          minutes,
+          null,
+          `${name} job ${job.name} is a reusable call; timeout-minutes belongs in the callee`,
+        );
+        continue;
+      }
+      assert.ok(minutes, `${name} job ${job.name} is missing timeout-minutes`);
+      assert.ok(minutes > 0, `${name} job ${job.name} timeout-minutes must be positive`);
+      const min = MIN_TIMEOUT[name]?.[job.name];
+      if (min) {
+        assert.ok(
+          minutes >= min,
+          `${name} job ${job.name} timeout-minutes must be >= ${min}, got ${minutes}`,
+        );
+      }
+    }
+  }
+});
+
+test("rg -L style: none of the four files lack timeout-minutes", () => {
+  const missing = Object.keys(TARGETS).filter((name) => !loadWorkflow(name).includes("timeout-minutes"));
+  assert.deepEqual(missing, [], `workflows still missing timeout-minutes: ${missing.join(",")}`);
+});
+
+test("incremental reusable callees bound their local jobs", () => {
+  const callees = {
+    "translate-shell-check-reusable.yml": { check: 15 },
+    "translate-finalize-reusable.yml": { finalize: 60 },
+  };
+  for (const [name, expected] of Object.entries(callees)) {
+    const jobs = jobBlocks(loadWorkflow(name));
+    for (const [jobName, min] of Object.entries(expected)) {
+      const job = jobs.find((entry) => entry.name === jobName);
+      assert.ok(job, `${name} is missing job ${jobName}`);
+      const minutes = jobTimeout(job.body);
+      assert.ok(minutes >= min, `${name} job ${jobName} timeout-minutes must be >= ${min}, got ${minutes}`);
+    }
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where four docs workflows could occupy a GitHub-hosted runner until the six-hour default if a step hung. `update-skills`, `Translate Incremental`, `Stale`, and `CodeQL` had no `timeout-minutes`. Sibling workflows (`r2-pages`, `pages`, `docs-code-ci`, `llms-full`, `translate-locale`) already set one.

## Why This Change Was Made

Each local job in those four files now sets `timeout-minutes`. Short jobs use 15. CodeQL uses 30, matching Docs Code CI. Incremental `prepare` uses 70 so the default 3600-second debounce can finish. GitHub does not allow `timeout-minutes` on a job that only `uses:` a reusable workflow, so incremental `validate-workflow-shell` and `finalize` are bounded in the callee files (`15` and `60`). The locale worker already had 360.

## User Impact

A hung skills update, incremental debounce, stale scan, or CodeQL run now fails on a job budget instead of holding a runner for up to six hours. Healthy runs are unchanged. Incremental translation still waits up to one hour for main to settle.

## Evidence

Live `node` reading the four workflow files (plus the two incremental callees). The reader walks `jobs:` and reports each job's `timeout-minutes`. It was first run against `origin/main` copies written to a temp dir (production files left in place), then against the patched files.

Before, every job in the four files reports `timeout: null`:

```console
$ node C:\Users\sebta\AppData\Local\Temp\docs-f004-live-read.mjs C:\Users\sebta\AppData\Local\Temp\docs-f004-main-wf\update-skills.yml C:\Users\sebta\AppData\Local\Temp\docs-f004-main-wf\translate-incremental.yml C:\Users\sebta\AppData\Local\Temp\docs-f004-main-wf\stale.yml C:\Users\sebta\AppData\Local\Temp\docs-f004-main-wf\codeql.yml
[
  { "workflow": "update-skills.yml", "jobs": [ { "name": "update", "timeout": null } ], "hasTimeoutString": false },
  { "workflow": "translate-incremental.yml", "jobs": [
      { "name": "validate-workflow-shell", "timeout": null },
      { "name": "prepare", "timeout": null },
      { "name": "plan", "timeout": null },
      { "name": "translate", "timeout": null },
      { "name": "provider-preflight", "timeout": null },
      { "name": "finalize", "timeout": null }
    ], "hasTimeoutString": false },
  { "workflow": "stale.yml", "jobs": [ { "name": "stale", "timeout": null } ], "hasTimeoutString": false },
  { "workflow": "codeql.yml", "jobs": [ { "name": "analyze", "timeout": null } ], "hasTimeoutString": false }
]
```

After the patch, local jobs report a positive timeout. Reusable-call jobs stay unset on the caller (GitHub restriction). Their callees now report 15 and 60:

```console
$ node C:\Users\sebta\AppData\Local\Temp\docs-f004-live-read.mjs .github/workflows/update-skills.yml .github/workflows/translate-incremental.yml .github/workflows/stale.yml .github/workflows/codeql.yml .github/workflows/translate-shell-check-reusable.yml .github/workflows/translate-finalize-reusable.yml
[
  { "workflow": "update-skills.yml", "jobs": [ { "name": "update", "timeout": 15 } ] },
  { "workflow": "translate-incremental.yml", "jobs": [
      { "name": "validate-workflow-shell", "timeout": null },
      { "name": "prepare", "timeout": 70 },
      { "name": "plan", "timeout": 15 },
      { "name": "translate", "timeout": null },
      { "name": "provider-preflight", "timeout": 15 },
      { "name": "finalize", "timeout": null }
    ] },
  { "workflow": "stale.yml", "jobs": [ { "name": "stale", "timeout": 15 } ] },
  { "workflow": "codeql.yml", "jobs": [ { "name": "analyze", "timeout": 30 } ] },
  { "workflow": "translate-shell-check-reusable.yml", "jobs": [ { "name": "check", "timeout": 15 } ] },
  { "workflow": "translate-finalize-reusable.yml", "jobs": [ { "name": "finalize", "timeout": 60 } ] }
]
```

`rg -L timeout-minutes .github/workflows/` now lists only `docs-live-smoke.yml` (sibling #164). The four files from this finding are no longer in that list. `r2-upload.mjs` and `docs-live-smoke.yml` are not in this diff.

Related: [#164](https://github.com/openclaw/docs/pull/164), [#69](https://github.com/openclaw/docs/pull/69), [#70](https://github.com/openclaw/docs/pull/70), [#61](https://github.com/openclaw/docs/pull/61).

## Real behavior proof

- **Behavior or issue addressed:** Four docs workflows had no job timeout, so a hang could occupy a runner until GitHub's six-hour default.
- **Real environment tested:** Windows 11, Node v24.19.0, repo checkout at C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f004 on branch fix/workflow-timeouts. origin/main copies were written to a temp dir; production files were left in place.
- **Exact steps or command run after this patch:** node C:\Users\sebta\AppData\Local\Temp\docs-f004-live-read.mjs on the origin/main copies, then the same reader on the patched workflow files.
- **Evidence after fix:** terminal output above. update=15, prepare=70, plan=15, provider-preflight=15, stale=15, analyze=30. Incremental shell-check callee=15, finalize callee=60. Caller jobs that only `uses:` a reusable workflow stay unset.
- **Observed result after fix:** A hung update-skills, incremental prepare, stale, or CodeQL job is now killed by timeout-minutes instead of the six-hour default. Incremental debounce still has 70 minutes so the default 3600-second wait can finish.
- **What was not tested:** A live scheduled run of update-skills, Stale, CodeQL, or Translate Incremental. This change only adds job budgets; it does not change what those workflows do when they complete.

## Summary

Audit finding F004. Sibling hang bounds are #161, #163, #164, and #165.
