### PR TITLE
fix: timeout Cloudflare cutover API fetches

### DIFF
--- a/.github/workflows/docs-code-ci.yml
+++ b/.github/workflows/docs-code-ci.yml
@@ -11,6 +11,7 @@ on:
       - "package.json"
       - "package-lock.json"
       - "scripts/cloudflare-cutover-docs-hosts.mjs"
+      - "scripts/*.test.mjs"
       - "scripts/docs-site/**"
       - "workers/**"
       - "wrangler.toml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,15 @@
 
 ## Unreleased
 
+**Highlights:** More reliable docs publishing and translation recovery, with bounded network requests and workflow jobs.
+
 - Preserve published heading IDs, emit unambiguous Mintlify link aliases and component targets, and open nested accordions for fragment navigation using the source-owned shared parsing and redirect contract.
 - Fix redundant locale rendering by excluding locale-owned roots from English page collection, including accidental localized `AGENTS.md` pages and duplicate locale-root Markdown exports.
+- Reject malformed remote R2 manifests before scoped uploads can replace the catalog and lose unrelated pages; thanks @SebTardif.
+- Skip locale publication when the source metadata is missing, unreadable, or empty, while preserving publication for matching source snapshots; thanks @SebTardif.
+- Abort stalled signed R2 requests so uploads can retry instead of hanging indefinitely; configure the per-request budget with `R2_UPLOAD_FETCH_TIMEOUT_MS`; thanks @SebTardif.
+- Bound live docs smoke requests and jobs while preserving the dispatch retry window; thanks @SebTardif.
+- Bound maintenance and translation workflow jobs, including reusable workflow callees and the incremental debounce; thanks @SebTardif.
+- Abort stalled Cloudflare hostname cutover requests, with a configurable `CLOUDFLARE_API_TIMEOUT_MS` budget; thanks @SebTardif.
+- Refresh syntax highlighting, icons, Markdown parsing, and diagrams with highlight.js 11.12.0, Lucide 1.39.0, markdown-it 15.0.1, and Mermaid 11.17.2.
+- Update CodeQL actions to 4.37.9 for the current analysis bundle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@
 - Bound live docs smoke requests and jobs while preserving the dispatch retry window; thanks @SebTardif.
 - Bound maintenance and translation workflow jobs, including reusable workflow callees and the incremental debounce; thanks @SebTardif.
 - Abort stalled Cloudflare hostname cutover requests, with a configurable `CLOUDFLARE_API_TIMEOUT_MS` budget; thanks @SebTardif.
+- Reject malformed and overflowing request timeout settings before network operations begin.
 - Refresh syntax highlighting, icons, Markdown parsing, and diagrams with highlight.js 11.12.0, Lucide 1.39.0, markdown-it 15.0.1, and Mermaid 11.17.2.
 - Update CodeQL actions to 4.37.9 for the current analysis bundle.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ per-request timeout. A stalled R2 request enters the existing retry loop; a
 stalled cutover request fails the helper. Set `R2_UPLOAD_FETCH_TIMEOUT_MS` for
 `scripts/docs-site/r2-upload.mjs`, or `CLOUDFLARE_API_TIMEOUT_MS` for
 `scripts/cloudflare-cutover-docs-hosts.mjs` (including dry runs), to raise the
-relevant budget. Use a positive integer number of milliseconds. The workflow job
-timeout remains an outer limit even when a request budget is raised.
+relevant budget. Use an integer from 1 to 2147483647 milliseconds (Node's maximum
+timer delay). The workflow job timeout remains an outer limit even when a request
+budget is raised.
 
 ## Secrets
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Source of truth lives in [`openclaw/openclaw`](https://github.com/openclaw/openc
 - Cloudflare deploys `workers/docs-router.ts`, which serves slashless page URLs, English markdown responses for `.md` paths or `Accept: text/markdown`, and `/api/search` through the `DOCS_BUCKET` R2 binding.
 - Cloudflare hosting details and limitations are documented in `CLOUDFLARE.md`.
 
+Signed R2 requests and the hostname cutover helper default to a 30-second
+per-request timeout. A stalled R2 request enters the existing retry loop; a
+stalled cutover request fails the helper. Set `R2_UPLOAD_FETCH_TIMEOUT_MS` for
+`scripts/docs-site/r2-upload.mjs`, or `CLOUDFLARE_API_TIMEOUT_MS` for
+`scripts/cloudflare-cutover-docs-hosts.mjs` (including dry runs), to raise the
+relevant budget. Use a positive integer number of milliseconds. The workflow job
+timeout remains an outer limit even when a request budget is raised.
+
 ## Secrets
 
 - `OPENCLAW_DOCS_SYNC_TOKEN` lives in `openclaw/openclaw` and lets the source repo push into this repo.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs:visual": "node scripts/docs-site/visual-smoke.mjs",
     "docs:check": "npm run docs:build && npm run docs:smoke && npm run docs:visual && node --check scripts/docs-site/llms-full.mjs",
     "skills:install": "npx --yes skills@1.5.22 add openclaw/carapace --skill openclaw-design openclaw-brand openclaw-carapace openclaw-design-system openclaw-marketing-pages openclaw-design-audit --agent codex --copy --yes",
-    "test": "node --test scripts/docs-site/*.test.mjs workers/*.test.mjs"
+    "test": "node --test scripts/*.test.mjs scripts/docs-site/*.test.mjs workers/*.test.mjs"
   },
   "devDependencies": {
     "@mdx-js/mdx": "3.1.1",

--- a/scripts/cloudflare-cutover-docs-hosts.mjs
+++ b/scripts/cloudflare-cutover-docs-hosts.mjs
@@ -2,13 +2,14 @@
 const apiToken = process.env.CLOUDFLARE_API_TOKEN;
 const zoneName = process.env.CLOUDFLARE_ZONE_NAME ?? "openclaw.ai";
 const dryRun = process.argv.includes("--dry-run");
-const fetchTimeoutMs = Number.parseInt(process.env.CLOUDFLARE_API_TIMEOUT_MS || "30000", 10);
+const fetchTimeoutMs = Number(process.env.CLOUDFLARE_API_TIMEOUT_MS || "30000");
 
 if (!apiToken) {
   throw new Error("CLOUDFLARE_API_TOKEN is required");
 }
-if (!Number.isFinite(fetchTimeoutMs) || fetchTimeoutMs < 1) {
-  throw new Error("CLOUDFLARE_API_TIMEOUT_MS must be a positive integer");
+// Larger delays overflow Node timers and can become one-millisecond timeouts.
+if (!Number.isInteger(fetchTimeoutMs) || fetchTimeoutMs < 1 || fetchTimeoutMs > 2_147_483_647) {
+  throw new Error("CLOUDFLARE_API_TIMEOUT_MS must be an integer between 1 and 2147483647 milliseconds");
 }
 
 const docsHost = `docs.${zoneName}`;

--- a/scripts/cloudflare-cutover-docs-hosts.mjs
+++ b/scripts/cloudflare-cutover-docs-hosts.mjs
@@ -2,9 +2,13 @@
 const apiToken = process.env.CLOUDFLARE_API_TOKEN;
 const zoneName = process.env.CLOUDFLARE_ZONE_NAME ?? "openclaw.ai";
 const dryRun = process.argv.includes("--dry-run");
+const fetchTimeoutMs = Number.parseInt(process.env.CLOUDFLARE_API_TIMEOUT_MS || "30000", 10);
 
 if (!apiToken) {
   throw new Error("CLOUDFLARE_API_TOKEN is required");
+}
+if (!Number.isFinite(fetchTimeoutMs) || fetchTimeoutMs < 1) {
+  throw new Error("CLOUDFLARE_API_TIMEOUT_MS must be a positive integer");
 }
 
 const docsHost = `docs.${zoneName}`;
@@ -162,6 +166,7 @@ async function cloudflare(path, init = {}) {
       "Content-Type": "application/json",
     },
     body: init.body ? JSON.stringify(init.body) : undefined,
+    signal: AbortSignal.timeout(fetchTimeoutMs),
   });
   const text = await response.text();
   const data = text ? JSON.parse(text) : {};

--- a/scripts/cloudflare-cutover-docs-hosts.test.mjs
+++ b/scripts/cloudflare-cutover-docs-hosts.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const script = fileURLToPath(new URL("./cloudflare-cutover-docs-hosts.mjs", import.meta.url));
+
+function cutoverRoot(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "docs-cutover-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function runCutover(root, env = {}, extra = {}) {
+  return spawnSync(process.execPath, [
+    "--import", pathToFileURL(path.join(root, "mock-fetch.mjs")).href,
+    script,
+    "--dry-run",
+  ], {
+    cwd: root,
+    env: {
+      PATH: process.env.PATH,
+      CLOUDFLARE_API_TOKEN: "test-token",
+      ...env,
+    },
+    encoding: "utf8",
+    ...extra,
+  });
+}
+
+test("Cloudflare API fetch attaches an AbortSignal so a stalled cutover call can time out", (t) => {
+  const root = cutoverRoot(t);
+  fs.writeFileSync(path.join(root, "mock-fetch.mjs"), `
+import fs from "node:fs";
+const calls = [];
+globalThis.fetch = async (input, init = {}) => {
+  const url = String(input);
+  calls.push({
+    url,
+    method: init.method ?? "GET",
+    hasSignal: Boolean(init.signal),
+    signalAborted: Boolean(init.signal?.aborted),
+    signalName: init.signal?.constructor?.name ?? null,
+  });
+  fs.writeFileSync("calls.json", JSON.stringify(calls));
+  if (url.includes("/zones?") && !url.includes("/dns_records") && !url.includes("/workers")) {
+    return Response.json({ success: true, result: [{ id: "zone1", name: "openclaw.ai" }] });
+  }
+  return Response.json({ success: true, result: [] });
+};
+`);
+  const result = runCutover(root);
+  assert.equal(result.status, 0, result.stderr);
+  const calls = JSON.parse(fs.readFileSync(path.join(root, "calls.json"), "utf8"));
+  assert.ok(calls.length > 0, "cutover must call fetch at least once");
+  for (const call of calls) {
+    assert.match(call.url, /^https:\/\/api\.cloudflare\.com\/client\/v4\//);
+    assert.equal(call.hasSignal, true, `${call.method} ${call.url} missing AbortSignal`);
+    assert.equal(call.signalName, "AbortSignal", `${call.method} ${call.url}`);
+    assert.equal(call.signalAborted, false, `${call.method} ${call.url} started already aborted`);
+  }
+});
+
+test("Cloudflare API fetch aborts a hung socket so cutover is not stuck", (t) => {
+  const root = cutoverRoot(t);
+  fs.writeFileSync(path.join(root, "mock-fetch.mjs"), `
+globalThis.fetch = (_input, init = {}) => new Promise((_resolve, reject) => {
+  const signal = init.signal;
+  const keepAlive = setTimeout(() => {}, 60_000);
+  const abort = () => {
+    clearTimeout(keepAlive);
+    const error = new Error("The operation was aborted");
+    error.name = "AbortError";
+    reject(error);
+  };
+  if (!signal) return;
+  if (signal.aborted) {
+    abort();
+    return;
+  }
+  signal.addEventListener("abort", abort, { once: true });
+});
+`);
+  const started = Date.now();
+  const result = runCutover(root, { CLOUDFLARE_API_TIMEOUT_MS: "80" }, { timeout: 4000 });
+  const elapsed = Date.now() - started;
+  assert.notEqual(result.status, null, `hung fetch was killed after ${elapsed}ms instead of aborting`);
+  assert.notEqual(result.status, 0, result.stdout);
+  assert.match(`${result.stderr}\n${result.stdout}`, /abort|timeout/i);
+  assert.ok(elapsed < 2000, `hung fetch ran ${elapsed}ms without aborting`);
+});

--- a/scripts/cloudflare-cutover-docs-hosts.test.mjs
+++ b/scripts/cloudflare-cutover-docs-hosts.test.mjs
@@ -31,6 +31,17 @@ function runCutover(root, env = {}, extra = {}) {
   });
 }
 
+for (const value of ["30s", "1.5", "0", "-1", "Infinity", "2147483648"]) {
+  test(`cutover rejects invalid timeout ${value} before making a request`, (t) => {
+    const root = cutoverRoot(t);
+    fs.writeFileSync(path.join(root, "mock-fetch.mjs"), 'globalThis.fetch = () => { throw new Error("Unexpected network request"); };\n');
+    const result = runCutover(root, { CLOUDFLARE_API_TIMEOUT_MS: value });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /CLOUDFLARE_API_TIMEOUT_MS must be an integer between/);
+    assert.doesNotMatch(result.stderr, /Unexpected network request/);
+  });
+}
+
 test("Cloudflare API fetch attaches an AbortSignal so a stalled cutover call can time out", (t) => {
   const root = cutoverRoot(t);
   fs.writeFileSync(path.join(root, "mock-fetch.mjs"), `


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running the docs hostname cutover would hang until the GitHub runner hit its job limit if the Cloudflare API socket stalled. `scripts/cloudflare-cutover-docs-hosts.mjs` called `api.cloudflare.com` with no `AbortSignal`, so a dry-run or live cutover from `pages.yml` never returned while the TCP connection sat idle.

## Why This Change Was Made

Every Cloudflare API `fetch` in the cutover script now carries `AbortSignal.timeout`. The default budget is 30000ms and can be raised with `CLOUDFLARE_API_TIMEOUT_MS`. Reads and writes share the same helper, so zone lookup, DNS, and Worker route calls all abort. R2 upload, live-smoke, locale commit, and the four workflow `timeout-minutes` changes from sibling PRs are unchanged.

## User Impact

A docs host cutover fails closed on a stalled Cloudflare API request instead of occupying a runner until the workflow times out. Operators can raise the per-request budget when a slow API call needs more than 30 seconds.

## Evidence

terminal output from running `scripts/cloudflare-cutover-docs-hosts.mjs` against the unfixed tree, then the same script after the patch.

Before, a successful zone lookup had no abort signal, and a hung lookup never returned:

```console
$ node --test scripts/cloudflare-cutover-docs-hosts.test.mjs
AssertionError [ERR_ASSERTION]: GET https://api.cloudflare.com/client/v4/zones?name=openclaw.ai&status=active missing AbortSignal
false !== true

AssertionError [ERR_ASSERTION]: hung fetch was killed after 4015ms instead of aborting
```

After the patch, the same production script attaches an AbortSignal on every Cloudflare API call and aborts a hung request inside the 80ms budget:

```console
$ CLOUDFLARE_API_TOKEN=test-token node --import file:///C:/Users/sebta/AppData/Local/Temp/docs-f006-signal-fetch.mjs scripts/cloudflare-cutover-docs-hosts.mjs --dry-run
{"url":"https://api.cloudflare.com/client/v4/zones?name=openclaw.ai&status=active","method":"GET","hasSignal":true,"signalName":"AbortSignal","signalAborted":false}
zone:openclaw.ai
{"url":"https://api.cloudflare.com/client/v4/zones/zone1/dns_records?name=docs.openclaw.ai&per_page=100","method":"GET","hasSignal":true,"signalName":"AbortSignal","signalAborted":false}
POST:dry-run:/zones/zone1/dns_records
dns:created:docs.openclaw.ai:A
dry-run complete
```

```console
$ CLOUDFLARE_API_TOKEN=test-token CLOUDFLARE_API_TIMEOUT_MS=80 node --import file:///C:/Users/sebta/AppData/Local/Temp/docs-f006-hung-fetch.mjs scripts/cloudflare-cutover-docs-hosts.mjs --dry-run
live-proof: fetch has AbortSignal aborted=false
Error [AbortError]: The operation was aborted
    at Timeout._onTimeout (node:internal/abort_controller:208:7)
    at listOnTimeout (node:internal/timers:635:17)
    at process.processTimers (node:internal/timers:571:7)
exit=1
```

`node --check scripts/cloudflare-cutover-docs-hosts.mjs` exits 0.

This missing abort signal has been present since the cutover script landed in [`bebb9a9fab`](https://github.com/openclaw/docs/commit/bebb9a9fab) (2026-05-23, 105 days). Sibling abort work is #163 and #164 and is not changed here.

## Real behavior proof

- **Behavior or issue addressed:** A stalled Cloudflare API fetch in the docs host cutover script never timed out, so `pages.yml` Cut over docs hostnames could occupy a runner until the job was killed.
- **Real environment tested:** Windows 11, Node v24.19.0, repo checkout at C:\Users\sebta\.grok\tmp\pr-gate-batch\docs-f006 on branch fix/cutover-fetch-timeout, synthetic Cloudflare API via a Node `--import` preload.
- **Exact steps or command run after this patch:** `node --check scripts/cloudflare-cutover-docs-hosts.mjs`. Then `CLOUDFLARE_API_TOKEN=test-token node --import file:///C:/Users/sebta/AppData/Local/Temp/docs-f006-signal-fetch.mjs scripts/cloudflare-cutover-docs-hosts.mjs --dry-run`. Then the same production script with `CLOUDFLARE_API_TIMEOUT_MS=80` and a hung `fetch` that only settles when the request signal aborts.
- **Evidence after fix:** terminal output above. Every Cloudflare API GET records hasSignal=true and signalName=AbortSignal. The hung request exits 1 after about 145ms with Error [AbortError]: The operation was aborted from AbortSignal.timeout, instead of sitting until the process is killed.
- **Observed result after fix:** Cutover fetches now carry a timeout signal. A hung api.cloudflare.com socket fails the script instead of occupying the process until the job is killed.
- **What was not tested:** A live Cloudflare zone with production credentials. Slow API calls that need more than the 30s default should set CLOUDFLARE_API_TIMEOUT_MS; that operator path was not run against the real openclaw.ai zone.

## Summary

Same abort class as #163 (R2 signed fetch) and #164 (live-smoke fetch), applied to the remaining operator cutover helper. Public path is `node scripts/cloudflare-cutover-docs-hosts.mjs` from `.github/workflows/pages.yml`.
