### PR TITLE
docs: preview v2026.9.2 release notes — DO NOT MERGE

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2165,6 +2165,7 @@
                 "group": "Release notes",
                 "pages": [
                   "releases/index",
+                  "releases/2026.9.2",
                   "releases/2026.9.1",
                   "releases/2026.8.2",
                   "releases/2026.8.1",

--- a/docs/releases/2026.9.2.md
+++ b/docs/releases/2026.9.2.md
@@ -1,0 +1,4292 @@
+---
+title: "v2026.9.2"
+description: "Reliability and recovery improvements, OpenAI GPT-6 Astra and Meta Muse Spark 1.3 support, and flexible task workspaces."
+keywords: [OpenClaw, v2026.9.2, reliability, GPT-6 Astra, Muse Spark 1.3, task workspace, recovery]
+---
+
+# v2026.9.2
+
+> **REVIEW DRAFT** — These release notes have not received human approval and are not authorized for publication.
+
+OpenClaw v2026.9.2 pairs support for OpenAI's GPT-6 Astra and Meta's Muse Spark 1.3 with practical reliability improvements. Update reports survive reconnects, eligible interrupted tasks resume after a restart, and completed answers remain available through specific saving failures. Both model additions support text and images for accounts with access. On supported OpenAI API connections, you can correct ongoing work without waiting for Astra to finish its response.
+
+The task workspace also lets you put a dashboard, browser, terminal, or file view at the center of a task and keep the conversation beside it. Guided local-model setup chooses a recipe for the computer running OpenClaw and checks that it can use tools, while people sharing a Gateway can connect their own model accounts without changing everyone else's default. More settings apply without a full restart, keeping unaffected conversations connected.
+
+> **Upgrade note for shared Gateways:** If you run several agents on one Gateway, review their conversation access before upgrading. Omitted settings now let agents with session tools read and search other agents' conversations, including other users' transcripts. Explicitly narrow visibility and agent-pair access where needed; mutually untrusted users need separate Gateways. See [Security and Privacy](#security-and-privacy) for the settings and their limits.
+
+**Release scale:** 1,245 PRs + 6 direct commits + 232 contributors.
+
+## Installation and Onboarding
+
+Setting up a local model now starts with the computer that will run it, and OpenClaw checks that the model can use a tool before making it your default. The rest of setup gets several practical repairs too, from preserving complete workspace instructions after a failed write to choosing the intended agent, opening a hosted dashboard, and recovering shell completion when a profile cannot be changed.
+
+<AccordionGroup>
+
+<Accordion title="Choose a local model for your computer">
+
+The [managed llama.cpp setup](/plugins/llama-cpp) now recommends a model using the available memory, supported graphics hardware, and disk space on the computer running OpenClaw. It shows you that computer's name, the model, and the download size before asking to proceed, which matters when you are opening setup in a browser connected to a different machine. Before changing your default, it checks both a response and a real file-read tool result; a failed or cancelled activation leaves the previous model selected.
+
+The [local-model recommendations](/gateway/local-models) begin with an 8 GiB memory floor for the smallest recipe, with larger choices needing more memory and, in some cases, graphics acceleration. Actual fit and speed still depend on available resources and the workload. CPU-only replies can still take several minutes, and setup now distinguishes a response-check timeout from a tool-use-check timeout with the failed check named in the error.
+
+Managed setup also applies [lean tools for local models](/concepts/experimental-features#local-model-lean-mode) before checking the candidate, reducing the large tool list a smaller model has to process while keeping the agent's ordinary instructions in normal chats. An explicit opt-out is preserved. On a Gateway with several agents, setting up just one local agent can still change shared lean-tool settings used by other agents, so review those settings after targeted setup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Recommend and verify a local model for the computer running OpenClaw, with confirmed downloads and preservation of the previous default on failed activation ([#138464](https://github.com/openclaw/openclaw/pull/138464), [issue #138426](https://github.com/openclaw/openclaw/issues/138426)). The new recipes are text-only; switching among previously configured managed models remains a separate limitation ([issue #138452](https://github.com/openclaw/openclaw/issues/138452)).
+
+**Bug fixes**
+
+- Apply lean tools consistently during managed local-model setup and identify which verification check timed out ([#138717](https://github.com/openclaw/openclaw/pull/138717), [issue #138705](https://github.com/openclaw/openclaw/issues/138705)). The targeted multi-agent setup issue ([#138753](https://github.com/openclaw/openclaw/issues/138753)) and an intermittent verification rejection ([#138736](https://github.com/openclaw/openclaw/issues/138736)) remain separate from the demonstrated single-agent CPU repair.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Set up the intended agent and workspace">
+
+New [workspace instruction and identity files](/concepts/agent-workspace) are now made available only after a complete write, so a disk or quota failure during first setup can be resolved and retried without leaving a newly truncated file behind. Existing files are preserved, including readable startup files in an already initialized workspace whose host permissions prevent new writes. Previously truncated files still need repair, and creating missing files requires write access and a filesystem that supports hard links; setup explains when that requirement cannot be met.
+
+For multi-agent installations, automatic command review and `openclaw setup --baseline` now use the configured System Agent's model, workspace, and session location. When no owner can be determined, baseline setup stops with guidance to configure the System Agent instead of suggesting an unsupported command flag.
+
+Before [local configuration changes](/cli/configure), OpenClaw also checks the installed Gateway's recorded data and configuration paths, even when the service is stopped. A confirmed mismatch stops the wizard before it writes to the wrong location. If those paths cannot be verified, configuration remains available with a warning and a pointer to `openclaw gateway status --deep`.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Publish complete generated workspace files after successful writes, keeping setup retries useful after storage failures ([#131108](https://github.com/openclaw/openclaw/pull/131108), [issue #127505](https://github.com/openclaw/openclaw/issues/127505)). Thanks @lockyer228, @obviyus.
+- Use the configured System Agent for baseline setup and automatic command review ([#132469](https://github.com/openclaw/openclaw/pull/132469), part of [issue #128637](https://github.com/openclaw/openclaw/issues/128637)). Thanks @xydt-tanshanshan, @obviyus, @junfxiao.
+- Reuse readable startup files in an initialized workspace without first requiring permission to create temporary files ([#138517](https://github.com/openclaw/openclaw/pull/138517), [issue #138514](https://github.com/openclaw/openclaw/issues/138514)).
+- Inspect the installed Gateway's recorded paths before local configuration writes, with credential-safe warnings when inspection is unavailable ([#138822](https://github.com/openclaw/openclaw/pull/138822)). The original Discord upgrade report in [issue #138342](https://github.com/openclaw/openclaw/issues/138342) remains unresolved. Thanks @maxpcuser.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Start with an OpenAI key">
+
+Clean, environment-only [agent runs](/cli/agent#agent-exec) using an OpenAI API key can now start through the built-in OpenClaw runtime when the optional Codex runtime is absent. This removes a setup failure before the agent could answer or begin its task, while explicitly chosen runtimes and existing session pins continue to require their selected runtime.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Run environment-only OpenAI tasks without first installing the optional Codex runtime ([#138449](https://github.com/openclaw/openclaw/pull/138449), [issue #138421](https://github.com/openclaw/openclaw/issues/138421)). Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Open a hosted dashboard link">
+
+On hosts that implement the [automatic browser handoff](/web/dashboard#automatic-browser-handoff), a dashboard bookmark or direct link can use the host's verified sign-in and return you to the page you intended to open. The handoff requires an identity-aware HTTPS service supplied by the host; deployments without it keep their existing login instructions, and a successful sign-in preserves the selected page, query, and fragment.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover direct dashboard links through an optional, host-verified browser sign-in handoff ([#136977](https://github.com/openclaw/openclaw/pull/136977)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover shell completion setup">
+
+When Doctor or onboarding cannot update your shell profile, [completion setup](/cli/completion) now provides a command that loads the prepared completions in your current shell instead of sending you back into the same permission failure. Run the complete command it displays; enabling completion for future shells still requires fixing the reported permission or read-only error and retrying installation. PowerShell recovery commands also handle paths containing typographic apostrophes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Provide usable current-session completion commands after profile-write failures, with matching translated guidance and corrected PowerShell quoting ([#137431](https://github.com/openclaw/openclaw/pull/137431), [issue #137409](https://github.com/openclaw/openclaw/issues/137409)).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## The New Web UI
+
+The browser workspace can now take the shape of the work you are doing. Put a dashboard, browser, terminal, or file view in the main area and keep the conversation beside it, then return to that arrangement when you come back. A visual gallery makes saved dashboards easier to find, while mentions, profiles, clearer progress, and more usable conversation history help you stay with the task as it grows or brings in other people.
+
+<AccordionGroup>
+
+<Accordion title="Arrange Chat, Dashboard, and task panels">
+
+You can now put the part of a task you are working on in the main view and keep the conversation beside it. Dashboard, Browser, Terminal, Files, Review, and Chat share the same controls, so a dashboard can take the larger space while Chat sits on the left, right, or below it. Swap exchanges the two views, Focus gives the main view the task area, and Restore split brings back the previous arrangement and size.
+
+The [task layout](https://docs.openclaw.ai/web/dashboards#arrange-your-task) remembers your choices in that browser, and rearranging or hiding panels preserves live widget inputs, chat drafts, terminals, and Review state. Incoming widgets respect an arrangement you have already saved, while compact Home opens with its conversation and composer visible. Closing a Dashboard view leaves its saved board intact, but reloading the page starts fresh widget views.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Move dashboards into the chat side panel with expandable views [#137068](https://github.com/openclaw/openclaw/pull/137068). Thanks @patrick-erichsen.
+- Swap, dock, focus, and remember task panels while retaining live view state [#138077](https://github.com/openclaw/openclaw/pull/138077).
+
+**Bug fixes**
+
+- Remove redundant close-button tooltips from side-panel tabs [#137656](https://github.com/openclaw/openclaw/pull/137656). Thanks @patrick-erichsen.
+- Preserve Dashboard drafts while the side panel is closed [#137744](https://github.com/openclaw/openclaw/pull/137744).
+- Use split or expanded Dashboard presentation, replacing obsolete set_chat_dock, dock, and chatDock instructions [#137819](https://github.com/openclaw/openclaw/pull/137819).
+- Restore the conversation when opening compact Home beside another session [#138550](https://github.com/openclaw/openclaw/pull/138550).
+- Open Dashboard directly and consolidate persistent panel controls in the task toolbar [#138713](https://github.com/openclaw/openclaw/pull/138713).
+- Align task toolbars and panel tabs across docking layouts [#138769](https://github.com/openclaw/openclaw/pull/138769).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Find dashboards in a visual gallery">
+
+The [Dashboard gallery](https://docs.openclaw.ai/web/dashboards#find-your-dashboards) gives saved boards a place you can browse by sight, search by task or author, and sort by title or recent activity, including dashboards beyond the first page of conversations. Supported boards show passive previews of their saved HTML as you scroll, making it easier to recognize the one you want before opening it with its conversation.
+
+Open the dashboard to use its controls. Gallery cards leave MCP Apps and non-HTML widgets out of their previews, and their Live badge describes a running session rather than confirming that every displayed value is current. Named dashboard and short session links also avoid the broad session-list searches that added waiting on large installations.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Find saved dashboards in a searchable task gallery [#137069](https://github.com/openclaw/openclaw/pull/137069). Thanks @patrick-erichsen.
+- Show passive saved-HTML previews while browsing the dashboard gallery [#138640](https://github.com/openclaw/openclaw/pull/138640). Thanks @patrick-erichsen.
+- Open named dashboards and short links with targeted session lookups [#138860](https://github.com/openclaw/openclaw/pull/138860).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Build and open a session dashboard">
+
+When the bundled Control UI skill is available to your agent, type `/dashboard` with what you want to see to request a board for the current session. Choosing Dashboard in the side panel opens the board directly without adding anything to your message. The [dashboard guide](https://docs.openclaw.ai/web/dashboards#build-a-dashboard-by-asking) includes a one-prompt demonstration, and the command uses the bundled Control UI instructions even when a workspace has another skill with that name. A custom skill named dashboard remains available through `$dashboard` or `/skill dashboard`, with its slash alias moved to `/dashboard_2`.
+
+Widgets pinned from an agent's global session stay with that agent's board and notify its authorized viewers. Automatically sized HTML widgets keep their content height instead of progressively shrinking, while manual sizes remain yours to set. If creating a visible dashboard session fails, cleanup preserves a newer replacement session and tells you when the original child needs inspection before retrying.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Request a dashboard through the command menu, with a separate alias for a same-named custom skill [#137685](https://github.com/openclaw/openclaw/pull/137685). Thanks @patrick-erichsen.
+
+**Bug fixes**
+
+- Preserve bundled dashboard instructions in native command requests [#138549](https://github.com/openclaw/openclaw/pull/138549).
+- Preserve agent and session ownership from widget pinning through board notifications [#138675](https://github.com/openclaw/openclaw/pull/138675).
+- Align board menu sizing and English Delete labels [#136711](https://github.com/openclaw/openclaw/pull/136711). Thanks @patrick-erichsen.
+- Keep automatic-height dashboard widgets from shrinking after opening [#136803](https://github.com/openclaw/openclaw/pull/136803).
+- Preserve replacement dashboard sessions during failed-spawn cleanup [#137183](https://github.com/openclaw/openclaw/pull/137183).
+
+**Documentation**
+
+- Embed the dashboard-building demo in the guide [#137058](https://github.com/openclaw/openclaw/pull/137058). Thanks @hannesrudolph.
+- Widescreen demonstration video in the dashboard guide [#137091](https://github.com/openclaw/openclaw/pull/137091). Thanks @hannesrudolph.
+- Update dashboard instructions for side-panel presentation and gallery behavior [#137701](https://github.com/openclaw/openclaw/pull/137701).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use interactive widgets in chat">
+
+Interactive [chat widgets](https://docs.openclaw.ai/tools/show-widget) now load their saved document through the authenticated OpenClaw connection, which lets supported widgets work behind login proxies without asking the embedded frame to sign in separately. A failed document load offers Retry, and an HTML download remains available when an image export cannot be produced.
+
+Canvas and MCP App previews keep the information that makes them interactive and appear once when live conversation content becomes saved history. Already loaded widgets retain their input during supported panel changes and renewed preview links. Strict previews remain script-free, dashboard permissions stay separate from inline previews, and a full reload creates a fresh view.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Load chat widgets through Gateway authentication and offer retry and HTML export [#138074](https://github.com/openclaw/openclaw/pull/138074).
+- Keep one stable Canvas or MCP App preview across chat history hydration [#138155](https://github.com/openclaw/openclaw/pull/138155). Thanks @josephnatsu, @obviyus, @szcascsa.
+- Preserve interactive App and widget metadata beside assistant preview references [#138593](https://github.com/openclaw/openclaw/pull/138593).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Mention teammates and find your Inbox">
+
+When a message needs someone's attention, type `@`, choose an eligible teammate, and check the Will notify indication before sending. Simply typing a name does not alert anyone. [Human mentions](https://docs.openclaw.ai/concepts/multi-user#mentioning-people) work with durable OpenClaw profiles and bring the message into the recipient's Inbox without giving them access to a conversation they could not already read.
+
+The [Mentions Inbox](https://docs.openclaw.ai/concepts/multi-user#temporary-mentions-inbox) is temporary. Entries last up to seven days, can be removed sooner by capacity limits, and clear when OpenClaw restarts or upgrades. Opening a mention leaves it in the list until you dismiss it. Optional Someone mentions me browser alerts default off and are best effort. The Inbox also keeps automation and model sign-in warnings current through busy periods, and an automation alert's arrow opens Automations.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Mention teammates and find messages addressed to you in Inbox [#135853](https://github.com/openclaw/openclaw/pull/135853). Thanks @ruel225.
+- Reduce temporary mention Inbox processing after messages are dismissed [#137714](https://github.com/openclaw/openclaw/pull/137714).
+
+**Bug fixes**
+
+- Make Inbox automation arrows open their destination [#136744](https://github.com/openclaw/openclaw/pull/136744).
+- Keep Inbox warnings current through automation bursts and failed refreshes [#137753](https://github.com/openclaw/openclaw/pull/137753).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recognize people and assign conversations">
+
+A single-owner installation using token or password access can now have a saved name, avatar, profile preferences, and My GitHub connection without setting up a separate sign-in service. These follow the [owner profile](https://docs.openclaw.ai/concepts/user-model#gateway-profile-and-github-credit) across its devices. On a Mac, an owner without an uploaded image can use the picture of the Mac account running OpenClaw, while paired browsers and supported Mac SSH connections can display saved profile photos again.
+
+For teams, assignment menus include registered people even when they are offline or have not owned a conversation, and grouped session headers bring presence and people cards closer to their work. Participant lists reveal additional names, and person Activity links use readable addresses. Shared token or password holders still share one owner identity, its preferences, and My GitHub connection, so use personal sign-in when each person needs a distinct profile.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Give single-owner Gateways a saved profile and shared device preferences [#136819](https://github.com/openclaw/openclaw/pull/136819).
+- Expand session participants from the others count [#136719](https://github.com/openclaw/openclaw/pull/136719). Thanks @patrick-erichsen.
+- Show owner presence and people cards in grouped session headers; id-only self profiles can still show self controls [#136985](https://github.com/openclaw/openclaw/pull/136985).
+- Give person Activity pages recognizable shareable URLs [#136989](https://github.com/openclaw/openclaw/pull/136989).
+- Use the Gateway Mac account picture as the owner fallback avatar; restart after changing the Mac picture [#137849](https://github.com/openclaw/openclaw/pull/137849).
+
+**Bug fixes**
+
+- Offer all registered teammates when assigning a session [#136978](https://github.com/openclaw/openclaw/pull/136978).
+- Restore profile photos in paired browsers and Mac SSH-tunnel views, and recover authorized location lookups [#137926](https://github.com/openclaw/openclaw/pull/137926).
+- Truncate newly seeded profile names without splitting emoji; previously saved corrupt names are unchanged [#137695](https://github.com/openclaw/openclaw/pull/137695). Thanks @ly85206559, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Find and organize conversations">
+
+Searching Sessions can now find matching active or archived conversations beyond the rows already loaded, with Load more sessions bringing in further matches. It searches conversation details such as names, models, status, and agent identity, while transcript search remains a separate way to search the messages themselves. Counts, grouping, and sorting still describe the loaded rows.
+
+Owner choices move into a compact submenu, sharing and owner details sit together in the chat header, and copied session links use the configured public address even through a local SSH tunnel. Unrelated agent activity no longer repeatedly reloads the selected agent's list, and pinning or renaming another session can continue while a model catalog loads. Opening a chat clears its unread dot immediately, although new activity arriving during the acknowledgement refresh can still briefly be masked.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Keep large owner lists inside a compact session-filter submenu [#135525](https://github.com/openclaw/openclaw/pull/135525). Thanks @vyctorbrzezowski.
+- Group chat ownership with leading visibility controls [#137067](https://github.com/openclaw/openclaw/pull/137067). Thanks @patrick-erichsen.
+
+**Bug fixes**
+
+- Refresh session summaries after observer updates are saved [#133034](https://github.com/openclaw/openclaw/pull/133034). Thanks @masatohoshino, @obviyus.
+- Clear unread dots immediately when conversations open [#134160](https://github.com/openclaw/openclaw/pull/134160). Thanks @vyctorbrzezowski.
+- Avoid session-list reloads for unrelated agent activity [#137772](https://github.com/openclaw/openclaw/pull/137772).
+- Copy configured public session URLs from tunneled connections [#137945](https://github.com/openclaw/openclaw/pull/137945).
+- Search session metadata before pagination and load additional matches [#138167](https://github.com/openclaw/openclaw/pull/138167).
+- Stop follow-on work from abandoned transcript searches [#138425](https://github.com/openclaw/openclaw/pull/138425).
+- Keep unrelated session edits moving during model catalog reloads for one-target agent groups; same-agent multi-target batches and embedded TUI retain their existing path [#138794](https://github.com/openclaw/openclaw/pull/138794).
+- Avoid ordinary-key cache churn in large session inventories [#138909](https://github.com/openclaw/openclaw/pull/138909).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Open long conversations">
+
+Opening a long conversation now puts the recent messages you selected ahead of background chats and a restored Home pane, with smaller initial transfers and reusable avatar previews. Valid prefetched history stays available through unrelated sidebar updates, and completed messages avoid repeated redraws while a new reply streams. Older messages remain available by scrolling upward.
+
+Large Codex histories use bounded pages and shortened tool-output previews, with full output retained in Codex. Very large individual records and some legacy histories can still exceed the transport limits. On the computer running OpenClaw, cold runtime history checks let unrelated activity continue, and browsing retained archives leaves less message content in memory between requests, at the cost of reading those pages from disk again.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Stop preparing oversized chat deltas once their requested byte budget is exceeded [#138655](https://github.com/openclaw/openclaw/pull/138655).
+
+**Bug fixes**
+
+- Open large Codex histories with paged transcripts and shorter tool previews; oversized records and near-limit legacy continuation cursors remain limitations [#136282](https://github.com/openclaw/openclaw/pull/136282). Thanks @goslingmanagment, @dmsrg399, @obviyus.
+- Reduce repeated rendering in long web conversations [#136396](https://github.com/openclaw/openclaw/pull/136396).
+- Compress large chat-history transfers and prioritize the visible conversation [#136862](https://github.com/openclaw/openclaw/pull/136862).
+- Keep valid prefetched chats through unrelated session-list updates [#137947](https://github.com/openclaw/openclaw/pull/137947).
+- Prioritize selected-chat history and reuse authenticated avatar previews [#138635](https://github.com/openclaw/openclaw/pull/138635).
+- Run cold transcript integrity checks away from the Gateway event loop [#138888](https://github.com/openclaw/openclaw/pull/138888).
+- Reduce retained message memory after browsing chat archives [#138933](https://github.com/openclaw/openclaw/pull/138933).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep drafts and attachments ready to retry">
+
+A rejected send can keep its original attachments and Retry action when you leave the conversation, move Home, or reload through a supported recovery path. Recovered documents regain their Open and Download controls, and permitted plain-HTTP installations can use attachment sending and recovery with browser storage available. Recovery keeps the request's identity so an uncertain send is not automatically repeated.
+
+Interrupted personal-account setup can resume with its original session and worktree, while failed cloud starts retain their error and elapsed time when you return. Covered app-triggered reloads protect unsaved starts while the page is responsive and offer an explicit discard action when needed. Incognito starts remain memory-only, and closing the page or choosing to discard unsaved input can still lose them.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Send and recover attachments on permitted plain-HTTP deployments, including affected model-picker and setup UUID handling [#137732](https://github.com/openclaw/openclaw/pull/137732). Thanks @fuller-stack-dev, @misselvexu.
+- Keep rejected attachments retryable after leaving a conversation [#138265](https://github.com/openclaw/openclaw/pull/138265).
+- Open and download recovered attachments after reload [#138295](https://github.com/openclaw/openclaw/pull/138295).
+- Resume saved personal-account setup without creating another worktree [#137921](https://github.com/openclaw/openclaw/pull/137921).
+- Preserve failed cloud starts and guard unsaved input during reloads [#138469](https://github.com/openclaw/openclaw/pull/138469).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preview images and retrieve current files">
+
+Successfully generated images remain visible when a later tool fails, and saved media replies keep one caption after reload. Project screenshots now follow the conversation's filesystem permissions, so a screenshot the session is allowed to use can also appear in chat. For a blocked image outside those folders, an administrator can inspect its path and choose Allow image for that file alone, with an expiring allowance and current access checks.
+
+Media requests reaching the updated server return current file contents, and conditional download resumes for mutable files restart with the current version instead of combining old and new bytes. Attachment lookup does less work in long histories, and verified Tailscale Serve users regain affected previews. An Omitted from history card explains a missing historical image without implying its bytes were recovered, and an old browser cache may still require reopening a fresh media URL.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep generated images visible alongside later tool errors [#131226](https://github.com/openclaw/openclaw/pull/131226). Thanks @cglashu, @a28hui, @obviyus.
+- Show placeholders for images omitted from conversation history [#135060](https://github.com/openclaw/openclaw/pull/135060). Thanks @linhongyu510, @obviyus.
+- Avoid repeated media captions and data-URL filenames in saved replies [#137500](https://github.com/openclaw/openclaw/pull/137500). Thanks @gaoanze888, @snls1994, @gordonzhy.
+- Restore image previews through verified Tailscale Serve identity [#136960](https://github.com/openclaw/openclaw/pull/136960). Thanks @fuller-stack-dev, @lamer217.
+- Serve updated media and avoid mixed-version downloads [#138442](https://github.com/openclaw/openclaw/pull/138442).
+- Preview project screenshots and allow individual outside images [#138856](https://github.com/openclaw/openclaw/pull/138856).
+- Reduce attachment lookup work in long conversation histories [#138857](https://github.com/openclaw/openclaw/pull/138857).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Follow the work that is running">
+
+Tool activity keeps related calls together after reload and shows a short purpose supplied by the acting agent when one is available, with full commands and results underneath. There are no extra model calls just to name those rows, and the description tells you the intended work while the result tells you whether it succeeded. If your configuration contains the retired `gateway.controlUi.toolTitles` key, remove it even when its value is false. `openclaw doctor --fix` handles supported configurations, while managed or included configuration files may need changes at their source.
+
+The task list keeps active work in creation order and recent completions first, with Refresh and recovery guidance when activity changes during loading. Older checklists stay paused during unrelated work, finished parent conversations stop looking busy while their children continue, and Swarm cards retain completed counts and readable task names. Activity also batches background refreshes, while heavily changing task lists can still require another refresh.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reload changed task lists instead of mixing pages; RPC clients must restart expired or old numeric cursors without a cursor [#133186](https://github.com/openclaw/openclaw/pull/133186). Thanks @shakkernerd.
+- Keep task rows stable and refresh recent completions; nested retries can still repeat scans under sustained activity [#135499](https://github.com/openclaw/openclaw/pull/135499). Thanks @vyctorbrzezowski.
+- Batch Activity refreshes and tolerate brief load during Codex startup and replies; abandoned-producer recovery can wait 30 seconds longer [#136762](https://github.com/openclaw/openclaw/pull/136762).
+- Keep Activity responsive and open sessions from their displayed rows [#136916](https://github.com/openclaw/openclaw/pull/136916).
+- Keep older progress cards paused during later runs; missing timestamps and idle-board reconciliation remain separate [#137323](https://github.com/openclaw/openclaw/pull/137323). Thanks @gaoanze888, @vyctorbrzezowski, @richard355168.
+- Reveal matching successfully completed task progress when collapse-by-default is enabled [#137569](https://github.com/openclaw/openclaw/pull/137569). Thanks @vacinc.
+- Show parent completion separately from continuing child work [#137789](https://github.com/openclaw/openclaw/pull/137789). Thanks @fuller-stack-dev.
+- Keep Swarm completion status from reverting during UI refresh [#138055](https://github.com/openclaw/openclaw/pull/138055).
+- Show meaningful task names on Swarm progress cards [#138183](https://github.com/openclaw/openclaw/pull/138183). Thanks @obviyus.
+- Group tool activity and show supplied execution purposes without title-generation calls [#138568](https://github.com/openclaw/openclaw/pull/138568). Thanks @jalehman.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use chat commands and scrolling controls">
+
+Choosing a command argument now submits the completed command from New Session, and the execution-host picker inserts valid settings while preserving the rest of a chat draft. Sending a message, submitting a chat command, or choosing Scroll to latest brings the newest output into view through composer resizing, while later manual scrolling and keys inside text or media controls remain under your control.
+
+Stop remains available for a known running response during reconnection and requests cancellation when the same authorized connection returns. Queued messages can resume when refreshed session state confirms the chat is idle, and accepted messages can stay pending through a temporary history rebuild before execution begins. Work that may already have started is not blindly sent again, and queued messages show a single usable Steer action when steering is available.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Request Stop while the web chat reconnects [#126548](https://github.com/openclaw/openclaw/pull/126548). Thanks @nianjiuzst, @obviyus.
+- Release queued messages when refreshed session state becomes idle [#131948](https://github.com/openclaw/openclaw/pull/131948). Thanks @vyctorbrzezowski.
+- Keep accepted messages pending through retryable history rebuilds [#137267](https://github.com/openclaw/openclaw/pull/137267). Thanks @jalehman.
+- Insert valid host settings from the execution-command picker [#137475](https://github.com/openclaw/openclaw/pull/137475). Thanks @jalehman.
+- Submit completed commands from the New Session argument menu [#137571](https://github.com/openclaw/openclaw/pull/137571). Thanks @jalehman.
+- Remove the duplicate Steer badge when the action is available [#137918](https://github.com/openclaw/openclaw/pull/137918). Thanks @patrick-erichsen.
+- Preserve explicit jumps to latest through chat layout changes [#138008](https://github.com/openclaw/openclaw/pull/138008).
+- Bring command output into view without overriding later reader scrolling [#138140](https://github.com/openclaw/openclaw/pull/138140).
+
+</details>
+
+</Accordion>
+
+<Accordion title="See the selected and serving model">
+
+The model control can now tell you which fallback model is actually serving the conversation while the open picker keeps your preferred model selected. When the session returns to that preference, the old fallback label clears. Known model names stay visible while switching chats and loading their options, including in locked chats, without enabling controls before their availability is known.
+
+Sign-in warnings are easier to distinguish from ordinary model details, provider headings offer a shortcut to Model Setup, and a provider with a usable profile can show Ready despite a failed sibling profile. Session Observer's model choices also recover after temporary catalog failures and ignore obsolete responses after agent switching. These labels describe the available catalog and session state, rather than verifying a provider credential or identifying a billing account.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Clarify model sign-in warnings and add Model Setup shortcuts [#136779](https://github.com/openclaw/openclaw/pull/136779). Thanks @patrick-erichsen.
+- Shorten account-picker guidance while preserving session scope [#137867](https://github.com/openclaw/openclaw/pull/137867).
+
+**Bug fixes**
+
+- Show usable multi-profile providers as ready [#122300](https://github.com/openclaw/openclaw/pull/122300). Thanks @alix-007, @weeli-009.
+- Keep known model names visible during session switches [#136810](https://github.com/openclaw/openclaw/pull/136810).
+- Show locked-chat model names and repair Android scroll and handshake races [#137041](https://github.com/openclaw/openclaw/pull/137041).
+- Recover Session Observer model choices after catalog loading fails [#137171](https://github.com/openclaw/openclaw/pull/137171). Thanks @shakkernerd.
+- Ignore obsolete Session Observer catalog responses after agent switching [#137243](https://github.com/openclaw/openclaw/pull/137243). Thanks @shakkernerd.
+- Show the serving fallback model on the chat composer [#138076](https://github.com/openclaw/openclaw/pull/138076). Thanks @fuller-stack-dev, @davidstoll.
+- Clear stale fallback model labels after session recovery [#138551](https://github.com/openclaw/openclaw/pull/138551).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Inspect connected computers and phones">
+
+The Devices page puts recognizable computers and phones, available resource readings, capabilities, and access details in one inventory. Connected CLI nodes and the Mac shared worker report load, memory, and home-volume disk snapshots, and a successfully saved last reading remains available with its age when a node goes offline. The CLI can show those summaries too. Load averages and used memory describe those measurements, rather than operating-system pressure, and offline values are historical.
+
+An Actions menu keeps copying IDs, pairing controls, and available desktops together, while an available Desktop opens in its own window. New Session and Move Session distinguish commands that are missing, waiting for pairing approval, or blocked by policy, so the next step matches the problem. The [device guidance](https://docs.openclaw.ai/web/control-ui) covers setup and reapproval, and Connection and System busyness show eligible mounted local disks separately.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show local-disk space and keep channel actions on the selected row [#136079](https://github.com/openclaw/openclaw/pull/136079).
+- Redesign Devices with resource meters, capability hints and Desktop access [#136858](https://github.com/openclaw/openclaw/pull/136858).
+- Report connected-node load, memory and home-volume disk snapshots [#136859](https://github.com/openclaw/openclaw/pull/136859).
+- Device actions, access details and dated offline meters [#137084](https://github.com/openclaw/openclaw/pull/137084).
+- Retain offline node readings and show resource summaries in the CLI [#137090](https://github.com/openclaw/openclaw/pull/137090).
+
+**Bug fixes**
+
+- Show the correct next step for unavailable device commands [#135453](https://github.com/openclaw/openclaw/pull/135453). Thanks @gaoanze888, @obviyus, @ctbritt.
+- Report CLI-node hardware models for device identity and icons [#137081](https://github.com/openclaw/openclaw/pull/137081).
+- Distinguish policy-blocked device commands from pending pairing [#137220](https://github.com/openclaw/openclaw/pull/137220).
+- Show policy denial before pairing guidance for multi-command workflows [#137244](https://github.com/openclaw/openclaw/pull/137244). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Review files and follow GitHub work">
+
+GitHub previews keep the exact issue, pull request, or comment destination you opened, even when another link has already filled the preview cache. They use the selected agent's configured account and explain sign-in, access, rate-limit, or connection failures, while remaining limited to public repositories. PR badges collect later pages of checks before reporting complete results, so a failure beyond the first page does not disappear behind a passing badge. Results beyond the collection limits can leave the badge absent.
+
+The Review panel keeps unchanged files out of a session's changes and reports full addition counts for large new text files even when their previews must stay bounded. [GitHub publication controls](https://docs.openclaw.ai/concepts/user-model#publish-with-your-account) also retain a retry and its original account across chat navigation and same-chat split panes. That state is held in page memory and clears on reload or relevant connection and access changes. A rejected first account choice can be refreshed before an explicit new Publish, while an uncertain outcome keeps checking the original request.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reload GitHub previews immediately after dismissing a loading card [#136772](https://github.com/openclaw/openclaw/pull/136772).
+- Preserve exact GitHub comment destinations after preview cache reuse [#136840](https://github.com/openclaw/openclaw/pull/136840).
+- Show useful GitHub preview errors and respect configured accounts [#136917](https://github.com/openclaw/openclaw/pull/136917).
+- Keep GitHub preview context current through delayed loading and start eligible Actions requests before their caller retires [#137075](https://github.com/openclaw/openclaw/pull/137075).
+- Share current PR snapshots across watchers and retire unused refresh work [#137807](https://github.com/openclaw/openclaw/pull/137807).
+- Show CI check counts and later failures only after complete collection, bounded at 1,000 checks [#138028](https://github.com/openclaw/openclaw/pull/138028).
+- Keep unchanged files out of session Review after large additions [#138877](https://github.com/openclaw/openclaw/pull/138877).
+- Keep accurate large-new-file totals and bounded previews under custom Git prefixes, carriage-return text, and unusual filename statistics [#138961](https://github.com/openclaw/openclaw/pull/138961).
+- Keep publication retries and completed PR links across navigation and split panes, with completion acknowledgement and read-only dismissal [#138759](https://github.com/openclaw/openclaw/pull/138759).
+- Recover rejected GitHub publisher choices through explicit refresh and publish [#137734](https://github.com/openclaw/openclaw/pull/137734).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Open and stop Side chat">
+
+Side chat has a visible keyboard shortcut, Command-Shift-S on Apple platforms and Ctrl-Shift-S elsewhere, so you can open or close the existing panel without reaching for its tab. Cancelling while conversation context is still loading now retires that request before it can later start a model call or replace a newer answer. The same preparation work is covered by the existing 60-second timeout.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add a discoverable keyboard shortcut for Side chat [#137627](https://github.com/openclaw/openclaw/pull/137627). Thanks @patrick-erichsen.
+
+**Bug fixes**
+
+- Cancel Side chat while conversation context is still loading [#137660](https://github.com/openclaw/openclaw/pull/137660).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Load and reconnect the browser workspace">
+
+The browser workspace downloads more code and text when the relevant view needs it, and reloads can reuse versioned themes, fonts, icons, and artwork already in the browser cache. Models and Plugins avoid competing initial loads, keeping useful controls visible while supplemental information arrives. Cloudflare Rocket Loader deployments also get the script protection needed for the affected blank-page startup failure.
+
+During reconnection, dashboard conversations remain readable, and local panel arrangement controls stay available while server actions wait for the connection. Phones can reach the Server updated recovery action and retry a failed refresh without losing the selected chat. New connections also avoid waiting behind their own presence notification. Operators rebuilding bundled UI assets in place still need to restart OpenClaw to pick up their new identity.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Defer tool-catalog code and session-preview styling until needed [#136866](https://github.com/openclaw/openclaw/pull/136866).
+- Load Memory Import text with its views [#136922](https://github.com/openclaw/openclaw/pull/136922).
+- Defer native-plugin rendering until activation [#138447](https://github.com/openclaw/openclaw/pull/138447).
+- Defer Cloud Workers settings text until needed [#138490](https://github.com/openclaw/openclaw/pull/138490). Thanks @obviyus.
+
+**Bug fixes**
+
+- Load the Control UI behind Cloudflare Rocket Loader [#136129](https://github.com/openclaw/openclaw/pull/136129). Thanks @grynn, @vyctorbrzezowski.
+- Reduce New Session startup waits, preserve Agent Settings deep links, and avoid duplicate Sessions startup requests [#136694](https://github.com/openclaw/openclaw/pull/136694).
+- Cache versioned Control UI themes, fonts and artwork across reloads [#137053](https://github.com/openclaw/openclaw/pull/137053).
+- Avoid duplicate Models and Plugins loads on cached routes [#137074](https://github.com/openclaw/openclaw/pull/137074).
+- Load login recovery text with the views that use it [#138529](https://github.com/openclaw/openclaw/pull/138529).
+- Skip desktop notification code when opening the dashboard in a browser [#138541](https://github.com/openclaw/openclaw/pull/138541).
+- Keep backed-up presence updates from blocking new connections [#138865](https://github.com/openclaw/openclaw/pull/138865).
+- Keep dashboard sessions readable during Gateway reconnects [#136760](https://github.com/openclaw/openclaw/pull/136760). Thanks @patrick-erichsen.
+- Make stale-page recovery reachable and retryable on phones [#136979](https://github.com/openclaw/openclaw/pull/136979). Thanks @jesse-merhi, @fuller-stack-dev.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read and navigate settings">
+
+Settings keep long descriptions beside their artwork and place controls deliberately on narrow screens, while notification preference cards align with the rest of the page. Picker selections are easier to see and affected menus respect reduced-motion preferences. Config exposes the selected Form or Raw mode and current section to assistive technology, and obsolete MCP save feedback clears when the settings context changes without cancelling the earlier write.
+
+Hebrew and Arabic text with leading direction marks displays in the intended direction, and punctuation remains visible while typing in native fields under CRT and Phosphor themes in Chromium. The first accent swatch shows the inherited color it restores. It is still a reset action, so clicking it can clear a matching explicitly saved profile color and make future color changes follow the inherited setting.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Clear stale MCP save feedback when settings context changes [#128490](https://github.com/openclaw/openclaw/pull/128490). Thanks @alix-007, @obviyus.
+- Make picker selections clearer and respect reduced motion [#133650](https://github.com/openclaw/openclaw/pull/133650). Thanks @vyctorbrzezowski.
+- Show the actual inherited color on the accent reset swatch [#135238](https://github.com/openclaw/openclaw/pull/135238). Thanks @vyctorbrzezowski.
+- Keep long plugin, MCP, and channel settings descriptions aligned with artwork and controls [#135843](https://github.com/openclaw/openclaw/pull/135843). Thanks @goslingmanagment, @dmsrg399.
+- Align notification preference cards at full width [#136816](https://github.com/openclaw/openclaw/pull/136816). Thanks @vyctorbrzezowski.
+- Expose Config mode and section selection to assistive technology [#137439](https://github.com/openclaw/openclaw/pull/137439). Thanks @aniruddhaadak80, @vyctorbrzezowski.
+- Render leading-mark Hebrew and Arabic text in the intended direction [#137474](https://github.com/openclaw/openclaw/pull/137474). Thanks @arieleli01212, @vyctorbrzezowski.
+- Keep punctuation visible while typing in CRT and Phosphor themes [#137507](https://github.com/openclaw/openclaw/pull/137507). Thanks @liuwqgit, @vyctorbrzezowski, @pavonis-martian.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose a microphone for Talk">
+
+When a saved microphone cannot be opened for a browser Talk call, the error can offer Use System default for this call. You decide whether to retry with that microphone, and your saved choice remains in place for later calls. Permission failures stay visible, and leaving or replacing the call retires the offer so an old button cannot open another microphone.
+
+Closing the microphone picker or leaving Appearance also prevents delayed device discovery from requesting camera or microphone access after you have moved on. Deliberately returning to an active picker still allows the normal permission request.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Offer a consent-based system-microphone retry for one Talk call [#136661](https://github.com/openclaw/openclaw/pull/136661). Thanks @takhoffman.
+
+**Bug fixes**
+
+- Cancel pending camera and microphone prompts when pickers close [#128482](https://github.com/openclaw/openclaw/pull/128482). Thanks @alix-007.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read Logs, Debug, and Usage">
+
+Debug shows when a snapshot is refreshing or waiting for a connection while leaving the last successful readings available. Disabled work lanes with nothing running or queued no longer appear as misleading blocked rows, and Logs keeps its initial load through routine updates without an old connection unexpectedly moving the view.
+
+Usage now keeps selected-day totals within the active session filters, while daily charts and daily exports retain those matching sessions across the requested date range. Provider, model, and tool filters select matching whole sessions, so their totals can include other usage within those sessions, and the costs remain estimates rather than provider billing records.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show when debug snapshots are refreshing or waiting for a connection [#129561](https://github.com/openclaw/openclaw/pull/129561). Thanks @vincentkoc, @shennng, @ahtgithub.
+- Hide misleading blocked rows for disabled idle work lanes and defer diagnostics text until its views load [#136811](https://github.com/openclaw/openclaw/pull/136811).
+- Keep Logs loading and scrolling tied to the current connection [#138459](https://github.com/openclaw/openclaw/pull/138459).
+- Keep selected-day Usage totals within the active session scope [#137396](https://github.com/openclaw/openclaw/pull/137396).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Control the community invitation">
+
+The workspace sidebar makes the existing Discord community easier to find with a dismissible invitation that waits until sidebar interaction finishes before appearing. Joining opens the community in another tab, while closing the card saves a dismissal for that browser origin. If saving fails, the card can still stay dismissed for the current page with a warning.
+
+Operators can [hide the invitation for the deployment](https://docs.openclaw.ai/web/control-ui#community-invitation) with `openclaw config set gateway.controlUi.communityInvite false` on the computer serving that UI. Existing pages pick up the change on refresh or reconnect, and re-enabling it keeps saved browser dismissals.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Find the OpenClaw Discord community from the workspace sidebar [#123351](https://github.com/openclaw/openclaw/pull/123351). Thanks @vyctorbrzezowski.
+- Add deployment-wide invitation control and recover failed dismissals [#136923](https://github.com/openclaw/openclaw/pull/136923). Thanks @vyctorbrzezowski.
+
+**Bug fixes**
+
+- Keep sidebar controls steady, distinguish device policy restrictions from pairing, avoid synchronous cold browser cleanup during session reset, and defer unchanged account text [#137004](https://github.com/openclaw/openclaw/pull/137004).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Follow linked Workboard cards">
+
+Existing linked Workboard cards continue to appear and update with their conversations. When a task-list continuation expires, Workboard can restart its scan once and use the fresh result to update cards and link started runs. Chat headers and session menus no longer offer Add to Workboard, and this change does not introduce a replacement capture workflow or remove existing cards.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover Workboard task scans after continuation expiry [#136802](https://github.com/openclaw/openclaw/pull/136802). Thanks @shakkernerd.
+
+**Limits and compatibility**
+
+- Remove Add to Workboard actions from Chat headers and session menus [#138618](https://github.com/openclaw/openclaw/pull/138618). Thanks @patrick-erichsen.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep shared terminals delivering output">
+
+When several people are viewing a terminal, one failed viewer connection no longer holds up output for the healthy viewers that remain. OpenClaw retires that failed delivery once, which also stops the same connection from producing an error for every queued update. This addresses the shared-output stall after a connection fails, without changing terminal permissions or explaining the original disconnect.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep failed viewer connections from pausing shared terminal output [#138818](https://github.com/openclaw/openclaw/pull/138818).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand diagram loading failures">
+
+A valid diagram should not send you back to rewriting its source because the renderer could not load. Mermaid errors now distinguish unavailable rendering, invalid diagram source, and an image that could not display, with the appropriate reload or correction guidance and the source still readable and copyable.
+
+For login-protected reverse proxies, the [Mermaid troubleshooting guide](https://docs.openclaw.ai/web/control-ui#mermaid-diagrams) explains which static renderer assets need to load without the page's cookies. Keep authentication on the dashboard and API routes, make only the required asset exception, and reload after correcting it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Distinguish unavailable Mermaid rendering from invalid diagrams [#138465](https://github.com/openclaw/openclaw/pull/138465). Thanks @thomastraum.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read current controls in your language">
+
+Twenty existing non-English locales have updated text for the web workspace's dashboard controls, mentions and Inbox, connected accounts, device settings, task names, and recovery messages. That includes translated Allow image controls, Mermaid failure guidance, unsaved-start warnings, and update and publication status, so the explanations surrounding these workflows keep up with their controls. Chinese and Japanese text also receives sentence-punctuation corrections.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Refresh meeting, session and profile text across 20 locales [#137007](https://github.com/openclaw/openclaw/pull/137007).
+- Translate mention selection, inbox and notification messages [#137113](https://github.com/openclaw/openclaw/pull/137113).
+- Refresh translated dashboard, device and model-selection guidance [#137150](https://github.com/openclaw/openclaw/pull/137150).
+- Translate account selection, sign-in and new-chat default guidance [#137327](https://github.com/openclaw/openclaw/pull/137327).
+- Refresh twenty web interface locales for side-panel controls and shortened-output notices [#138219](https://github.com/openclaw/openclaw/pull/138219).
+- Refresh translations for current device and plugin controls [#138435](https://github.com/openclaw/openclaw/pull/138435).
+- Translate unsaved-start recovery warnings and diagnostics status messages [#138680](https://github.com/openclaw/openclaw/pull/138680).
+- Translate the Allow image button across supported locales [#138904](https://github.com/openclaw/openclaw/pull/138904).
+- Translate update progress and publication backlog guidance [#138926](https://github.com/openclaw/openclaw/pull/138926).
+
+**Bug fixes**
+
+- Translate the Swarm parallel-task heading [#138401](https://github.com/openclaw/openclaw/pull/138401).
+- Translate diagram loading and rendering recovery messages across 20 locales [#138559](https://github.com/openclaw/openclaw/pull/138559).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose a workspace and start a conversation">
+
+New Session makes the choice between Current checkout and New worktree explicit, with the starting branch and worktree name in the Checkout control. Device and cloud sessions continue to require a managed worktree, and local sessions can choose Current checkout when a worktree choice is unavailable. Recent Windows folders use readable short names, and the sidebar's familiar controls and nested-session loading placeholders keep their spacing through supported layouts.
+
+The composer no longer shows the naming notice or prepared-name preview below the draft, but background naming still runs. Eligible unsent draft text can go to the selected utility provider before you press Start, as the [session naming guide](https://docs.openclaw.ai/web/control-ui#new-session-names) explains. Removing that preview does not change the transmission, and Start does not wait for a name.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Make session checkout choices and branch settings explicit [#136822](https://github.com/openclaw/openclaw/pull/136822).
+
+**Bug fixes**
+
+- Shorten Windows folder names in recent-session choices [#136582](https://github.com/openclaw/openclaw/pull/136582). Thanks @teddytennant, @obviyus.
+- Match the sidebar plus icon to adjacent controls [#136608](https://github.com/openclaw/openclaw/pull/136608). Thanks @patrick-erichsen.
+- Clear naming text from the New Session composer [#136612](https://github.com/openclaw/openclaw/pull/136612). Thanks @patrick-erichsen.
+- Align collapse, search and new-session controls in the desktop sidebar [#137317](https://github.com/openclaw/openclaw/pull/137317). Thanks @vyctorbrzezowski.
+- Reserve child-session row space while loading [#138304](https://github.com/openclaw/openclaw/pull/138304). Thanks @vyctorbrzezowski.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Expand a table without losing its links">
+
+Expanded chat tables keep the same supported file previews and session links as their inline version, including keyboard activation. Following a link dismisses the expanded view so you can use its destination, closing it returns focus to Expand table, and changing conversations no longer leaves a hidden chat's table over the active one. The [table guide](https://docs.openclaw.ai/web/control-ui#markdown-tables) also explains the existing, narrower navigation support in Ask OpenClaw.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep expanded table links and conversation navigation working, restore overflow indicators, and reject invalid inherited-property saved route names [#136433](https://github.com/openclaw/openclaw/pull/136433).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Updates and Maintenance
+
+Update reports now stay available after a restart, and more settings can change while your Claw keeps working. The maintenance work also preserves working preferences during upgrades, keeps eligible interrupted tasks able to continue, and makes backups, conversation cleanup, and repair diagnostics more useful when an installation needs attention.
+
+<AccordionGroup>
+
+<Accordion title="Follow an update through restart">
+
+An update now leaves a report you can return to after the connection drops and OpenClaw comes back. The update dialog follows the saved attempt, Settings → Updates reopens its latest report, and the CLI and chat use the same recorded steps, outcome, and verification results. Successful updates keep that detail too, so you do not have to reconstruct what happened from a disappearing notification. The [update history guide](https://docs.openclaw.ai/cli/update#run-history-and-reports) covers `openclaw update status` and administrator history queries.
+
+Configured owners can ask for an update in chat or use `/update`, with guidance when their account lacks owner access. Chat updates require `commands.ownerAllowFrom` and the existing `commands.restart` permission, and reports for existing web conversations can be saved directly into the conversation without an extra model turn. Managed services may miss intermediate notices, and a usable delivery route is still needed for an external chat notice.
+
+A saved report describes what OpenClaw recorded. Missing verification stays unverified, and an interrupted CLI update can still leave a running record that locks update and configuration controls. An idle Gateway may also miss a separately started CLI update until it restarts, so a running label alone is not proof that the updater is alive.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add owner /update requests with persisted results and staged-download recovery [#136588](https://github.com/openclaw/openclaw/pull/136588). Thanks @hxy91819, @zyw02, @toneloke, @jackiedepp, @sonpiaz.
+- Retain update run history and share reports across CLI, chat, and restart notices [#138690](https://github.com/openclaw/openclaw/pull/138690). Thanks @obviyus, @lifeviwer.
+- Keep update progress, reports, and recovery actions across Gateway restarts [#138737](https://github.com/openclaw/openclaw/pull/138737). Thanks @obviyus, @lifeviwer.
+
+**Bug fixes**
+
+- Explain owner refusals, distinguish update outcomes, and identify disabled macOS Gateway services [#136995](https://github.com/openclaw/openclaw/pull/136995). Thanks @fuller-stack-dev.
+- Show managed-update cancellation errors before the CLI exits [#138806](https://github.com/openclaw/openclaw/pull/138806).
+
+Admitted dry-run previews record a skipped attempt and require writable shared state, although they leave the installation unchanged. History has no automatic deletion. Sidebar reports can remain for up to 24 hours until that browser acknowledges them. The failed pre-swap download recovery applies only when the previous runtime can be verified as safe.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Complete package and source updates">
+
+Package updates preserve the files another updater is actively preparing and the shared plugin dependencies another installation still needs. Once the replacement Gateway has passed the existing readiness and version checks, the updater keeps that healthy process running instead of interrupting it with a second restart. Supported upgrades from the published v2026.8.2 package also retain the code needed by the older updater to finish replacement and bring its previously active managed service back.
+
+Source installations address a different part of the same journey. The repaired updater keeps the code it needs available while generated files are replaced, letting it finish configuration processing and restart the Gateway after a rebuild. Ordinary CLI commands also skip a needless rebuild when only unchanged files' timestamps differ. An updater already running older code cannot acquire those fixes midway through its own replacement, so the transition installing the repair may still need operator recovery.
+
+On Linux without a service manager, the updater can proceed when the selected Gateway is idle and service inspection permits it, explaining why restart was skipped. **When upgrading that setup from the published v2026.8.2 CLI, confirm no Gateway is running and use the one-time `openclaw update --no-restart` path.** The [update reference](https://docs.openclaw.ai/cli/update) explains the service checks and manual restart steps.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve other installations' shared plugin dependencies during updates [#134099](https://github.com/openclaw/openclaw/pull/134099). Thanks @billverhelle, @bryantegomoh, @obviyus.
+- Finish source updates after generated files are replaced [#136535](https://github.com/openclaw/openclaw/pull/136535). Thanks @romneyda.
+- Skip unnecessary CLI rebuilds in unchanged source checkouts [#136634](https://github.com/openclaw/openclaw/pull/136634). Thanks @jason-allen-oneal.
+- Allow updates on idle service-less Linux installations [#136798](https://github.com/openclaw/openclaw/pull/136798). Thanks @vincentkoc.
+- Preserve active npm update stages during leftover cleanup [#137998](https://github.com/openclaw/openclaw/pull/137998).
+- Avoid restarting a healthy Gateway twice during updates [#138354](https://github.com/openclaw/openclaw/pull/138354). Thanks @gregbond, @obviyus.
+- Restart the Gateway after replacing a Git installation [#138781](https://github.com/openclaw/openclaw/pull/138781). Thanks @jason-allen-oneal, @vincentkoc.
+
+**Limits and compatibility**
+
+- Retain upgrade compatibility for v2026.8.2 packages [#136395](https://github.com/openclaw/openclaw/pull/136395). Thanks @fuller-stack-dev, @vincentkoc.
+
+The older packaged compatibility window covers published v2026.8.2 and the exact d413210bc7420923d101ce64211511cdac7b9464 artifact, not arbitrary older development packages. The PR identity also appears in v2026.9.1 evidence, but equivalence of that older shipped patch is unproven. Protected staging does not make simultaneous package swaps safe, and abandoned stages need confirmed-inactive manual cleanup. Legacy clawdbot-gateway.service detection remains a limitation on service-less Linux. A separate npm prefix alone does not isolate shared state from older packages.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep working settings during upgrades">
+
+Automatic updates now keep enabled skill preferences when a prerequisite happens to be missing from the update environment, and fully repairable older multi-agent configurations retain current choices such as the update channel, port, and original default agent. A failed agent-settings save also keeps the previous complete file readable. Enabled skills still need their prerequisites before they can run, and an explicit standalone Doctor repair can still disable unavailable skills.
+
+**Remove `messages.suppressToolErrors`, even if its value is `false`, or run `openclaw doctor --fix` to migrate it.** The retired setting no longer suppresses the final warning when a tool fails and the run has delivered no reply. Channel settings continue to control mid-turn progress.
+
+If an intended owner has lost access to restart or update commands because their saved identity uses an older `channel:user:id` form, run the same explicit Doctor repair to migrate recognized, unambiguous entries. Upgrading alone does not rewrite those owner entries, and ambiguous identities or default-agent choices still need manual correction.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve complete agent settings when a save fails [#131431](https://github.com/openclaw/openclaw/pull/131431). Thanks @zenglingbiao, @shojikumaru, @obviyus.
+- Keep enabled skills from being disabled by automatic-update Doctor repairs [#138730](https://github.com/openclaw/openclaw/pull/138730). Thanks @fuller-stack-dev, @obviyus.
+- Preserve current settings when migrating legacy agent rosters [#138837](https://github.com/openclaw/openclaw/pull/138837).
+
+**Limits and compatibility**
+
+- Retire tool-error suppression and migrate existing settings with Doctor [#137775](https://github.com/openclaw/openclaw/pull/137775). Thanks @neoclaw-latrobe, @gwy-origin, @joncursi.
+- Repair legacy owner identities before using owner-only commands [#137780](https://github.com/openclaw/openclaw/pull/137780). Thanks @shakkernerd.
+
+The deprecated SDK field `suppressToolErrorWarnings` is ignored and is scheduled for removal in the first stable release after 2026.10. A reply already delivered prevents a duplicate final warning. Agent-settings saves preserve supported symlink chains and permissions without claiming protection from every hardware or power-loss failure.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Apply settings without a full restart">
+
+You can change more of how your Claw works without restarting the whole Gateway. With the default hybrid [configuration reload](https://docs.openclaw.ai/gateway/configuration#config-hot-reload), routine changes to tools, approvals, messaging, speech, browser defaults, retention, and update policy reach the next relevant operation while unaffected conversations stay connected. Logging changes reach already-running channels and plugins, dashboard serving can be switched on or off, and a loaded OpenTelemetry exporter can be replaced on its own when its settings change.
+
+Access changes apply at the place they matter. Pending automatic pairing approvals recheck current policy, revoked device commands are cancelled, and rotating a token or password within the same authentication mode reconnects affected shared-credential clients while independently paired clients stay connected. Existing sign-in failures and earned lockouts survive rate-limit changes. Changing the shell affects new terminals, while disabling terminals closes existing sessions and re-enabling allows fresh ones.
+
+Changes that replace a channel, browser, or exporter can briefly interrupt that service, and failed service replacement can require Gateway recovery. Working hooks survive a replacement that fails to load, and active channels restore their incoming routes after plugin replacement. Refresh open browser pages for changed interface preferences or terminal policy. Listener and process settings, authentication-mode changes, and dashboard asset roots or base paths still require a full restart.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reload pairing, HTTPS headers and future shells, and restore chat embed opt-in [#136832](https://github.com/openclaw/openclaw/pull/136832).
+- Reload device permissions, browser defaults, terminal retention, allowed origins, and same-mode credentials [#137160](https://github.com/openclaw/openclaw/pull/137160).
+- Apply terminal and shared messaging policy changes while the Gateway runs [#137412](https://github.com/openclaw/openclaw/pull/137412).
+- Apply authentication rate limits and discovery mode without restarting [#137790](https://github.com/openclaw/openclaw/pull/137790).
+- Reload routine approval, messaging, speech, retention, update, and browser settings while preserving working hooks and channel routes [#138112](https://github.com/openclaw/openclaw/pull/138112). Thanks @ylcn91, @nianjiuzst, @cnaghibi1.
+- Enable or disable the dashboard without restarting the Gateway [#138497](https://github.com/openclaw/openclaw/pull/138497).
+- Reload diagnostics and OpenTelemetry settings, and keep shared monitoring running when Telegram webhooks stop [#138556](https://github.com/openclaw/openclaw/pull/138556).
+
+**Bug fixes**
+
+- Apply HTTP API availability and limits, tool and CLI-agent policies, UI preferences, and APNs relay settings without restarting Gateway [#136738](https://github.com/openclaw/openclaw/pull/136738).
+- Apply logging and browser-import permission changes without restart [#138462](https://github.com/openclaw/openclaw/pull/138462).
+
+Pairing-policy changes preserve already paired devices, and changed SSH verification settings require fresh proof. Live HSTS changes affect subsequent responses. External widgets in saved and streaming assistant messages follow the external-embed opt-in. Detached-terminal deadlines use the original disconnect time and can close already-expired sessions immediately. Managed browser launch changes replace only affected browsers on next use, leaving externally attached browsers running. SecretRef credential rotation needs an explicit `gateway.auth.mode`. Discovery off stops local multicast, while configured wide-area discovery can remain active. Disabling dashboard serving returns 404 for its HTTP requests, and missing assets can return 503 while re-enabling prepares them. Logging keeps explicit overrides and already-queued records' policy. Plugin installation and other documented restart-owned browser settings still require restart.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue eligible work after restart">
+
+A Full Access task interrupted by a Gateway restart can inspect its saved conversation and use fresh, currently authorized shell commands or delegated work to continue the original request without asking you to send it again. The [restart recovery guide](https://docs.openclaw.ai/gateway/restart-recovery) explains how inherited Full Access and explicit session choices apply, while work restricted for safe replay or uncertain delivery keeps its narrower permissions.
+
+Queued follow-up replies also retain their original Gateway association after the initiating request ends, and one reply finishing during shutdown no longer removes another unfinished reply's recovery record. These repairs preserve eligibility to continue work and deliver its result. Interrupted calls and expired process or approval handles are not replayed automatically, and a failed recovery-record write or an uncertain external delivery can still need attention.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover interrupted replies under their original Gateway during restart [#138071](https://github.com/openclaw/openclaw/pull/138071).
+- Preserve independent recovery markers for simultaneous replies at shutdown [#138519](https://github.com/openclaw/openclaw/pull/138519).
+- Retain restart recovery ownership for queued webchat and RPC replies [#138565](https://github.com/openclaw/openclaw/pull/138565).
+- Restore effective Full Access tools for continued work after Gateway restart [#138701](https://github.com/openclaw/openclaw/pull/138701).
+
+The queued-reply repairs preserve recovery selection and saved markers; they do not establish universal next-process delivery or exactly-once external actions. Gateway ownership remains separate when several instances share a process. A failed durable recovery write is reported even though cancellation proceeds.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Stop the Gateway with accurate cleanup status">
+
+Stopping the Gateway now keeps tracked requests, commands, and required cleanup together until they settle, so a finished response does not release services that its remaining work still needs. If required cleanup fails, the process reports an unsuccessful stop instead of starting a replacement inside a runtime that has not finished closing. Commands that time out during startup can return promptly while shutdown continues to track their cleanup separately.
+
+Several specific waits are addressed along the way. Committed restarts retire obsolete follow-up retries, suspended Gateways cancel background work that has not started, and bursts of file logs drain in batches. Already-running startup preparation and plugin cleanup are still joined, which can add time to a stop. A stop requested from within Gateway chat reports that it has been scheduled and lets the requesting operation settle, with final termination remaining the responsibility of the serving process or its service manager.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Wait for accepted Gateway work, report failed cleanup, and keep delayed question controls tied to their original question [#136146](https://github.com/openclaw/openclaw/pull/136146).
+- Retire queued follow-up retries when Gateway restart commits [#136713](https://github.com/openclaw/openclaw/pull/136713). Thanks @ericcaiwx-star, @obviyus, @potterdigital.
+- Stop late request entry after Gateway shutdown and restore catalog loading [#136998](https://github.com/openclaw/openclaw/pull/136998).
+- Handle in-chat Gateway stop requests without crashing or waiting on themselves [#137456](https://github.com/openclaw/openclaw/pull/137456). Thanks @vincentkoc.
+- Join active startup preparation and plugin cleanup during shutdown [#137794](https://github.com/openclaw/openclaw/pull/137794).
+- Drain bursts of file logs with bounded asynchronous batches [#137833](https://github.com/openclaw/openclaw/pull/137833).
+- Retain cleanup ownership when commands time out or stop during startup [#138093](https://github.com/openclaw/openclaw/pull/138093).
+- Clean up source-checkout Gateway processes on shutdown [#138239](https://github.com/openclaw/openclaw/pull/138239).
+- Cancel queued background work when a suspended Gateway closes [#138734](https://github.com/openclaw/openclaw/pull/138734).
+
+Delayed question controls remain associated with the original question and can display “Unavailable” when that question is no longer usable. Pending approvals, questions, and pairing decisions stay pending after an observer disconnects. The request-preparation repair also restores affected model-catalog loading. Source-checkout child cleanup covers its repaired launcher, not every supervising wrapper. A scheduled stop is not confirmed termination or guaranteed response receipt; total shutdown time and complete descendant termination remain dependent on the work and cleanup involved.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Hand maintenance back to an external controller">
+
+Deployment controllers that pause new work before maintenance can now explicitly hand an unfinished wait over to restart recovery. An administrator arms `gateway.suspend.handoff` for the exact suspended process, then the controller sends `SIGTERM` and owns launching the replacement. This gives managed deployments a supported way to interrupt eligible conversation work after their maintenance waiting period, without having two owners trying to restart the same Gateway.
+
+The [external-app integration guide](https://docs.openclaw.ai/gateway/external-apps#cooperative-host-suspension) covers the handoff's expiry and refusal rules. Arming it alone does not stop the process, and pending final conversation writes can refuse the handoff. Terminal commands and scrollback end with the old process and are not recovered.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Hand suspended Gateway work back to external restart controllers [#138885](https://github.com/openclaw/openclaw/pull/138885).
+
+The handoff requires administrator scope and expires with its suspension lease. Repeating it does not renew interruption authority, and resume, process replacement, or another accepted lifecycle action invalidates it. Controllers must defer when the method is unsupported or refused.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Create and restore complete backups">
+
+[Backups](https://docs.openclaw.ai/cli/backup) now handle managed configuration and credential links such as those used by NixOS and Home Manager, retaining portable links to the content included in the backup. Slow snapshots involving older audit logs can complete without holding the migration lock for the whole copy, and malformed archive headers are rejected before restoration creates its destination.
+
+Git backups also preserve text after an embedded NUL character, which could previously truncate a value or collapse distinct record keys. This includes affected iMessage recovery records in global backups. **Recreate affected older Git backups from intact source data after updating, even if the old backup passed verification.** Updating cannot recover bytes already missing from a backup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep legacy audit capture consistent during slow backups [#130962](https://github.com/openclaw/openclaw/pull/130962). Thanks @gaoanze888, @obviyus, @73ttv627re77.
+- Back up and restore managed configuration and credentials symlinks [#136343](https://github.com/openclaw/openclaw/pull/136343). Thanks @vsumner, @nianjiuzst, @obviyus.
+- Reject malformed archive headers before backup restoration starts [#137718](https://github.com/openclaw/openclaw/pull/137718).
+- Preserve embedded-NUL text in Git backups [#138327](https://github.com/openclaw/openclaw/pull/138327). Thanks @obviyus, @ced-cm, @holny.
+
+Managed absolute links qualify only when their resolved targets are declared backup assets; unsafe or undeclared targets remain rejected. If older audit state changes throughout three capture attempts, creation leaves no archive and asks for a retry after migration settles. The embedded-NUL repair applies to Git backup serialization, not all database reads.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Archive and clean up large conversation stores">
+
+Reaching the active-session limit now archives eligible ordinary conversations so you can search for them and restore them later, while previously archived conversations stop counting against that limit. The interface explains why a conversation was archived, and [cleanup previews](https://docs.openclaw.ai/cli/sessions#cleanup-maintenance) distinguish archival from removal. Cap-created archives can still be permanently deleted later under disk pressure, and other retention policies continue to apply.
+
+Large conversation stores also do less maintenance work on the thread serving interactive Gateway requests. Eligible transcript reclamation and physical disk accounting run in workers, excluded sessions avoid unnecessary metadata reads, and large archive backlogs can progress without overflowing SQLite's parameter limit. Scan scheduling and old-history inspection use less temporary memory in their affected paths, keeping the same retention decisions and disk totals.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Archive ordinary conversations when the active-session limit is reached [#133366](https://github.com/openclaw/openclaw/pull/133366). Thanks @vacinc.
+- Avoid loading excluded sessions during cleanup checks [#138470](https://github.com/openclaw/openclaw/pull/138470).
+- Reduce initial scheduling work and memory pressure during large session disk scans [#138604](https://github.com/openclaw/openclaw/pull/138604).
+- Move physical session disk accounting off the Gateway thread [#138669](https://github.com/openclaw/openclaw/pull/138669).
+- Reduce temporary memory during old-history cleanup scans [#138940](https://github.com/openclaw/openclaw/pull/138940).
+
+**Bug fixes**
+
+- Keep the Gateway responsive during large session cleanup [#126035](https://github.com/openclaw/openclaw/pull/126035). Thanks @hermanzeng, @obviyus.
+- Allow large session archive cleanups to progress [#137545](https://github.com/openclaw/openclaw/pull/137545).
+- Report protected agent-main sessions accurately in archive and delete previews [#137953](https://github.com/openclaw/openclaw/pull/137953). Thanks @obviyus, @r3n3x.
+- Clean up large managed worktrees without argument overflow [#138066](https://github.com/openclaw/openclaw/pull/138066).
+
+Manual, legacy, stale-dashboard, and recovery archives remain protected from the cap-created archive deletion tier, as do otherwise protected sessions. Protected agent-main archive/delete previews now fail accurately, but global-session previews can still describe an action the Gateway refuses. Native session-owner and incognito reclamation paths remain synchronous. Worker scans still perform filesystem work and have no universal speed or total-memory guarantee. Large managed-worktree cleanup retains restorable branch history, edits, and tracked deletions.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Get repair advice for the right installation">
+
+[Doctor](https://docs.openclaw.ai/cli/doctor) gives repair instructions for the installation you are actually inspecting. A failed remote connection points you back to that host, its credentials, and its tunnel or network connection, while a source-install dashboard repair command includes the detected checkout path so it can be copied from another directory. Service advice distinguishes installing a missing service, starting an installed one, and explicitly replacing its definition, and explains when Nix, an external supervisor, or the invoking shell prevents installation.
+
+Full read-only lint finds expired credentials in the original agent and shared stores and reports their usable paths. Legacy Discord, Matrix, Codex, and Teams checks skip unrelated startup work when it is not needed. Invalid plugin settings now produce a configuration error instead of making the command appear missing, with core shell completion still available while you repair the settings and regenerate plugin completion. Use `doctor --lint` or bare `doctor --json` for read-only diagnosis, since ordinary Doctor can migrate state.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Resolve agent paths against the selected service home [#116157](https://github.com/openclaw/openclaw/pull/116157). Thanks @matthewsynthia, @obviyus, @mohammedalkindi.
+- Bind Control UI repair commands to the detected checkout [#137354](https://github.com/openclaw/openclaw/pull/137354).
+- Keep remote Doctor connection failures out of local service recovery [#137465](https://github.com/openclaw/openclaw/pull/137465).
+- Give accurate Gateway service recovery commands and cleanup results [#137505](https://github.com/openclaw/openclaw/pull/137505).
+- Match service installation advice to Nix, supervisor and shell restrictions [#137548](https://github.com/openclaw/openclaw/pull/137548).
+- Inspect original credential stores during full Doctor lint [#137610](https://github.com/openclaw/openclaw/pull/137610).
+- Check legacy session and Teams files through lightweight path resolution [#138128](https://github.com/openclaw/openclaw/pull/138128).
+- Report invalid plugin settings directly and retain core shell completion [#138131](https://github.com/openclaw/openclaw/pull/138131).
+
+**Improvements**
+
+- Skip unused Discord and Matrix migration startup work [#137529](https://github.com/openclaw/openclaw/pull/137529).
+
+Differing CLI and service homes now resolve agent paths against the selected service environment, but a separate systemd enabled-state display limitation remains. Service guidance does not add authority to replace an externally owned service. After invalid configuration is repaired, regenerate shell completion to restore plugin commands.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Start managed services and migrated installs">
+
+Managed Windows Gateways stay alive through startup and can be stopped while startup is still pending, avoiding the case where a command reported a stop and the Gateway appeared afterward. Linux service maintenance correctly reads valid comments and continued lines, preserving runnable service definitions, recovery backups, and operator overrides.
+
+Startup also refreshes migrated plugin policy before checking readiness and avoids repeated database scans during migration decisions. Large valid agent configurations with repeated plugin-owned model choices no longer hit the repaired startup bottleneck. These changes let the affected installations reach their normal readiness checks, while genuine configuration changes or failed database checks still prevent startup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep managed Windows Gateway startup alive and stoppable, and clarify existing-workspace selection [#136980](https://github.com/openclaw/openclaw/pull/136980). Thanks @hermannmetzker-ai, @dasx.
+- Preserve systemd services, backups and overrides when reading continued lines [#137448](https://github.com/openclaw/openclaw/pull/137448).
+- Refresh migrated plugin policy metadata before Gateway readiness checks [#137717](https://github.com/openclaw/openclaw/pull/137717). Thanks @hermannmetzker-ai.
+- Avoid duplicate database scans in migration checks [#138315](https://github.com/openclaw/openclaw/pull/138315).
+- Avoid repeated database checks during Gateway startup [#138977](https://github.com/openclaw/openclaw/pull/138977).
+- Remove startup stalls from repeated agent model references [#136379](https://github.com/openclaw/openclaw/pull/136379). Thanks @sunlit-deng, @obviyus, @liuwqgit.
+
+The Windows changes do not resolve every historical upgrade, workspace-ownership, or stale-Codex report. Linux parsing prevents the repaired corruption path but does not reconstruct already damaged unit files. Remaining database integrity checks can still block startup.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Inspect database compatibility and errors">
+
+Database compatibility checks used by updates, Doctor, and Gateway maintenance now inspect private copies while preserving the original database files and surrounding SQLite files, including committed changes waiting in a write-ahead log. These checks need temporary space and copying time, and can refuse to finish when a safe copy cannot be prepared.
+
+When inspection or verification fails, diagnostics retain useful Node and SQLite error codes. A stable malformed file can report that it is not a database instead of incorrectly appearing to change throughout inspection, and database cleanup releases its original maintenance lock even if the surrounding storage environment has changed. A generic disk I/O error still needs investigation before attributing it to a full disk.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Include native error codes in read-only SQLite snapshot failures [#137999](https://github.com/openclaw/openclaw/pull/137999).
+- Include native Node and SQLite codes in database verification errors [#138095](https://github.com/openclaw/openclaw/pull/138095).
+- Release database leases using their original state location [#138454](https://github.com/openclaw/openclaw/pull/138454).
+- Preserve database files while checking update compatibility [#138868](https://github.com/openclaw/openclaw/pull/138868). Thanks @fuller-stack-dev, @dpriscal.
+- Report malformed database files accurately during read-only inspection [001e5d6b75c7](https://github.com/openclaw/openclaw/commit/001e5d6b75c7de0c071f687590a063ac6d2b6b10). Thanks @vincentkoc.
+
+Compatibility snapshots are temporary inspection copies, not recovery backups or rollback. Native codes add diagnostic detail without changing verification or quarantine decisions. Incognito cleanup's unwanted files were unrelated shared state, not persisted incognito transcripts. The direct commit's accompanying release-validation changes remain internal.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Measure slow requests and shutdown work">
+
+Operators investigating slow requests can now separate the wait before a Gateway handler starts, the handler's elapsed time, and the first response through the existing diagnostics exporters. The [Gateway RPC metrics](https://docs.openclaw.ai/gateway/opentelemetry#gateway-rpc) cover authenticated WebSocket requests, and normal logs also show slow reply-preparation stages separately from waiting for a model or tool. Health observations retain pauses that repeated reads could previously hide, so a later healthy check does not erase the earlier observation from enabled monitoring.
+
+During shutdown, count-only reports show remaining tracked work and the transition into server cleanup. The existing `OPENCLAW_GATEWAY_RESTART_TRACE=1` option adds entered-phase markers to help locate a wait before that phase finishes. Routine successful continuations move to debug logs, and an unchanged stale-worker assignment stops producing the same disk-space warning every minute.
+
+These measurements show observed elapsed phases and completed monitoring windows. They do not identify the responsible function by themselves, and a response accepted for sending is not proof the client received it. Check dropped-observation counters before treating monitoring as complete. If a script calls `openclaw logs`, omit unset `--limit`, `--max-bytes`, and `--interval` options instead of passing empty values, which now produce an error.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Measure Gateway request latency phases in diagnostics exporters [#138015](https://github.com/openclaw/openclaw/pull/138015).
+- Retain observed Gateway delays in monitoring metrics [#138249](https://github.com/openclaw/openclaw/pull/138249).
+- Report remaining work and shutdown phase progress [#138379](https://github.com/openclaw/openclaw/pull/138379).
+- Move normal continuation diagnostics to debug logging [#137328](https://github.com/openclaw/openclaw/pull/137328).
+
+**Bug fixes**
+
+- Reduce session-title reads and log slow reply-preparation stages [#136971](https://github.com/openclaw/openclaw/pull/136971).
+- Suppress repeated disk-space probes for unchanged stale worker assignments [#137001](https://github.com/openclaw/openclaw/pull/137001).
+- Reject empty numeric options in the logs command [#137336](https://github.com/openclaw/openclaw/pull/137336). Thanks @alix-007, @vincentkoc.
+- Keep recent trajectory recordings within their byte limit without overflowing large-backlog deletion limits [#138637](https://github.com/openclaw/openclaw/pull/138637).
+- Retain event-loop stalls across repeated health checks [#138908](https://github.com/openclaw/openclaw/pull/138908).
+
+**Documentation**
+
+- Explain whole-process CPU ratios in health and monitoring guides [#138804](https://github.com/openclaw/openclaw/pull/138804).
+
+RPC observations exclude HTTP routes, handshakes, and malformed frames; early acknowledgments can precede completed agent work. Shutdown count categories can overlap. Event-loop metrics describe completed observation windows, not individual-stall counts or an overall native p99. CPU ratios describe whole-process core use, including worker and native threads, and can exceed one without proving a main-thread hang. Trajectory capture retains nothing if its newest event alone exceeds the byte budget.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Attempt a bounded installation repair">
+
+On the computer running OpenClaw, an interactive `openclaw triage --run` can attempt an installation repair using configured models and their permitted fallbacks. Doctor lint runs before and after the attempt, skips inference when it finds no errors initially, and keeps the result unsuccessful if errors remain afterward. The attempt is limited to one turn, ten minutes overall, five minutes for the turn, and 40 tool calls.
+
+**Explicit `--run` permits host commands without further approval prompts during that repair.** Filesystem tools enforce the installation or candidate-root boundary, but shell commands follow the repair prompt and have no OS sandbox. Explicit tool denies remain in force, and unsupported execution routes produce guidance for an external handoff. The [installation triage guide](https://docs.openclaw.ai/cli/triage#installation-target-and-embedded-handoff) explains these limits and the checked result.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Run bounded configured-model installation repair with before-and-after Doctor checks [#138673](https://github.com/openclaw/openclaw/pull/138673). Thanks @obviyus, @lifeviwer.
+
+The embedded repair does not activate an update, restart services, create a backup, or roll back files. Doctor lint determines the reported repair result and is not a guarantee of complete application health.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Messaging
+
+Discord meetings can now leave behind notes you can return to, and Slack conversations give you more useful ways to stop work, follow a reply, or make a decision. The changes also carry through the everyday parts of messaging, from keeping the instructions attached to one message to preserving code, recordings, and generated files as they move through a conversation.
+
+<AccordionGroup>
+
+<Accordion title="Stop and follow Slack agent sessions">
+
+In supported Slack agent sessions, the native Stop button now reaches the work running in the selected conversation, including overlapping replies in group DMs, while session status shows when the agent is working or waiting for an approval. Rename a supported session in Slack and OpenClaw keeps that name through later messages, with delayed controls checked against the conversation they belong to.
+
+Existing apps need the two session-event subscriptions described in the [Slack setup guide](https://docs.openclaw.ai/channels/slack#additional-manifest-settings), and native session status requires a reply thread. A completed first reply can still lose its title association after cleanup or restart, and overlapping replies can still interfere with the shared working indicator. Progress cards also keep earlier errors as recovered history after a successful turn, so a finished task does not keep looking failed.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add native Slack Stop, session status, and synchronized titles for supported agent sessions; plain bots are outside scope and a narrow short-reply Stop race remains [#136706](https://github.com/openclaw/openclaw/pull/136706). Thanks @danielduerr.
+
+**Bug fixes**
+
+- Route Slack Stop and title updates to the active conversation [#137658](https://github.com/openclaw/openclaw/pull/137658).
+
+- Route Slack Stop and title controls to current conversation owners, including overlapping replies and protection against delayed controls reaching replacement sessions [#137863](https://github.com/openclaw/openclaw/pull/137863).
+
+- Mark earlier Slack tool failures as recovered after a successful turn [#137523](https://github.com/openclaw/openclaw/pull/137523). Thanks @joncursi, @neoclaw-latrobe.
+
+- Remove stray formatting backslashes from Slack progress and previews [#137526](https://github.com/openclaw/openclaw/pull/137526). Thanks @joncursi.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Finish Slack replies without replaying uncertain sends">
+
+In [Slack compact progress mode](https://docs.openclaw.ai/channels/slack#text-streaming), the final answer arrives as a new message after any conversation or media that appeared while the agent worked. Temporary progress is removed after Slack confirms delivery, and a failed send leaves the preview available.
+
+Slack writes also distinguish an explicit rate-limit rejection from a lost response. A supported rate-limit response can retry up to twice after Slack’s requested wait, including ordinary messages and upload completion. If the outcome is uncertain, OpenClaw reports the failure and avoids automatically repeating text Slack may already have received. That tradeoff means an unaccepted reply can remain missing when its outcome cannot be established.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Avoid Slack Socket Mode startup timeouts caused by empty request bodies while preserving nonempty request payloads [#136528](https://github.com/openclaw/openclaw/pull/136528). Thanks @openclaw-agent-man, @obviyus, @dan2k3k4, @gustav-bliss.
+
+- Post Slack compact-mode completion as a new reply before clearing progress [#137952](https://github.com/openclaw/openclaw/pull/137952). Thanks @pash-openai.
+
+- Avoid replaying uncertain Slack stream writes and drain queued replies before cleanup [#138221](https://github.com/openclaw/openclaw/pull/138221).
+
+- Retry explicit Slack rate limits without replaying uncertain writes [#138487](https://github.com/openclaw/openclaw/pull/138487).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use tables and decision buttons in Slack">
+
+When a Slack reply would be easier to use as a table or a few choices, the agent now has guidance to offer that format without requiring you to ask for Block Kit. A status request can become an organized report, or a decision can arrive with buttons that let you choose and continue the conversation. This uses the existing Slack renderer and supported controls, with plain text for simple replies and a text fallback for richer ones; the format the agent chooses still depends on the model and request.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Guide Slack agents to offer useful tables and decision buttons using existing controls, without adding native modal delivery [#138896](https://github.com/openclaw/openclaw/pull/138896). Thanks @patrick-erichsen.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Save and revisit Discord meeting notes">
+
+You can configure a listen-only bot to [take Discord meeting notes](https://docs.openclaw.ai/channels/discord#meeting-notes) when people enter a voice room, then return to the overview, decisions, action items, and speaker-labeled transcript from the [Meetings page](https://docs.openclaw.ai/web/control-ui#meetings-page). Agents can also read permitted saved meetings, so the conversation can continue from what was discussed without you having to paste the notes into a new chat.
+
+Occupancy capture is opt-in and needs Discord voice and speech-to-text setup. Tell participants that transcripts will be captured and stored before enabling it, and configure at most one room per account and guild. The bot waits 30 seconds after everyone leaves, and a meeting can reopen with its existing transcript within 10 minutes, including after a restart. Continuous capture remains the default for existing setups and now retains its capture identity through temporary startup failures.
+
+People with operator read access share access to meetings across the Gateway, regardless of the selected agent; use separate Gateways when readers need isolation. Model summaries can fall back to heuristic notes, and very long meetings can omit middle sections from the model’s summary input, so use the transcript when a particular detail matters.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Capture occupied Discord meetings and browse saved notes in Meetings [#136679](https://github.com/openclaw/openclaw/pull/136679).
+
+**Bug fixes**
+
+- Preserve transcript capture identity through automatic startup retries [#138830](https://github.com/openclaw/openclaw/pull/138830).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep Discord voice with the speaker">
+
+In a shared Discord voice room, a delayed request keeps the identity and permissions of the person who spoke it, while spoken answers queue in order instead of replacing one another. One speaker’s failed connection can recover when they speak again without disconnecting everyone else, and OpenAI agent-proxy early wake acknowledgments require the name at the start of the utterance instead of matching an unfinished ordinary word.
+
+OpenAI and xAI voice replies also handle interruptions against the answer currently playing when another answer is queued, and later replies can continue after cancellation. The follow-up playback repair keeps a partial audio frame from ending the conversation during a provider pause. Direct voice-model history remains separate for each speaker while agent consultations share the room conversation; a room retains at most eight speaker connections, subject to the provider’s own limits.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Require an exact leading wake name for early Discord voice acknowledgments and resume queued speech after cancellations, encoder failures, or rejected requests [#136982](https://github.com/openclaw/openclaw/pull/136982).
+
+- Interrupt the currently playing Discord OpenAI or xAI answer and release later replies using local playback progress, not an assertion of remote listening [#138072](https://github.com/openclaw/openclaw/pull/138072).
+
+- Keep Discord realtime voice playing through partial-frame provider pauses [#138536](https://github.com/openclaw/openclaw/pull/138536).
+
+**Security and trust**
+
+- Keep Discord voice permissions with each speaker, queue answer audio, and let Google Live complete normal, interrupted, and empty requested replies [#137433](https://github.com/openclaw/openclaw/pull/137433).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Edit and split Discord messages">
+
+Long Discord replies keep their code, Unicode characters, and surrounding quote or list context when they need several messages, and attachment captions avoid extra empty code blocks. Sends and edits also preserve intentional indentation and trailing newlines, while an explicitly empty edit can clear an attachment caption without removing the attachment. Extremely small configured message limits can still constrain formatting, and the existing access checks continue to apply.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reject unsupported Discord activity names before presence updates while retaining the six supported activity types [#137677](https://github.com/openclaw/openclaw/pull/137677). Thanks @teddytennant, @obviyus.
+
+- Keep Discord formatting and allow caption-clearing edits [#138347](https://github.com/openclaw/openclaw/pull/138347).
+
+- Preserve Discord code and attachment captions across message boundaries, and prevent later send or callback failures from replaying an accepted upload [#138413](https://github.com/openclaw/openclaw/pull/138413).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Send rich replies through Telegram">
+
+With Telegram rich messages enabled, collapsible details keep their headings, code, quotes, tables, and nested sections together through sends and edits. Unsupported markup remains readable as literal text, so examples do not silently lose their wrappers.
+
+Telegram progress mode also keeps Claude CLI commentary in one temporary message, shows when context compaction completes or remains incomplete, and gives the final answer priority over pending commentary. Commentary remains temporary even with verbose mode enabled. For installations that depend on a proxy, explicitly configured trusted SOCKS5 routes now carry Bot API requests and incoming attachments through the intended transport, including supported cases where the media destination cannot be resolved locally; the proxy itself must still be locally resolvable and reachable.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Suggest permitted standard or custom emoji after rejected Telegram reactions when available, without automatically retrying them [#129817](https://github.com/openclaw/openclaw/pull/129817). Thanks @aniruddhaadak80, @obviyus.
+
+- Restore Telegram SOCKS attachments and shared HTTPS-proxy requests [#131436](https://github.com/openclaw/openclaw/pull/131436). Thanks @scoootscooob, @kevph2026, @mjamiv.
+
+- Keep structured Markdown inside Telegram details sections [#132688](https://github.com/openclaw/openclaw/pull/132688). Thanks @sunlit-deng, @obviyus, @yangmanbobo.
+
+- Prioritize final Telegram answers over temporary Claude CLI commentary [#134826](https://github.com/openclaw/openclaw/pull/134826). Thanks @vacinc.
+
+- Preserve Telegram account and sender-policy names during Doctor cleanup, and skip empty session-reclamation workers while retaining pending archive recovery [#137860](https://github.com/openclaw/openclaw/pull/137860).
+
+- Keep unsupported prototype-named Telegram tags as literal markup [#137870](https://github.com/openclaw/openclaw/pull/137870). Thanks @teddytennant, @obviyus.
+
+- Remove routine per-poll Telegram log noise [#138331](https://github.com/openclaw/openclaw/pull/138331). Thanks @teddytennant, @vincentkoc, @r3n3x.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Change messaging settings while channels stay connected">
+
+You can adjust how long OpenClaw waits to [combine a burst of messages](https://docs.openclaw.ai/concepts/messages#inbound-debouncing) without reconnecting Discord, Feishu, iMessage, Mattermost, Microsoft Teams, Signal, Slack, Telegram, or WhatsApp. New work uses the saved delay, while a setting change alone leaves an already pending batch on its existing schedule. Acknowledgement-reaction scope also applies to new turns without reconnecting the supported channels, and work already in progress keeps the policy it started with.
+
+Known webhook addresses now ask the sender to retry while a channel or plugin is being replaced. This depends on the sender honoring the retry response; the message has not been accepted or stored at that point. Multi-account IRC setups can also add or edit a non-default named account without disconnecting its siblings, while shared settings, default-account changes, and removals can still restart the channel.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Adjust incoming-message grouping while nine supported channels stay connected, retaining conservative refresh for plugins that do not declare live setting reads [#138780](https://github.com/openclaw/openclaw/pull/138780).
+
+**Bug fixes**
+
+- Keep channel reloads and shutdowns scoped to their Gateway [#126547](https://github.com/openclaw/openclaw/pull/126547). Thanks @nianjiuzst, @ylcn91.
+
+- Return retryable webhook responses during channel and plugin replacement [#138627](https://github.com/openclaw/openclaw/pull/138627). Thanks @ylcn91.
+
+- Apply acknowledgement scope on new Slack, Discord, Signal, Matrix, Telegram, and WhatsApp turns without reconnecting; retain captured policy and Slack conflict-retry order [#138638](https://github.com/openclaw/openclaw/pull/138638).
+
+- Reload named IRC account additions and edits without disconnecting siblings, retain original teardown ownership, and recover accepted queued channel messages within existing limits [#138699](https://github.com/openclaw/openclaw/pull/138699).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Apply controls to one message">
+
+Put a supported text directive before a task and OpenClaw keeps the task, including its formatting, while applying the requested controls. [Thinking, verbosity, and authorized tracing](https://docs.openclaw.ai/tools/thinking) can stay with that one message through queueing and model changes, then later messages return to their inherited preferences. A standalone directive still saves a default, and model selection remains persistent. Telegram’s separate handling of multiline commands can still discard later lines before they reach this shared parser.
+
+Native verbose menus in Telegram, Slack, and Discord show the current level and let you choose on, off, or full without changing anything merely by opening the menu. Malformed explicit text commands such as `/exec gateway` now return an argument error instead of becoming an unintended message to the agent. For scripts changing channel accounts, a blank `--account` is rejected before a change begins; omit the option when you intend the command’s normal default selection.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show current verbose settings in Telegram, Slack, and Discord menus, and refresh session listings after saved directive changes [#118822](https://github.com/openclaw/openclaw/pull/118822). Thanks @iamvaleriofantozzi, @lassobjjmadrid, @obviyus.
+
+- Reject empty account selectors before channel changes [#136412](https://github.com/openclaw/openclaw/pull/136412). Thanks @marmar9615-cloud, @obviyus.
+
+- Route QR sign-in to the explicitly selected channel and preserve its session key; existing WhatsApp clients select WhatsApp, while older callers retain first-provider selection [#136313](https://github.com/openclaw/openclaw/pull/136313). Thanks @qinghuanandejiangshi, @obviyus.
+
+- Reject positional execution-command arguments in chat [#137562](https://github.com/openclaw/openclaw/pull/137562). Thanks @jalehman.
+
+- Keep attachment hints from duplicating /status command output [#138193](https://github.com/openclaw/openclaw/pull/138193).
+
+- Keep the task after text /exec and /think directives [#138545](https://github.com/openclaw/openclaw/pull/138545).
+
+- Preserve one-message thinking, verbosity, and authorized tracing through queued execution and model changes; retain saved defaults for later messages [#138695](https://github.com/openclaw/openclaw/pull/138695).
+
+- Drain complete message-command JSON output before exit while preserving success and failure exit status [#137275](https://github.com/openclaw/openclaw/pull/137275). Thanks @chelsealong, @josephbergvinson, @obviyus, @609nft.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Answer a waiting agent question">
+
+When Claude Code needs an answer before continuing, its native question can now reach the channel conversation instead of appearing only in the web dashboard. Replying in plain text to that same conversation can answer the waiting question and resume the run, including in installations with several agents. This repairs the existing question workflow, with Telegram directly demonstrated; messages containing media do not use this early plain-text answer path.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Deliver native Claude questions and answers in channel conversations [#136745](https://github.com/openclaw/openclaw/pull/136745). Thanks @mushuiyu886, @obviyus, @iselbernal.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Follow progress and the final reply">
+
+Progress mode can stay quiet about routine tool calls while keeping the updates that help you follow the task or need your attention. On the supported Discord, Telegram, Slack, Matrix, Mattermost, and Teams personal-chat presentations, configured commentary, reasoning, and approval or failure notices remain available, and `streaming.progress.toolProgress` lets you opt into the tool log. Slack compact progress keeps its own presentation and omits plans.
+
+Narrated progress also catches up with activity that arrived while an update was being written, including urgent failures after a draft was hidden. When work finishes, a delayed typing or reaction start is followed by cleanup once that request settles, preventing it from bringing back an obsolete working indicator.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep channel progress quiet with approvals and failures visible; preserve Canvas widgets through script-policy loading changes and defer Models Settings text until needed [#137342](https://github.com/openclaw/openclaw/pull/137342). Thanks @obviyus.
+
+- Refresh progress narration after buffered tool activity and hidden-draft failures [#137912](https://github.com/openclaw/openclaw/pull/137912).
+
+- Clear typing and reactions after late provider starts [#138891](https://github.com/openclaw/openclaw/pull/138891).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve conversation replies and resets">
+
+A final answer already delivered to the same external conversation can now suppress the extra automatic reply or same-conversation agent announcement, even when another layer rewrites the tool’s visible output. This depends on confirmed final delivery to that destination; a progress update, a dry run, or a message to another conversation does not count as the answer.
+
+Conversation resets also preserve the distinction between a status confirmation and an ordinary answer, and resetting an existing but empty conversation no longer creates the malformed history that could block the next reply. Upgraded conversations with an older pending reset wait for an active reply to finish, while a late Stop during finalization leaves an already accepted answer completed. These fixes prevent the affected new failures; they do not reconstruct previously lost or malformed history.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Match conversation replies without scanning unrelated waiting turns [#127182](https://github.com/openclaw/openclaw/pull/127182).
+
+- Avoid loading retained channel events during cleanup [#138851](https://github.com/openclaw/openclaw/pull/138851).
+
+**Bug fixes**
+
+- Preserve case-distinct Matrix and Signal sessions during cleanup [#122006](https://github.com/openclaw/openclaw/pull/122006). Thanks @raminoodle733, @obviyus, @yunligou711-commits.
+
+- Keep reset confirmations distinct from assistant answers [#124633](https://github.com/openclaw/openclaw/pull/124633). Thanks @ericcaiwx-star, @obviyus.
+
+- Keep empty conversations usable after manual or automatic resets [#125336](https://github.com/openclaw/openclaw/pull/125336). Thanks @kiranvk-2011, @obviyus, @abacha, @danielduerr.
+
+- Defer legacy pending resets until active replies finish [#131569](https://github.com/openclaw/openclaw/pull/131569). Thanks @wangmiao0668000666, @obviyus.
+
+- Preserve completed replies when Stop arrives during finalization [#131949](https://github.com/openclaw/openclaw/pull/131949). Thanks @zhangguiping-xydt, @obviyus, @guanbear.
+
+- Let queued follow-ups proceed after terminal delivery makes no progress for a 30-second idle window, without claiming the stalled send succeeded [#132395](https://github.com/openclaw/openclaw/pull/132395). Thanks @sebtardif, @obviyus.
+
+- Keep customized message routes independent of cached destinations [#136941](https://github.com/openclaw/openclaw/pull/136941).
+
+- Suppress duplicate same-conversation announcements after confirmed message delivery [#137923](https://github.com/openclaw/openclaw/pull/137923).
+
+- Honor confirmed final delivery after tool-output rewrites [#138148](https://github.com/openclaw/openclaw/pull/138148).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep code, links, and speech examples intact">
+
+Code examples need to survive as code, including the spaces and literal characters that make them useful. Shared reply cleanup and Markdown rendering now preserve more of that content through tables, repeated-prose removal, and final message rendering, while one-word Slack or Google Chat link labels remain readable on plain-text delivery paths.
+
+Speech directives written inside Markdown code also remain literal examples in final replies and saved history, rather than being removed and treated as instructions to speak. The separate incremental speech cleaner is outside that repair.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve one-word angle-link labels in plain-text messages [#136306](https://github.com/openclaw/openclaw/pull/136306). Thanks @cestercian, @obviyus.
+
+- Preserve literal reply code and spacing; keep enabled sibling channels loadable, disable their owner only when all are explicitly disabled, and leave unspecified siblings under existing plugin policy [#136756](https://github.com/openclaw/openclaw/pull/136756).
+
+- Preserve inline-code spaces, unfinished-link code, and IPv6 links; keep Matrix code mentions literal and Telegram native code padding correct [#137812](https://github.com/openclaw/openclaw/pull/137812).
+
+- Preserve speech-tag examples inside Markdown code [#138319](https://github.com/openclaw/openclaw/pull/138319).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Send and recover generated media and documents">
+
+When an agent has already generated images or other files, a later tool error or reasoning-only response no longer decides which of those attachments survive. The [media guide](https://docs.openclaw.ai/nodes/images#auto-reply-pipeline) explains how generated files remain available alongside the warning, even when the warning mentions only one of them.
+
+New M4A and audio WebM uploads stay in the audio workflow, staged recordings can use their original URL to recover the file type, and portrait video frames use display orientation when that information is available. Allowed local macro-enabled Excel workbooks can also be sent as attachments, preserving extension capitalization when staging uses the original extension. This handles the workbook as a file; it does not run or certify its macros, and audio transcription still needs its own setup.
+
+Cancelling an attachment-bearing reply now reaches preparation and the outgoing adapters, with Gateway cancellation waiting for abandoned upload cleanup. Cancellation cannot undo a send that has already begun, and the preparation repair does not add a deadline to an unattended transfer that hangs without being cancelled.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Stop attachment preparation and clean abandoned uploads on cancellation [#132552](https://github.com/openclaw/openclaw/pull/132552). Thanks @alix-007, @zhanglei99586.
+
+- Show byte, kilobyte, and fractional-megabyte limits in media rejection and image-omission messages without changing size limits [#136987](https://github.com/openclaw/openclaw/pull/136987).
+
+- Preserve all generated attachments after later tool errors or reasoning-only replies [#137646](https://github.com/openclaw/openclaw/pull/137646).
+
+- Keep uploaded M4A and audio WebM recordings classified as audio [#138035](https://github.com/openclaw/openclaw/pull/138035). Thanks @yangmanbobo.
+
+- Respect display orientation in video frames and photo resize warnings [#138050](https://github.com/openclaw/openclaw/pull/138050).
+
+- Forward cancellation through outgoing message and attachment adapters [#138146](https://github.com/openclaw/openclaw/pull/138146).
+
+- Use source URLs to recognize staged audio and video attachments [#138190](https://github.com/openclaw/openclaw/pull/138190).
+
+- Accept local macro-enabled Excel attachments and preserve extension case [#138978](https://github.com/openclaw/openclaw/pull/138978). Thanks @shannon0430, @obviyus.
+
+**Documentation**
+
+- Document generated attachment preservation after later tool errors [#137827](https://github.com/openclaw/openclaw/pull/137827).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use commands and recover on other channels">
+
+Nextcloud Talk recognizes structured help and status commands, including authorized group commands without a bot mention, and an accepted message can recover through the existing queue after a temporary conversation lookup failure. Mattermost recognizes mention-prefixed commands when text commands are enabled and lets them bypass chat batching; later reactions, button clicks, and username checks can also retry a failed lookup instead of inheriting a cached outage. The already failed Mattermost event is not replayed automatically.
+
+Tlon summary requests refresh their history after an account restarts, and long IRC replies retain literal code and link destinations across messages. WhatsApp now delivers the final failure explanation instead of discarding it with intermediate error noise. For a confirmed iMessage helper stall, OpenClaw attempts bounded recovery for later actions, which can relaunch Messages.app and delay the original error by up to 30 seconds; the failed action is still reported and is never automatically resent.
+
+Direct Matrix encryption setup and encrypted account addition finish their client setup before publishing the enabled settings to a running Gateway. Concurrent account changes prompt a review and rerun instead of being overwritten, although verification can still fail and the encryption choice may still be saved. This change covers those direct commands, with the interactive wizard and separately running encryption processes outside its scope.
+
+<details class="release-source-toggle">
+
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Accept mixed-case HTTPS prefixes in Feishu custom addresses [#113611](https://github.com/openclaw/openclaw/pull/113611). Thanks @sebtardif, @obviyus, @vectorpeak.
+
+- Refresh Tlon summary history after account restarts [#114580](https://github.com/openclaw/openclaw/pull/114580). Thanks @sunlit-deng, @obviyus.
+
+- Retry temporary Nextcloud Talk conversation lookup failures [#114625](https://github.com/openclaw/openclaw/pull/114625). Thanks @sunlit-deng, @obviyus.
+
+- Recognize structured Nextcloud Talk help and status commands [#134817](https://github.com/openclaw/openclaw/pull/134817). Thanks @lordratner.
+
+- Point Twitch missing-token errors to the correct account setting [#136838](https://github.com/openclaw/openclaw/pull/136838). Thanks @ly85206559, @obviyus.
+
+- Show final turn failures in WhatsApp chats and groups [#136864](https://github.com/openclaw/openclaw/pull/136864). Thanks @vyctorbrzezowski, @nianjiuzst, @osolmaz, @dougbutdorf.
+
+- Attempt automatic recovery after confirmed iMessage bridge stalls [#137029](https://github.com/openclaw/openclaw/pull/137029). Thanks @omarshahine.
+
+- Keep unknown Teams reaction names as readable strings in notifications and outgoing requests without expanding Graph’s accepted reaction types [#137681](https://github.com/openclaw/openclaw/pull/137681). Thanks @teddytennant, @altaywtf.
+
+- Explain missing-mention skips in normal logs for iMessage, WhatsApp, Signal, LINE, Mattermost, Zalo user, and Buzz, with effective per-group configuration guidance [#137829](https://github.com/openclaw/openclaw/pull/137829).
+
+- Run mention-prefixed Mattermost commands before chat batching [#137902](https://github.com/openclaw/openclaw/pull/137902). Thanks @goffern, @vincentkoc.
+
+- Retry failed Mattermost channel and user lookups on subsequent events [#137968](https://github.com/openclaw/openclaw/pull/137968). Thanks @goffern, @vincentkoc.
+
+- Save Matrix encryption settings after direct setup finishes [#138254](https://github.com/openclaw/openclaw/pull/138254).
+
+- Keep code and links intact in split IRC replies [#138328](https://github.com/openclaw/openclaw/pull/138328).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Memory
+
+Memory needs to stay useful as conversations grow, daily notes become longer-term knowledge, and you change the way your Claw stores and searches them. This release repairs several places where that continuity could break, from daily memories missing later evidence to recalled context disappearing when a session rotated, while reducing repeated search and indexing work and giving you a clearer view of what is taking up disk space.
+
+<AccordionGroup>
+
+<Accordion title="Carry useful memory through dreaming and rotation">
+
+Memories first recorded by the daily [Dreaming](/concepts/dreaming) pass can now collect evidence from later recalls and grounded observations, so they can qualify for long-term storage under the existing promotion rules. The original source stays attached, and reinforcement from combined memory and Wiki searches now counts only the memory results actually shown to the model. During consolidation, the model chooses what to add, merge, or supersede, while OpenClaw builds the saved entries from their source evidence and preserves unrelated memories.
+
+[Active Memory](/concepts/active-memory) also keeps eligible recalled context and unavailable-memory warnings through session rotation. A completed, grounded recall can still reach the reply when its cleanup crosses the deadline, without turning on transcript exports; failed recalls, failed cleanup, and unavailable results remain excluded from that recovery. Dreaming and Skill Workshop now share visible background capacity in System busyness, with foreground work keeping its own capacity.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Share background capacity across Dreaming and skill reviews, and let plugins request tool-free completions without temporary conversations. The completion API requires a supporting host; Workshop remains limited to one run at a time. [#136938](https://github.com/openclaw/openclaw/pull/136938)
+
+**Bug fixes**
+
+- Let daily-first memories accumulate evidence for promotion while retaining their original citation and existing thresholds. [#136965](https://github.com/openclaw/openclaw/pull/136965) Fixes [#136963](https://github.com/openclaw/openclaw/issues/136963). Thanks @cleebailey75, @obviyus, @kaxo-io.
+- Retain eligible timeout recall, reinforce only visible search results, and reject NaN or infinity in Base64 LanceDB embeddings. Recovered timeout summaries are not cached or saved in session debug lines. [#137894](https://github.com/openclaw/openclaw/pull/137894)
+- Preserve rotated recall and saved audit timestamps while composing Dreaming entries from source evidence. [#137967](https://github.com/openclaw/openclaw/pull/137967)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Prepare and refresh memory with less repeated work">
+
+[Memory searches](/concepts/memory-search) that return only notes, or no results at all, now skip processing unrelated conversation history. First searches also avoid decoding unrelated saved prompts and reopening an already verified agent database, while indexing large memory files prepares their source text once instead of repeating the same work for each piece. These changes address specific sources of delay as your saved history grows, with the selected search corpus, annotations, and transcript access checks preserved.
+
+Preparing memory tools no longer starts the embedding provider before a search is requested, and changing settings after a failed search lets the tool retry with the new configuration immediately. Targeted refreshes read fewer unrelated session records, while an exact lookup for a missing message in an imported CLI conversation now returns empty history instead of substituting recent messages that do not answer the request.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse source preparation while indexing large memory files, preserving their annotations. [#137784](https://github.com/openclaw/openclaw/pull/137784)
+- Read fewer unrelated sessions during targeted memory refresh, stream cached embedding rows, and avoid repeated diagnostic queries. [#138766](https://github.com/openclaw/openclaw/pull/138766)
+
+**Bug fixes**
+
+- Skip session-history processing for searches without transcript results. [#137774](https://github.com/openclaw/openclaw/pull/137774)
+- Validate session keys without decoding saved conversation entries. [#138051](https://github.com/openclaw/openclaw/pull/138051)
+- Defer embedding setup until search execution and discard stale failure cooldowns when settings change; unchanged failing settings retain the one-minute cooldown. [#138136](https://github.com/openclaw/openclaw/pull/138136) Fixes [#138114](https://github.com/openclaw/openclaw/issues/138114).
+- Reuse verified agent database connections during startup and cold memory search. [#138166](https://github.com/openclaw/openclaw/pull/138166) Fixes [#121985](https://github.com/openclaw/openclaw/issues/121985) and completes the diagnosed cold-search repairs for [#137750](https://github.com/openclaw/openclaw/issues/137750). Thanks @grynn, @wg-mojo.
+- Return empty history for unavailable imported-conversation messages; imported snapshots can still be limited by their byte budget. [#136720](https://github.com/openclaw/openclaw/pull/136720) Fixes [#136671](https://github.com/openclaw/openclaw/issues/136671).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use the selected memory plugin">
+
+If you use an alternative memory plugin and keep Memory Core enabled for Dreaming, indexing now stays with the plugin you selected. Memory Core can continue contributing Dreaming support without starting unwanted embedding work or lending its private-conversation recall permission to the other plugin. This prevents that unselected component from starting new work; embedding batches already submitted to a provider still need separate handling.
+
+Affected plugins that keep their memory managers immutable can now report status, search, read, and finish cleanup normally, so the Memory page can show the actual provider instead of a misleading attention warning. Dreaming schedules also follow frequency changes, disabling, and re-enabling after a plugin reload, without requiring a full restart.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Keep indexing and private recall with the selected memory plugin while retaining supported Dreaming contributions. [#131779](https://github.com/openclaw/openclaw/pull/131779) Fixes [#131743](https://github.com/openclaw/openclaw/issues/131743). Thanks @ruel225, @obviyus, @hartmark.
+
+**Bug fixes**
+
+- Reconcile Dreaming schedules after plugin reload, with service-context scheduler access that expires when the service stops or its scheduler is replaced. [#134818](https://github.com/openclaw/openclaw/pull/134818) Fixes [#134816](https://github.com/openclaw/openclaw/issues/134816). Thanks @w9n, @obviyus.
+- Keep immutable memory-plugin managers usable for status, search, reads, and cleanup. [#138402](https://github.com/openclaw/openclaw/pull/138402) Fixes [#138370](https://github.com/openclaw/openclaw/issues/138370). Thanks @rileyjjy, @obviyus, @cyb3rb1ade, @liuwqgit.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read and validate Memory Wiki pages">
+
+Once your [Memory Wiki](/cli/wiki) vault is active, opening an existing visible page by its exact Markdown path reads that page without scanning unrelated pages, so a broken file elsewhere no longer has to block the page you asked for. Local source sync can also reuse an existing compiled Wiki after startup. Fresh CLI processes still validate the saved snapshot, and lookups by a short name, page ID, or missing path can still need a vault scan.
+
+Saving a Wiki claim now rejects confidence values outside the supported 0–1 range before changing the page, preventing those new values from distorting later search results. Existing pages remain readable, including older invalid values that this change does not repair.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reject out-of-range confidence when saving Wiki claims, preserving the page on validation failure. [#125656](https://github.com/openclaw/openclaw/pull/125656) Thanks @wanyongstar, @obviyus.
+- Read exact Wiki pages without repeating whole-vault work and reuse existing compiled content during local sync. [#129897](https://github.com/openclaw/openclaw/pull/129897) Fixes [#116048](https://github.com/openclaw/openclaw/issues/116048). Thanks @bsniznd, @sloptop-the-terrible.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Inspect and preserve saved memory">
+
+When a memory database grows, explicit memory status checks now show its file size, transaction log, reusable space, and retained embedding cache, including cache entries left after caching was disabled. Those measurements overlap, so they should not be added together as separate pieces of disk usage. The [disk-space recovery guide](/concepts/memory-builtin#reclaim-disk-space) explains how to use the existing offline compaction command with a verified backup and stopped writers, preserving sessions and allowing you to skip an index reset when you only need to reclaim unused pages.
+
+Forgetting a session also protects unrelated saved memory when a staged file rewrite fails, allowing you to fix the storage problem and retry. Doctor imports large legacy memory logs in batches and recognizes configured secret-store credentials without telling you to replace working keys, while file-watcher warnings now point to supported recovery steps for the affected agent.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Protect retained memory files when a staged rewrite during session forgetting fails. Protection is per file; a failed multi-file purge can still need a retry, and the restrictive-directory fallback restores data only on caught failures. [#131383](https://github.com/openclaw/openclaw/pull/131383) Thanks @zenglingbiao, @obviyus.
+- Batch large legacy memory-log imports in Doctor while preserving retention and restartable recovery. A fatal commit failure can roll back the current batch; earlier committed batches and the legacy source remain. [#136968](https://github.com/openclaw/openclaw/pull/136968) Thanks @vincentkoc.
+- Replace obsolete watcher advice with supported root-reduction and agent-specific reindexing steps. Global and agent extra paths combine, and changing file patterns alone does not reduce watched roots. [#137181](https://github.com/openclaw/openclaw/pull/137181) Fixes [#137156](https://github.com/openclaw/openclaw/issues/137156).
+- Recognize secret-store memory provider keys in Doctor. This checks configuration presence; unresolved references remain separately reported and successful provider authentication is not implied. [#137782](https://github.com/openclaw/openclaw/pull/137782) Fixes [#137742](https://github.com/openclaw/openclaw/issues/137742). Thanks @teddytennant, @obviyus, @rayseling.
+- Expose memory storage usage and explain safe offline disk reclamation using existing maintenance commands, without automatic shrinking or a change to retention. [#137876](https://github.com/openclaw/openclaw/pull/137876) Thanks @alexisballo2, @ralf003, @nexxarion.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep removed tool context available to compaction">
+
+When OpenClaw shortens a long conversation, tool results discarded while repairing mismatched calls and replies now remain available to the summarizer. The removed-message count and token estimate include them too, closing a specific gap where useful tool output could disappear from both the summary input and its accounting. Ordering after repeated pruning still has a known limitation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Include tool results discarded during pairing repair in compaction summary input and removed-history counts. [#134987](https://github.com/openclaw/openclaw/pull/134987) Thanks @qingminglong, @dengshanzhi, @obviyus.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Skills
+
+Skills get practical repairs from creation through installation and remote use. Workshop explains more failed reviews and protects current edits during uncertain restores, while paired and remote workers use the instructions and supporting files prepared for their own turn. Bundled guidance also gives agents a clearer path through dashboard building and delegated work without changing the permissions those tasks require.
+
+<AccordionGroup>
+
+<Accordion title="Validate and recover Workshop changes">
+
+[Skill Workshop](/tools/skill-workshop) now identifies conflicting support-file locations before saving a proposal, and refuses proposals or evaluations that would silently omit unreadable or excessively nested content. When agents sharing a workspace cannot start a collection review because a provider credential is missing, the error names the affected provider and agent so the operator can fix authentication without guessing at model settings.
+
+Restoring an older collection backup also protects later edits and deliberate deletions when the relevant files cannot be verified. Some older backups need [manual recovery](/tools/skill-workshop#when-an-older-backup-cannot-be-restored-automatically); keep complete private copies of both the backup and current files while choosing what to restore, and do not change saved hashes or flatten live files to force an automatic restore.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Identify overlapping Workshop support-file paths before a proposal is saved ([#136375](https://github.com/openclaw/openclaw/pull/136375)). Thanks @teddytennant, @obviyus.
+- Reject incomplete skill-directory reads and protect current edits and deletions when an older collection backup cannot be verified ([#138082](https://github.com/openclaw/openclaw/pull/138082)).
+- Explain missing provider credentials in shared-workspace collection reviews while preserving the matching-identity requirement ([#138318](https://github.com/openclaw/openclaw/pull/138318), [issue #138257](https://github.com/openclaw/openclaw/issues/138257)). Thanks @chelsealong, @obviyus, @markmilian.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use skills on paired and remote workers">
+
+Skills running on [paired and remote workers](/gateway/cloud-workers) now refer to the instructions, scripts, and resources copied to that worker, including when a skill is selected explicitly. An active turn keeps its prepared instructions, and later edits on the Gateway apply to later turns. Connected nodes also publish a skill's name, description, and instructions from the same file read, avoiding a mismatch when that file changes during discovery.
+
+If an optional discovered skill folder disappears, a worker conversation can continue with the resources that remain available. Explicitly selected or pinned skills, unreadable nested resources, and integrity failures still stop the affected turn. Copied skill files remain temporary inputs, so background commands must not depend on them surviving after the turn ends.
+
+A failure to delete disposable skill files no longer changes a successful worker result into a failure or hides the original cancellation or timeout. [Cleanup warnings](/cli/worker#runtime-boundary) identify files that may remain; wait for the worker or session and its processes to stop before removing them manually. Credential cleanup remains separate and strict. Cloud startup also reports whether a download failed during connection, TLS, the HTTP response, or body transfer, helping operators investigate the relevant part of setup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve a worker's result or original error when temporary skill-file deletion is denied, with separate credential cleanup and actionable warnings ([#136958](https://github.com/openclaw/openclaw/pull/136958), [issue #136957](https://github.com/openclaw/openclaw/issues/136957)).
+- Skip vanished optional discovered skill roots without advertising missing resources or aborting a valid worker follow-up ([#136974](https://github.com/openclaw/openclaw/pull/136974), [issue #136783](https://github.com/openclaw/openclaw/issues/136783)). Thanks @jalehman.
+- Transfer accompanying skill files to paired-node Codex runs without blocking the first reply ([#137358](https://github.com/openclaw/openclaw/pull/137358)).
+- Use the transferred skill copy consistently for remote instructions, explicit references, and supporting scripts ([#138091](https://github.com/openclaw/openclaw/pull/138091)).
+- Share program-availability checks across overlapping remote-node reconnect refreshes while rejecting retired-connection results ([#138116](https://github.com/openclaw/openclaw/pull/138116)).
+- Keep node skill descriptions and instructions from the same captured file, with clearer diagnostics for invalid selected skills ([#138719](https://github.com/openclaw/openclaw/pull/138719)).
+- Stop repeated file-stability checks when a skill watcher is disabled, replaced, or shut down ([#137616](https://github.com/openclaw/openclaw/pull/137616)).
+- Keep cloud skill inputs private and out of ordinary Git staging and synchronization, drain owned startup authentication and update preparation on timeout or shutdown, and report download phases. Provider plugins gain the optional cancellable `prepareSyntheticAuth` hook ([#137071](https://github.com/openclaw/openclaw/pull/137071)). Thanks @fuller-stack-dev.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Install and track skill packages">
+
+The [Skills interface](/tools/skills#installer-specs) now selects the installation recipe advertised for your operating system when a skill leaves recipe IDs implicit. That corrects cases where the button showed one platform's dependency but selected another platform's recipe.
+
+ClawHub installation also stops with repair or restore guidance when its shared tracking file is damaged, preserving the file and existing skills instead of replacing their update and integrity records. Normal installation and updates can resume after valid tracking is restored. Large archive uploads and library browsing also avoid unnecessary copies of archive content or skill payloads, while keeping their existing results, selected revisions, and permissions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Avoid redundant temporary archive copies during skill upload retries, commits, and installation ([#138854](https://github.com/openclaw/openclaw/pull/138854)).
+- Read only needed skill metadata when browsing the library or preparing default skills for a new session ([#138973](https://github.com/openclaw/openclaw/pull/138973)).
+
+**Bug fixes**
+
+- Select the advertised platform recipe from skill dependency buttons, including shared macOS setup consumers ([#138063](https://github.com/openclaw/openclaw/pull/138063), [issue #138062](https://github.com/openclaw/openclaw/issues/138062)).
+- Preserve installed skills and their tracking when the ClawHub lock file is malformed or unreadable ([#138884](https://github.com/openclaw/openclaw/pull/138884), [issue #127986](https://github.com/openclaw/openclaw/issues/127986)). Thanks @obviyus, @yetval.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Guide dashboard building and delegated follow-through">
+
+A bundled Control UI skill now guides agents through building a dashboard in the intended conversation, preserving existing widgets, and checking what actually renders. Follow-up guidance explains supported ways to load external data and troubleshoot blank remote widgets without changing the widget sandbox or automatically configuring hosting.
+
+Updated [delegation guidance](/tools/subagents) carries the requested outcome through child completion messages, so agents are instructed to continue authorized work after an intermediate review or check and verify the final result. For a request to land a pull request, that includes checking that GitHub reports it as merged. The instructions still allow a specific blocker when the remaining work needs new authority, credentials, or an external decision.
+
+Skill authors also get clearer [ClawHub publishing guidance](/tools/creating-skills#publishing-to-clawhub), including which personal and organization roles can publish and where the canonical commands live. [Code Mode guidance](/tools/code-mode) corrects an outdated restriction on completing pending tool calls; these instruction changes do not introduce new runtime permissions or a new publication capability.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Bundle a Control UI skill for session dashboards, remote-widget troubleshooting, and rendered checks ([#137166](https://github.com/openclaw/openclaw/pull/137166), [issue #137164](https://github.com/openclaw/openclaw/issues/137164)). Thanks @fuller-stack-dev.
+- Guide dashboard builders on conversation placement, sandbox limits, proxy protocols, and visual verification ([#137785](https://github.com/openclaw/openclaw/pull/137785)). Thanks @fuller-stack-dev.
+- Clarify ClawHub publishing roles and direct authors to the canonical command references ([#138157](https://github.com/openclaw/openclaw/pull/138157)).
+- Correct the pending-call completion guidance for restart-safe Code Mode paths without changing runtime behavior ([#138501](https://github.com/openclaw/openclaw/pull/138501)).
+
+**Bug fixes**
+
+- Carry requested-outcome verification through direct and queued delegated completions and bundled task guidance ([#137851](https://github.com/openclaw/openclaw/pull/137851)). Thanks @fuller-stack-dev.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Native Apps
+
+Experimental Talk on Watch lets you start a voice conversation directly from your wrist, with the iPhone used for setup rather than relaying the call. The companion messaging path gets its own recovery screen, while iPhone and Android conversations become easier to read, copy, and follow through longer tasks. On Mac, personal browser sign-in brings your own account into shared Gateways, and clearer approval panels make it easier to see what you are allowing. Linux companion work addresses specific AppImage startup failures.
+
+<AccordionGroup>
+
+<Accordion title="Talk directly from Apple Watch">
+
+[Talk on Watch](https://docs.openclaw.ai/platforms/ios#standalone-voice) is a new experimental way to speak with your Claw without the paired iPhone carrying the audio or relaying each message. Enable Standalone Voice under iPhone Settings → Apple Watch, then open Talk on Watch and tap Start. You can choose an agent, read the recent transcript, mute the microphone, and end the call from the Watch; simply opening the screen does not start recording, and each call has its own conversation.
+
+Setup requires an administrator connection on the iPhone, a trusted secure Gateway address the Watch can reach independently, and a compatible realtime provider using ICE-lite and UDP. The Watch receives its own limited read and Talk credentials, while permanent provider credentials stay on the Gateway. There is no TURN relay or TCP/WebSocket audio fallback, so a network that blocks the required UDP connection cannot use this path. [Talk configuration](https://docs.openclaw.ai/nodes/talk) explains the supported combinations.
+
+Keep OpenClaw on screen until the call connects. Network recovery is bounded, and an OpenAI call needs a fresh start when its 30-minute lease expires. Physical Watch microphone and speaker behavior, wrist-down operation, radio handoff, and long-call endurance still need device validation, so treat this as an experimental capability.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Start standalone realtime voice conversations from Apple Watch [#135808](https://github.com/openclaw/openclaw/pull/135808). Thanks @obviyus.
+
+**Limits and compatibility**
+
+The source records native/provider probes and simulator coverage, not a physical Watch audio or endurance acceptance run.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover Watch companion messages">
+
+The existing iPhone-relayed Watch chat now saves pending messages and completed replies on both devices, allowing a restart or reconnect to recover work without automatically repeating a send whose outcome is uncertain. Queued messages retain their original conversation even if you switch chats on the phone, and a saved reply can still be read after the spoken-reply wait has ended.
+
+Update both apps, then use [iPhone Settings → Apple Watch → Message Delivery](https://docs.openclaw.ai/platforms/ios) to inspect replies or a Delivery uncertain warning. Check the original conversation before resending uncertain work. Older unsent messages that lack enough delivery information appear as Needs review, and the original 48-hour deadline still applies to new deliveries and their saved replies.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover Watch companion messages and review delivery status on iPhone [#137463](https://github.com/openclaw/openclaw/pull/137463).
+
+**Limits and compatibility**
+
+Recovery covers app termination and reconnects. It does not establish exactly-once execution, power-loss durability, or physical paired-device background endurance.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use native realtime Talk and answer controls">
+
+Compatible audio-only clients can now use native GPT-Live with their configured ChatGPT OAuth or Platform credentials while the Gateway handles tools and tasks for the call. The client must explicitly support the Gateway-controlled mode; OpenAI GA Realtime still requires a Platform key for this mode. Status requests, cancellation, redirects, and follow-ups stay with the work started by that call, and saved conversation history is kept separate from what was actually said in the new call.
+
+When an answer to a pending question loses its confirmation, OpenClaw reports the uncertainty instead of sending the answer again as another instruction. Check the conversation before retrying. Questions from standalone attached MCP sessions need the Control UI or native question controls, and protected Copilot steering remains unavailable. [Talk mode](https://docs.openclaw.ai/nodes/talk) covers these client and authentication boundaries, along with the separate handling of call audio and accepted tasks.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Enable native realtime Talk and call-scoped question answers, retain direct task answers in Chat after audio disconnects, correct maintenance-worker readiness, and wait for session-delivery shutdown [#134003](https://github.com/openclaw/openclaw/pull/134003). Thanks @as76, @edenfunf, @obviyus.
+
+**Bug fixes**
+
+- Update Talk mode independently of speech-provider startup [#138045](https://github.com/openclaw/openclaw/pull/138045).
+- Keep Talk task diagnostics tied to the replacement connection [#138169](https://github.com/openclaw/openclaw/pull/138169).
+
+**Limits and compatibility**
+
+Negotiated clients share a two-session limit per connection. Provider task acceptance is not proof of audible delivery or deployment to a physical audio device. Optional connection diagnostics do not change authorization.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Interrupt Android Talk and follow its state">
+
+On eligible Android audio setups, Talk can keep listening while it speaks, so an interruption stops queued speech even after the provider has finished generating the reply. This requires active native echo cancellation and Android communication audio; other setups keep taking turns between listening and playback. Thinking, Listening, and Speaking now follow the current response and playback more closely, and new successful spoken answers appear once in Chat while errors and interrupted partial replies stay visible.
+
+The native speech loop also sends recognized phrases and resumes listening after the answer, keeps capture running when reply audio is muted, and respects Stop or a switch to push-to-talk. Around that conversation, Disconnect stays disconnected, failed settings loads are shown as errors rather than empty data, and unresolved sends remain visible for recovery. [Android guidance](https://docs.openclaw.ai/platforms/android) explains the native Talk path, while [Talk mode](https://docs.openclaw.ai/nodes/talk) covers the audio requirements.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Improve Android Talk interruption and status, and preserve macOS approval deadlines [#135934](https://github.com/openclaw/openclaw/pull/135934). Thanks @masatohoshino.
+- Send native Android Talk phrases, inherit session thinking, and refresh Talk settings on next use; preserve Disconnect, failed-settings-load errors, and unresolved sends [#136934](https://github.com/openclaw/openclaw/pull/136934).
+
+**Limits and compatibility**
+
+Final physical-device echo cancellation, Bluetooth/wired acoustics, and external-provider speech were not established by the retained validation. Playback completion is approximate on routes without usable timestamps; existing duplicate chat history is not migrated. The macOS approval-deadline repair is a separate supporting outcome in the same source.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read and copy iPhone conversations">
+
+iPhone conversations keep the current reply and working indicator visible as the assistant moves through tool calls, with streaming tables growing without repeatedly shifting earlier text. Opening the keyboard preserves the latest messages when you were already following them, while a deliberate scroll or selected search result keeps your chosen position. Scrolling near the left edge also takes a more clearly horizontal gesture before it opens the sidebar.
+
+When you want to reuse part of a reply, [Select Text](https://docs.openclaw.ai/platforms/ios) opens an iOS selection sheet so you can copy a passage without taking the whole message. Code blocks gain a raw-code copy button on both iOS and Mac, tall Mermaid previews keep their first and last nodes reachable, and native Swarm progress responds to settings changes without reconnecting or bringing back an older enabled state.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Copy selected iOS message text and native chat code blocks [#136729](https://github.com/openclaw/openclaw/pull/136729). Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Keep the latest iPhone messages visible through keyboard transitions [#136660](https://github.com/openclaw/openclaw/pull/136660). Thanks @solvely-colin, @jeffsteinbok, @nikolaihack.
+- Stabilize iPhone streamed replies, tables, and chat scrolling [#136702](https://github.com/openclaw/openclaw/pull/136702). Thanks @virpoe, @nikolaihack.
+- Keep tall Mermaid previews fully reachable in iOS and Mac chat [#137704](https://github.com/openclaw/openclaw/pull/137704).
+- Refresh native Swarm progress when settings change and ignore older replies [#138064](https://github.com/openclaw/openclaw/pull/138064).
+
+**Limits and compatibility**
+
+The iPhone transcript repairs do not establish complete resolution of physical-device lag or every blanking report. Shared Apple changes include Mac code copying and Mermaid scrolling; the Select Text sheet is iOS-only.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use Android progress and dashboards">
+
+Android task progress now sits in its own attached panel above the message composer, expanding upward while the editor and its controls stay in place. Progress cards show labeled bars alongside their text and links, and the Effort and Permissions sheets keep their choices reachable on smaller screens. Policy default and Default model have distinct labels, so checking permissions is less easily confused with resetting a model choice.
+
+Jump to latest lives in the chat header and appears only when newer content is hidden, leaving more room beneath the messages. Opening Dashboard from a conversation now selects that conversation's board and gives the embedded page a full-size viewport, so it can be read and used after it loads.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show Android Jump to latest only when content is hidden [#136742](https://github.com/openclaw/openclaw/pull/136742).
+- Anchor Android task progress during expansion, completed by the separate-panel layout below [#136964](https://github.com/openclaw/openclaw/pull/136964).
+- Make Android effort, permission navigation and task progress easier to read [#137442](https://github.com/openclaw/openclaw/pull/137442). Thanks @iwhatsskill.
+- Dock Android task progress above the message composer [#137568](https://github.com/openclaw/openclaw/pull/137568). Thanks @iwhatsskill.
+- Open the correct Android conversation dashboard at full size [#137691](https://github.com/openclaw/openclaw/pull/137691).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep mobile Gateway connections current">
+
+Android Stop, Forget, and reconnect now finish against the connection you selected, preventing pending secondary connections or old credential writes from reviving a connection you retired. Changing focus also preserves a handshake that is already underway. Disconnect shows Offline while retaining pairing; forgetting a Gateway removes its local saved connection, but does not revoke pairing on the remote Gateway.
+
+In the active iOS app, other enabled Gateways can stay connected while you use the focused one, including through temporary discovery gaps. With Background App Refresh enabled, the iPhone can also request opportunities to update its last-seen status and attempt a reconnect without a push relay. [iOS controls that background schedule](https://docs.openclaw.ai/platforms/ios), and may suspend connections when the app is no longer active.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Enable iPhone background-refresh requests for presence and reconnects [#136722](https://github.com/openclaw/openclaw/pull/136722).
+- Order Android disconnect, credential cleanup and reconnect operations [#137389](https://github.com/openclaw/openclaw/pull/137389).
+- Preserve Android connection handshakes while changing Gateway focus [#137519](https://github.com/openclaw/openclaw/pull/137519).
+- Keep secondary iOS Gateway connections alive [#138286](https://github.com/openclaw/openclaw/pull/138286).
+
+</details>
+
+</Accordion>
+
+<Accordion title="See phone resource readings">
+
+The Devices page can show memory readings from connected iPhones and iPads, plus memory and available storage from Android phones, when the Gateway supports device resource reporting. The apps send a reading on connection and refresh it while connected, giving you a way to check phone resources from the same place as your other devices.
+
+These phone readings include processor count rather than CPU load. iOS omits disk usage, Android storage appears only when it can be sampled, and suspension or a lost connection can pause fresh readings.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add iPhone and iPad memory reporting to Devices [#137082](https://github.com/openclaw/openclaw/pull/137082).
+- Show Android memory and available storage readings in Devices [#137083](https://github.com/openclaw/openclaw/pull/137083).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Connect the Mac app to the right Gateway">
+
+The Mac app keeps remote address text in place while you finish typing, and connection failures retain the explanation needed to act on them. An incompatible protocol tells you whether to update the computer running OpenClaw or the Mac app, while conflicting saved device identities show their file paths and IDs. Those conflicts still need deliberate repair; changing a Gateway token is suggested only for a token problem.
+
+When you use several Gateways, chat commands, widgets, approvals, settings, and status stay with the window or connection that owns them. Primary dashboards follow a changed Primary, independent saved-profile windows keep their own connection, and older replies cannot replace the selected Gateway's current settings. Switching Primary clears the old configuration draft, while reconnecting to the same Gateway preserves valid edits. A save already sent can still reach the previous Gateway, so changing selection does not undo an in-flight change.
+
+The Tailscale Dashboard link opens the root or configured custom path, heartbeat details follow the active Gateway, and a remembered Usage page stays open during dashboard startup. The [Mac remote connection guide](https://docs.openclaw.ai/platforms/mac/remote) covers the connection choices and troubleshooting path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Explain Mac and Gateway protocol mismatches with update guidance [#136432](https://github.com/openclaw/openclaw/pull/136432). Thanks @outkasttttt.
+- Open the correct dashboard path from Mac Tailscale settings [#136669](https://github.com/openclaw/openclaw/pull/136669). Thanks @theangrypit, @obviyus.
+- Preserve partial Gateway URLs during macOS setup and settings edits [#136983](https://github.com/openclaw/openclaw/pull/136983). Thanks @hannesrudolph.
+- Keep Mac windows and approvals on the correct Gateway, refresh Primary Voice Wake words, and recover interrupted SSH forwarding [#137089](https://github.com/openclaw/openclaw/pull/137089).
+- Keep Mac settings and actions on their Gateway, preserve edits until explicit Config Reload, retain confirmed ClawHub install outcomes, and remove URL user names, passwords, and fragments from diagnostics [#137502](https://github.com/openclaw/openclaw/pull/137502).
+- Show heartbeat status for the active macOS Gateway [#138310](https://github.com/openclaw/openclaw/pull/138310).
+- Identify conflicting Mac device identities and preserve connection errors [#138360](https://github.com/openclaw/openclaw/pull/138360). Thanks @maxsxu, @vincentkoc, @hannesrudolph.
+- Preserve native connection errors through cleanup [#138475](https://github.com/openclaw/openclaw/pull/138475).
+- Preserve restored Usage navigation during native dashboard startup [#137402](https://github.com/openclaw/openclaw/pull/137402).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Sign in to a personal Gateway from your browser">
+
+If your Gateway uses Cloudflare Access, you can enter its address in the Mac app and [sign in through your usual browser](https://docs.openclaw.ai/platforms/mac/remote#connect-with-your-browser), then return to its dashboard under your own account without copying a shared token. The website's Get the apps → Open in Mac app action opens the same connection editor with the address filled in, and the app remembers the selected Gateway after restart.
+
+Renewing the same account preserves its browser preferences, chat history, and queued messages. Signing in as someone else closes the previous account's native chat windows and uses separate history and queues, leaving earlier pending messages with their original account. Removing the saved Gateway clears its credentials and dashboard browser data.
+
+This browser handoff currently supports Cloudflare Access, and native device approval remains a separate step unless the Gateway's existing automatic approval policy allows it. Personal saved Gateways also stay separate from the machine Primary that supplies Mac capabilities and Talk. Eligible Team dashboards can use personal identity for attribution, while shared-token and password connections keep their existing owner flow.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Connect personal Mac Gateways through Cloudflare browser sign-in and website handoff [#138745](https://github.com/openclaw/openclaw/pull/138745).
+
+**Bug fixes**
+
+- Open Team dashboards with personal sign-in in the Mac app [#137933](https://github.com/openclaw/openclaw/pull/137933).
+
+**Limits and compatibility**
+
+Personal Team-dashboard identity routing also supports its documented eligible trusted-proxy and managed Tailscale routes; the browser-to-app saved-session handoff is Cloudflare Access-only. Native machine connections retain their separate identity.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Inspect command and pairing approvals">
+
+Mac command approvals now put the command and working directory in a resizable panel, with wrapping, scrolling, selectable paths, and Copy for the exact displayed command. Details keeps executable information available without crowding the decision, and remote requests no longer say they will run on the Mac merely because that is where the prompt appeared.
+
+Pairing requests identify the device and its requested access, show administrator warnings, and distinguish a capability update from replacing a device token. You can inspect full IDs and versions in Details or use Copy ID. Command-Return approves the displayed request once, while Return alone does not; Not Now or Escape on pairing requests leaves them pending. Always Allow Here remains available only when the command policy permits it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Inspect and copy commands in a resizable Mac approval panel [#138049](https://github.com/openclaw/openclaw/pull/138049).
+- Clarify Mac pairing access, administrator warnings, and device details [#138137](https://github.com/openclaw/openclaw/pull/138137).
+
+**Limits and compatibility**
+
+The command-panel redesign does not add the separately planned authoritative Gateway scope and warning display. Pairing administrator warnings are included in the pairing change.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use supported Mac controls in Dashboard Settings">
+
+[Dashboard Settings](https://docs.openclaw.ai/web/control-ui) gains a This Mac group for app behavior, device capabilities, permissions, and local Talk and update controls when a supporting Mac app exposes the native bridge. These controls remain owned by the Mac and appear only where that bridge supports them. Voice Wake trigger words belong to the connected Gateway, so their editor also works in an ordinary browser when the Gateway advertises the required methods.
+
+Mac AI setup now shows confirmed connection-test rejection reasons and lets you explicitly retry or choose another connection without an old response wiping newer input. Uncertain outcomes keep their verification step, and older Gateways may still require the existing wait. Other daily controls receive focused repairs too, with scheduled-job lists retaining recent edits and deletions, and the browser sidebar resizing and remembering its width even with only one or two tabs.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add This Mac settings and browser Voice Wake trigger-word editing [#137971](https://github.com/openclaw/openclaw/pull/137971).
+
+**Bug fixes**
+
+- Recover rejected Mac AI setup without overwriting new input or automatically repeating uncertain activation [#138814](https://github.com/openclaw/openclaw/pull/138814).
+- Keep Mac scheduled-job lists current after edits and deletions [#138209](https://github.com/openclaw/openclaw/pull/138209).
+- Restore browser-sidebar resizing with few open tabs [#137992](https://github.com/openclaw/openclaw/pull/137992).
+
+**Limits and compatibility**
+
+The Dashboard UI change does not itself supply the companion Swift bridge or establish retirement of native Settings. Check again during uncertain AI setup observes the attempt; prepared plugins may already persist.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reduce idle Mac background work">
+
+The Mac app stops checking Tailscale while Connection settings are hidden, retires timers when requests finish, and stops presence sampling after opting out once the required clear succeeds. Its node worker also stays under the app's process control, so restarting or stopping that worker does not leave it running behind the app.
+
+The animated menu-bar icon keeps its existing motion with less CPU work in the measured idle scenarios. This is a focused reduction in background activity and animation cost; battery-life gains and the cleanup of separately detached provider processes are outside these changes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Stop orphaned macOS node workers during app restart and shutdown [#135663](https://github.com/openclaw/openclaw/pull/135663). Thanks @colton-harris.
+- Stop Mac background checks when their views or requests finish [#136741](https://github.com/openclaw/openclaw/pull/136741).
+- Reduce menu-bar animation CPU use while idle [#137027](https://github.com/openclaw/openclaw/pull/137027).
+
+**Limits and compatibility**
+
+Menu-bar CPU comparisons used signed profiling builds on macOS 27 beta with animation enabled. Hidden-dashboard WebKit wakeups remain outside that animation repair.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose a Mac Dock icon">
+
+You can choose Original, Heritage, Clawmark, Origami, Pincer, or Open C in [Settings → General → Dock icon](https://docs.openclaw.ai/platforms/mac/icon), with light and dark previews side by side and the selection saved for each OpenClaw profile. Custom designs change the Dock icon while the app is running; Finder and the Dock after quitting continue to use Original. On macOS 26 and later, Original follows the system's Icon & widget style setting.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Choose six Mac Dock icon designs with light and dark previews [#138002](https://github.com/openclaw/openclaw/pull/138002).
+
+**Limits and compatibility**
+
+Source and package checks support the picker, but installed-app relaunch and native appearance-transition validation remain unverified.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Start the Linux AppImage">
+
+The Linux AppImage packaging now avoids optional media dependencies and bundled Wayland libraries that caused the demonstrated startup failures and blank windows on affected systems. Supported media playback stays bundled, while the graphics connection uses compatible host libraries. Quick Chat also explains when a Gateway needs a missing token or password and directs you to its recovery path without discarding the paired device token.
+
+Check the [Linux requirements](https://docs.openclaw.ai/platforms/linux) before choosing a system for the companion. The AMD64 AppImage requires glibc 2.35 and GLIBCXX_3.4.30, which standard RHEL 9 and Rocky Linux 9 do not provide; extracting an AppImage bypasses FUSE requirements, not that library floor. The fixes address the reproduced startup failures, with graphics compatibility still depending on the host GPU and compositor.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show missing-credential recovery guidance in Linux Quick Chat [#137065](https://github.com/openclaw/openclaw/pull/137065). Thanks @vincentkoc.
+- Start Linux AppImages without incompatible bundled media dependencies [#137106](https://github.com/openclaw/openclaw/pull/137106). Thanks @vincentkoc, @ahmadtv, @soulafein83.
+- Repair Linux AppImage Wayland-library conflicts and verify packaging tools and isolated updater signing [#137797](https://github.com/openclaw/openclaw/pull/137797). Thanks @vincentkoc, @ahmadtv, @soulafein83.
+
+**Documentation**
+
+- Document the AMD64 AppImage library floor and extraction limits [#137176](https://github.com/openclaw/openclaw/pull/137176). Thanks @vincentkoc, @ahmadtv, @soulafein83.
+
+**Limits and compatibility**
+
+The Mesa reproduction used a controlled software-rendering environment. It does not qualify every physical GPU/compositor, establish an aarch64 AppImage download, or prove the new production signing-and-publication flow was exercised.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read native controls in your language">
+
+The existing native-app languages receive updated labels and guidance across phones, watches, and Mac, including chat selection and code-copy actions, model controls, Dock icon choices, and Gateway error titles. Apple translations also cover standalone Watch voice setup and microphone permission, plus Mac browser sign-in and reconnect guidance, so the instructions surrounding those features are available in the supported language catalogs.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Translate chat copy actions and Mac background-session errors [#137182](https://github.com/openclaw/openclaw/pull/137182).
+- Refresh native app translations across 21 languages [#138372](https://github.com/openclaw/openclaw/pull/138372).
+- Translate Watch voice setup and Mac Gateway sign-in guidance [4e3dce94d098](https://github.com/openclaw/openclaw/commit/4e3dce94d09868b62d67325c54df96ffbed689c1).
+
+**Bug fixes**
+
+- Localize Mac Gateway action-failure alert titles [#136781](https://github.com/openclaw/openclaw/pull/136781). Thanks @vincentkoc.
+
+**Limits and compatibility**
+
+These are updates to existing languages, not new language support or implementation of the translated features. Localized-screen layout and linguistic quality were not verified in every language.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Models and Providers
+
+OpenClaw v2026.9.2 adds support for OpenAI's GPT-6 Astra and Meta's Muse Spark 1.3 alongside fixes that help conversations continue and active work finish. On its supported API-key path, Astra also lets you send live corrections and keep receiving output while direct tools run. Codex can retain its thread after supported compaction interruptions, long CLI-backed replies avoid being stopped while still producing output, and temporary provider failures get more appropriate recovery and retry guidance. People sharing a Gateway can also choose their own model account for each chat.
+
+<AccordionGroup>
+
+<Accordion title="Use OpenAI's GPT-6 Astra and steer active work">
+
+OpenClaw v2026.9.2 adds [support for OpenAI's GPT-6 Astra](/providers/openai#gpt-6-astra), so accounts with access can choose it for conversations using text and images. You can select `openai/gpt-6-astra` with an OpenAI API-key profile or an eligible ChatGPT/Codex subscription. Subscription model discovery confirms account access before offering Astra; an unavailable catalog can temporarily leave it out of the picker.
+
+On the official OpenAI endpoint with an API key and the built-in OpenClaw runtime, Astra can continue reasoning and responding while direct tools run. A cached WebSocket also lets you send a correction into the active response, including text or images, without waiting for it to finish first. Accepted instructions remain attached to the conversation through continuation and reconnect. SSE keeps ordinary queued delivery, and these built-in-runtime capabilities are separate from native Codex execution.
+
+You can change the thinking level before the next turn while retaining a compatible cached prompt prefix. Automatic compaction, automatic truncation, pro mode, and API multi-agent mode do not support that optimization, and a restart or rewritten history starts a fresh request. Finish pending tool results or approvals in a compatible Astra mode before switching. Where runtime capabilities permit it, `/think ultra` also enables proactive delegation to sub-agents, using `max` effort in OpenClaw and `xhigh` in native Codex.
+
+Astra's full context window is 1,050,000 tokens, with up to 128,000 output tokens, while OpenClaw keeps its default active input budget at 272,000. Choosing Off does not disable Astra's reasoning, and the cost estimate preserves its higher long-context pricing tier.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add GPT-6 Astra selection, reasoning controls and tiered cost estimates [#137550](https://github.com/openclaw/openclaw/pull/137550). Thanks @chac4l.
+- Run Astra tools asynchronously, steer active responses, and update thinking effort [#138046](https://github.com/openclaw/openclaw/pull/138046).
+
+**Bug fixes**
+
+- Require account discovery before listing Astra for subscriptions [#137561](https://github.com/openclaw/openclaw/pull/137561).
+- Preserve Astra steering history and reusable effort prompts [#138434](https://github.com/openclaw/openclaw/pull/138434).
+- Honor current output limits and reasoning settings when Astra resumes required input, retaining earlier effort controls [#138436](https://github.com/openclaw/openclaw/pull/138436).
+- Preserve mid-response steering and original prompt ownership with runtime context [#138575](https://github.com/openclaw/openclaw/pull/138575).
+- Preserve Astra reasoning settings for metadata-free OpenAI and ChatGPT requests, while Azure deployments retain explicitly configured capabilities [#138626](https://github.com/openclaw/openclaw/pull/138626).
+- Expose Astra Ultra where runtime capabilities support it, using max in OpenClaw and xhigh in native Codex [#138739](https://github.com/openclaw/openclaw/pull/138739).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Select Meta Muse Spark 1.3">
+
+OpenClaw now supports [Meta's Muse Spark 1.3](/providers/meta), with Standard and Contributor choices for accounts that have access. Both accept text and image input and expose reasoning controls, a 1,048,576-token context window, and up to 131,072 output tokens. Select `meta/muse-spark-1.3` for Standard or `meta/muse-spark-1.3-contributor` for Contributor.
+
+Fresh Meta setups now choose Standard 1.3, while existing primary-model selections and older catalog choices remain available. Contributor has separate access and data-use terms, so check the provider guide before choosing that version.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add Muse Spark 1.3 choices and update new Meta setups [#136553](https://github.com/openclaw/openclaw/pull/136553). Thanks @tharuntejmeta, @romneyda.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose your own account for a chat">
+
+People sharing a Gateway can now connect their own supported model accounts in **Settings → Profile → Connected accounts**, choose a default for new chats, and use **Account for this chat** to make a separate choice for an existing conversation. Changing the default leaves existing chats alone, and collaborators and forks keep the account already selected for that chat. Model availability, status labels, fallback checks, and retry estimates now follow that personal selection.
+
+[Personal accounts](/concepts/multi-user#per-person-model-accounts) support Anthropic API keys, OpenAI API keys or browser/device sign-in, and Grok/xAI API keys or device sign-in where those methods are enabled. The Gateway must identify each person first, including for CLI setup; a shared password or device pairing alone does not identify a distinct teammate. Collaborators see a personal-account label without its private email or account details. Shared same-provider fallback can still apply, so selection is not a billing guarantee or isolation from administrators. Claude CLI keeps its required account restriction.
+
+Administrators and integrations also gain a Gateway API for inspecting provider accounts and saving or clearing their priority order. Configuration-controlled order remains authoritative, and a successful save can precede the background refresh that applies it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Connect personal provider accounts and choose each chat's account; retain hidden dashboard panels, replacement catalog workers, and accurate node-policy guidance [#134970](https://github.com/openclaw/openclaw/pull/134970). Thanks @scoootscooob.
+- Manage provider account order through the Gateway API [#132450](https://github.com/openclaw/openclaw/pull/132450). Thanks @jesse-merhi.
+
+**Bug fixes**
+
+- Match model readiness to the selected personal or chat account [#137702](https://github.com/openclaw/openclaw/pull/137702).
+- Honor selected personal accounts when choosing models and backups [#137765](https://github.com/openclaw/openclaw/pull/137765).
+- Label selected personal accounts privately in status and model listings [#137793](https://github.com/openclaw/openclaw/pull/137793).
+- Base exhausted-fallback retry estimates on the selected personal account [#137853](https://github.com/openclaw/openclaw/pull/137853).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Find available models after refresh">
+
+Model pickers keep the names, reasoning information, and configured choices they already know through more refresh and configuration-reload cases. Native Codex models retain their account-scoped availability, repeated browsing can reuse discovered inventory when a provider is unavailable, and Hugging Face's bundled models remain selectable before a key is added. A listed model still needs valid credentials, compatible runtime support, and account access before it can answer.
+
+[Hosted catalog updates](/concepts/models#hosted-catalog-updates) can now import eligible tool-capable text models from models.dev for providers that opt in, so adding each supported model no longer needs a separate OpenClaw change. New listings appear after a refreshed catalog has been published and downloaded and the Gateway has restarted. Provider policies and configured allowlists continue to apply.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Import eligible provider models into the hosted catalog while preserving provider policy and the last valid publication [#137131](https://github.com/openclaw/openclaw/pull/137131). Thanks @obviyus.
+
+**Bug fixes**
+
+- Keep bundled Hugging Face DeepSeek R1, DeepSeek V3.1, and GPT-OSS 120B selectable before adding credentials [#127118](https://github.com/openclaw/openclaw/pull/127118). Thanks @rrmars, @obviyus.
+- Keep native Codex models selectable after catalog refresh [#134524](https://github.com/openclaw/openclaw/pull/134524). Thanks @jason-allen-oneal.
+- Keep discovered models available across repeated model-picker visits [#136915](https://github.com/openclaw/openclaw/pull/136915).
+- Preserve cold model names and reasoning metadata, report failed model calls and provider HTTP status accurately, and avoid retrying successful replies because of stale error text [#137063](https://github.com/openclaw/openclaw/pull/137063).
+- Keep model lists coherent through configuration reloads [#137180](https://github.com/openclaw/openclaw/pull/137180). Thanks @shakkernerd.
+- Retain configured model metadata through full catalog refreshes [#137896](https://github.com/openclaw/openclaw/pull/137896).
+- Recognize provider aliases when editing model fallbacks [#136586](https://github.com/openclaw/openclaw/pull/136586). Thanks @teddytennant, @obviyus.
+- Save utility-model defaults when no primary model is configured [#137633](https://github.com/openclaw/openclaw/pull/137633).
+- Skip unnecessary plugin discovery for absent fallback notices [#138445](https://github.com/openclaw/openclaw/pull/138445).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Connect and discover local model services">
+
+The local-server guide now uses [llmman](/providers/llmman), the maintained replacement for Inferrs, with corrected startup commands, readiness checks, and troubleshooting for requests that work directly but fail during a larger agent task. Existing Inferrs documentation links redirect to the new guide. Keep its unauthenticated service on loopback or behind trusted access controls.
+
+Managed llama.cpp also resolves a selected Hugging Face GGUF file without scanning unrelated files in a large repository, while self-hosted discovery keeps its time budget stable when the computer's clock changes. These fixes preserve the existing model-address and integrity requirements.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Resolve Hugging Face models from large repositories [#136384](https://github.com/openclaw/openclaw/pull/136384). Thanks @sunlit-deng, @obviyus.
+- Keep model discovery deadlines stable across clock changes [#138356](https://github.com/openclaw/openclaw/pull/138356). Thanks @coderdailyone, @vincentkoc.
+
+**Documentation**
+
+- Replace retired Inferrs setup instructions with llmman guidance [#128644](https://github.com/openclaw/openclaw/pull/128644). Thanks @ericcurtin, @sallyom.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue and branch Codex conversations">
+
+Codex conversations keep the model and account selected for their native thread when you continue them, including imported conversations whose model differs from the agent's default. **Fork from here** retains the draft and source thread's current model on Codex 0.153 or newer, and an empty native tool catalog no longer makes a supervised conversation look corrupt. Separate Ask OpenClaw conversations also keep separate Codex threads.
+
+If compaction is interrupted after OpenClaw saves a new session, supported continuation paths can recover its recorded predecessor and keep the existing native thread. That includes ordinary messages, side questions, and same-thread resume, with outdated queued compaction and control commands prevented from changing the successor session. A confirmed deletion of an ordinary managed Codex thread instead creates a fresh native thread in the same OpenClaw session; it cannot restore the deleted native history.
+
+Ordinary post-tool summaries stay on the completed work's prepared model and account. Supervised tool-only runs that cannot safely produce a summary retain their completed work and explain that no final summary was produced, without repeating those actions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep Codex-backed System Agent conversations independent [#131901](https://github.com/openclaw/openclaw/pull/131901). Thanks @iwhatsskill, @vacinc, @liuwqgit, @stayif.
+- Preserve Codex model and credential ownership across chat turns [#136754](https://github.com/openclaw/openclaw/pull/136754). Thanks @rothelektronik.
+- Keep Codex post-tool summaries on the completed work's model and account [#136758](https://github.com/openclaw/openclaw/pull/136758).
+- Continue and branch Codex conversations with an empty tool catalog [#137087](https://github.com/openclaw/openclaw/pull/137087).
+- Recover deleted Codex threads while retaining the selected model [#137123](https://github.com/openclaw/openclaw/pull/137123).
+- Preserve native model identity in Codex forks and reapply app restrictions [#137167](https://github.com/openclaw/openclaw/pull/137167).
+- Preserve Codex threads after interrupted compaction [#138473](https://github.com/openclaw/openclaw/pull/138473). Thanks @vincentkoc.
+- Reject outdated Codex compaction after session rollover [#138767](https://github.com/openclaw/openclaw/pull/138767). Thanks @vincentkoc.
+- Reject outdated Codex controls after session rollover [#138820](https://github.com/openclaw/openclaw/pull/138820). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Open large Codex histories">
+
+Continuing a long Codex conversation now uses a bounded history renderer that keeps the needed context without first building a much larger temporary string. Resuming large saved records also spends less CPU scanning them, and prompt annotation or confirmed steering avoids rebuilding search information when the searchable content has not changed. These changes reduce specific preparation costs; large-record decoding and parsing can still take time.
+
+When browsing native Codex or Claude sessions on connected computers, slow hosts can now add their results after the initial partial list arrives, subject to the viewer's current access. Internal voice consultations also stop producing false prompt-mirroring warnings when their hidden input was already saved.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce history-scanning CPU when resuming large Codex conversations [#138784](https://github.com/openclaw/openclaw/pull/138784).
+
+**Bug fixes**
+
+- Avoid redundant history indexing during native Codex turns [#136836](https://github.com/openclaw/openclaw/pull/136836).
+- Bound Codex history rendering and suppress false hidden-consultation warnings [#138849](https://github.com/openclaw/openclaw/pull/138849).
+- Deliver late native-session catalog results from slow connected hosts [#138674](https://github.com/openclaw/openclaw/pull/138674).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Launch the intended Codex runtime">
+
+Managed Codex now uses version 0.153.4 and resolves the installation owned by its plugin across supported installation layouts, including Windows launchers in paths with spaces. A missing managed package produces repair guidance instead of silently selecting an unrelated older binary. Externally managed runtimes retain the general 0.149.0 minimum, while individual features such as canonical message forks require a newer version.
+
+Restricted and message-only turns keep their intended tool limits. If an older administrator-managed Codex policy blocks those turns, the error explains the manual file or MDM migration needed to preserve ChatGPT-only login restrictions. Scheduled runs whose app inventory times out keep their saved access binding and report a timeout suitable for existing retry handling, without executing tools or asking for unnecessary reauthorization. Codex cloud sessions also skip startup of an OpenClaw worker they do not use.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Skip unused worker prewarming for Codex cloud sessions [#138455](https://github.com/openclaw/openclaw/pull/138455).
+
+**Bug fixes**
+
+- Start the intended managed Codex package across installation layouts [#136655](https://github.com/openclaw/openclaw/pull/136655). Thanks @hermannmetzker-ai.
+- Update managed Codex while preserving restricted-turn tool boundaries [#137009](https://github.com/openclaw/openclaw/pull/137009).
+- Explain legacy Codex policy repairs for restricted tasks [#136496](https://github.com/openclaw/openclaw/pull/136496). Thanks @pfrederiksen, @obviyus.
+- Update managed Codex to 0.153.4 and preserve app-inventory timeout outcomes [#138725](https://github.com/openclaw/openclaw/pull/138725).
+
+**Documentation**
+
+- Document Codex startup argument quoting and array limits [#138878](https://github.com/openclaw/openclaw/pull/138878).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Stop Codex turns and understand refusals">
+
+Stopping a newly accepted Codex request now waits for confirmation that the selected turn ended, including side questions, while preserving other conversations on the connection. If conversation-history writes are blocked, cancellation and timeout can still release the turn, and a delayed write cannot later save an obsolete successful answer. Missing cancellation confirmation remains a reported failure.
+
+Recognized biological-risk and cyber-policy refusals now explain the refused turn without telling you to start over or automatically trying another model. You can continue the same conversation with a later request; the provider's safety policy still determines what it accepts.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Explain Codex policy refusals without restarting or trying another model [#136194](https://github.com/openclaw/openclaw/pull/136194). Thanks @leilei3167, @vyctorbrzezowski, @dougbutdorf.
+- Confirm early Codex cancellation without stopping peer conversations [#138876](https://github.com/openclaw/openclaw/pull/138876).
+- Finish stopped Codex turns when history writes are blocked [#138920](https://github.com/openclaw/openclaw/pull/138920).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use installed Claude Code and answer its questions">
+
+OpenClaw now talks directly to the Claude Code executable already installed on your computer, preserving existing login and configuration, warm conversations, resumed sessions, approvals, and questions. Script wrappers and command aliases retain their verified launch arguments, and fallback session titles use the first real prompt instead of preceding instruction metadata. Keep Claude Code current.
+
+Malformed Claude questions now return the failing field and correction guidance, so a corrected call with a fresh tool-use ID can reach you. Codex and Copilot also show question prompts that could previously remain invisible, including Codex side conversations, while supported credential requests provide a Control UI link for protected entry. A visible prompt can still encounter a separate problem receiving the answer.
+
+When Claude deliberately ends a turn without a reply, recognized stop reasons are explained and automatic replay is suppressed. Check any tool effects before retrying manually, because the work may already have changed something even though no final answer arrived.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Use direct Claude Code transport and preserve verified wrapper invocation arguments [#138707](https://github.com/openclaw/openclaw/pull/138707).
+
+**Bug fixes**
+
+- Show agent questions across Codex and Copilot harnesses [#133165](https://github.com/openclaw/openclaw/pull/133165). Thanks @edenfunf, @obviyus.
+- Explain deliberate Claude stops and avoid replaying completed tool effects [#136498](https://github.com/openclaw/openclaw/pull/136498). Thanks @harjothkhara, @obviyus, @adityasngh.
+- Explain invalid Claude question fields and how to retry [#137390](https://github.com/openclaw/openclaw/pull/137390). Thanks @liuwqgit, @cyborgobi.
+- Use real prompts for Claude session titles and directories [#138845](https://github.com/openclaw/openclaw/pull/138845). Thanks @colton-harris, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve compatible reasoning and prune tool context">
+
+Supported moves from Opus 5, Sonnet 5, Opus 4.8, or Fable 5 onto Fable 5.1 can retain readable earlier reasoning. Fable 5.1 also keeps the hidden runtime context needed for that continuity in saved transcripts and exports, while leaving it out of visible chat and compaction summaries. Other Anthropic-compatible models return to transient runtime context, avoiding repeated old details on later requests. Switching away and back, changing thinking level, or rewriting the prompt can still invalidate reasoning.
+
+[Session pruning](/concepts/session-pruning) keeps trimmed tool results trimmed across later requests while preserving the full local history. Direct Anthropic API-key requests in cache-TTL mode use server-side clearing based on token thresholds, rather than the client TTL and hard-clear settings, and protection rules now include historical tools that are no longer available. After restarting a branched conversation, client-side restoration can still pick a sibling branch's pruning marker and change the context sent to the model.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve supported Fable 5.1 reasoning across runtime events and model entry; eligible direct API-key adaptive-thinking requests remove invalidated blocks with counts-only warnings [#136782](https://github.com/openclaw/openclaw/pull/136782).
+- Limit retained runtime context to proven Fable 5.1 identities [#136990](https://github.com/openclaw/openclaw/pull/136990).
+- Keep tool-result trims stable and use direct Anthropic server clearing; restarted branched sessions retain a sibling-marker restoration limitation [#137021](https://github.com/openclaw/openclaw/pull/137021).
+- Preserve protected retired-tool results during Anthropic pruning [#137632](https://github.com/openclaw/openclaw/pull/137632). Thanks @patrick-erichsen.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover eligible provider failures">
+
+A model can still be working before it has visible text to send. Anthropic, Google, Mistral, Bedrock, and Ollama now count parsed keepalives, reasoning, and other response events as activity, and active CLI-backed answers retain their existing quiet allowance and time to finish delivery. Truly silent calls and overall run limits still expire.
+
+Temporary provider errors receive more appropriate retry handling and advice. ChatGPT SSE preserves the service's requested retry delay, and eligible Bedrock connection failures before output can continue from completed tool work within the existing recovery limit. A failed unrelated harness plugin no longer blocks healthy models, later requests can recover from a transient catalog mismatch, and beginning provider sign-in leaves serving plugins active. These paths keep their existing safeguards against replaying completed effects.
+
+For a new billing failure, the initial wait falls from five hours to ten minutes, although upgrading does not shorten an already-active window or detect a top-up immediately. Explicitly ordered preferred credentials can also be retried on a later real request after their cooldown. Repeated rate-limit failures without a provider reset time can progressively delay those attempts up to 24 hours, so returning from a paid fallback is subject to successful recovery.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover model preparation after a transient catalog mismatch [#127712](https://github.com/openclaw/openclaw/pull/127712). Thanks @kiranvk-2011, @kvk-code, @obviyus, @wikipediabrown, @felirami.
+- Preserve account details when agent sessions refresh OAuth tokens [#127988](https://github.com/openclaw/openclaw/pull/127988). Thanks @yetval, @obviyus.
+- Route OpenAI OAuth token exchange and refresh through applicable HTTP(S) proxies, retaining NO_PROXY and excluding ALL_PROXY-only setup [#131161](https://github.com/openclaw/openclaw/pull/131161). Thanks @rob1nzon, @obviyus, @artemeey.
+- Keep model responses alive while providers continue sending events [#131929](https://github.com/openclaw/openclaw/pull/131929). Thanks @vyctorbrzezowski.
+- Reduce the initial wait after new provider billing failures to ten minutes [#136364](https://github.com/openclaw/openclaw/pull/136364). Thanks @holny, @altaywtf, @whl1997-an, @gang-9885, @fiatvxufhsezb79-wq.
+- Retry preferred ordered credentials after cooldown, with request-driven rate-limit backoff up to 24 hours when no reset time is supplied [#136784](https://github.com/openclaw/openclaw/pull/136784). Thanks @patrick-erichsen, @john-rood, @haynzz, @bottenbenny, @vibecodooor, @zeynalnia, @acidyards, @taw0002.
+- Release consumed model-response events from retained stream queues [#136848](https://github.com/openclaw/openclaw/pull/136848).
+- Honor ChatGPT HTTP status and Retry-After during SSE retries [#137146](https://github.com/openclaw/openclaw/pull/137146).
+- Respect deliberate silence from fallback models [#137225](https://github.com/openclaw/openclaw/pull/137225). Thanks @ignacioarsuaga, @obviyus.
+- Resume Bedrock turns after pre-output connection failures [#137368](https://github.com/openclaw/openclaw/pull/137368). Thanks @yigtwxx, @altaywtf.
+- Distinguish temporary provider failures from missing-model configuration errors; bare Codex overload and internal-error tags still receive inferred HTTP statuses [#137771](https://github.com/openclaw/openclaw/pull/137771).
+- Keep healthy models usable when another harness plugin fails [#137777](https://github.com/openclaw/openclaw/pull/137777).
+- Keep active CLI-backed answers from being stopped as stuck [#138280](https://github.com/openclaw/openclaw/pull/138280). Thanks @anandnsharma, @anand-thepasselgroup, @obviyus.
+- Keep serving plugins active during provider sign-in discovery [#138838](https://github.com/openclaw/openclaw/pull/138838).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep OpenAI request context and terminal facts">
+
+OpenAI Responses retains the instruction to finish an answer after compaction through reasoning-only and empty-response retries. If request preparation fails, a later successful request can establish fresh continuation state so subsequent turns stop resending the entire history; that first recovery request still sends the full conversation.
+
+Failed requests with unfinished tool calls now retain the provider's reported usage, served model, and available failure reason when terminal information arrives. Incomplete tools remain blocked, along with later parallel tool completions after the incomplete call. Tiny managed output budgets are raised to the API's 16-token minimum, and explicitly selected agents can use their allowed API model overrides on multi-agent Gateways without requiring a system agent.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve continuation instructions through post-compaction retries [#136236](https://github.com/openclaw/openclaw/pull/136236). Thanks @vincentkoc.
+- Restore Responses continuation after preparation errors [#137630](https://github.com/openclaw/openclaw/pull/137630).
+- Preserve literal tool property names through Codex and OpenAI schema handling [#137840](https://github.com/openclaw/openclaw/pull/137840).
+- Normalize tiny managed Responses output budgets to 16 tokens [#138828](https://github.com/openclaw/openclaw/pull/138828).
+- Retain usage and failure details for incomplete Responses tool calls [#138880](https://github.com/openclaw/openclaw/pull/138880). Thanks @razdgann.
+- Resolve API model overrides through the explicitly selected agent [#137913](https://github.com/openclaw/openclaw/pull/137913). Thanks @obviyus, @syncword.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Configure voice and video services">
+
+Talk now checks for an unambiguous agent owner before loading providers, and voice-choice discovery can load provider catalogs without starting each full plugin. Compatible video-description services also honor their configured API-key or no-auth mode, with credentials reflected in service errors removed from diagnostics.
+
+Ending a Gateway-controlled OpenAI Realtime call now reports a failed provider hangup and retains it for bounded automatic cleanup retries. If those attempts are exhausted, cleanup remains incomplete and the call still reserves capacity; pressing End again is not the retry mechanism. The [OpenAI cleanup guidance](/providers/openai#gateway-controlled-realtime-call-cleanup) explains recovery, including that a restart can lose the in-memory cleanup obligation and does not prove the provider call ended.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report missing Talk ownership before loading providers [#137612](https://github.com/openclaw/openclaw/pull/137612).
+- Retry failed Realtime hangups without losing provider call ownership [#137636](https://github.com/openclaw/openclaw/pull/137636).
+- Load Talk provider catalogs without full plugin startup [#138483](https://github.com/openclaw/openclaw/pull/138483).
+
+**Security and trust**
+
+- Honor video authentication settings and redact reflected request credentials [#138205](https://github.com/openclaw/openclaw/pull/138205).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Respect exclusive Copilot tools">
+
+[Copilot](/plugins/copilot) now honors direct tools that must run without overlapping other tool calls in the same attempt. They wait for earlier calls to finish and hold later ones until they settle, including failure, while ordinary tools keep their parallel execution. Cancelled queued calls do not begin executing.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Honor sequential execution across sibling Copilot tools [#137980](https://github.com/openclaw/openclaw/pull/137980). Thanks @amknight.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep optional Codex apps from blocking chat">
+
+An unavailable optional Codex app no longer prevents an unrelated conversation or heartbeat check-in from starting when a successful app snapshot identifies the problem. OpenClaw logs the unavailable apps and continues with the remaining tools, including supported resumed sessions and forks. The unavailable app stays unavailable, and snapshot failures, tool permissions, and scheduled access checks retain their existing restrictions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Warn about unavailable optional Codex apps without blocking unrelated conversations [#138687](https://github.com/openclaw/openclaw/pull/138687). Thanks @kimiyu-186.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Retain Codex usage and ordered live replies">
+
+Concurrent conversations keep reply text in order while a reader temporarily falls behind, including across tool and final events, within the existing connection limit. A client that permanently stops reading can still be disconnected.
+
+Codex [turn usage](/reference/token-use#how-to-see-current-token-usage) now adds the reported counts from every unique completed response, including responses before a retry or cancellation. Those totals remain separate from the current context window, so a missing final context snapshot stays unavailable instead of showing the cumulative usage as if it were the remaining conversation context.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve ordered concurrent replies and cumulative Codex usage, drain admitted Codex startup on shutdown, retain intended transcript workspace headers, distinguish actual timeouts, and keep final redacted SSH diagnostics [#137030](https://github.com/openclaw/openclaw/pull/137030).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Automations and Scheduling
+
+You can manage existing automations from authenticated admin chat, keep their saved schedules and permissions through edits and copies, and let a self-cleaning job finish its result after removing its own schedule. Background checks retain their conversation context, while delegated tasks gain more specific recovery and stop behavior so you can follow the work through an interruption.
+
+<AccordionGroup>
+
+<Accordion title="Manage existing automations from admin chat">
+
+An administrator can now use [Control UI chat to manage existing automations](https://docs.openclaw.ai/automation/cron-jobs#conversational-management) across the Gateway, including a reminder created in Telegram. You can ask your Claw to find it, inspect it, change it, run it or remove it, with the same administrative reach as the Automations page.
+
+This requires a fresh authenticated Control UI turn with `operator.admin` permission, and managing someone else's job preserves its creator and scheduled execution policy. Creating command jobs remains a CLI or Gateway API operation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Manage all existing Gateway automations from authenticated admin chat [#137857](https://github.com/openclaw/openclaw/pull/137857).
+- Accept positional job IDs for automation run history [#138438](https://github.com/openclaw/openclaw/pull/138438). Thanks @dasx, @vincentkoc, @he-yufeng.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve schedules, alerts and permissions">
+
+Editing an [automation](https://docs.openclaw.ai/automation/cron-jobs) now keeps the timing and alert choices you saved, including fractional-second cooldowns and stagger windows. A 90-second interval stays visible as 90 seconds, while alert settings that follow global defaults remain inherited until you deliberately override them. Copies also retain tool restrictions, model fallbacks and context choices, with fresh authorization for the new job.
+
+New automations created through Claude Code or Codex can retain the native file and command capabilities authorized in the creating turn. If an older job already has an empty tool-permission list, recreate it or explicitly edit its tools from a fresh authorized turn. Administrator-managed shell restrictions still apply.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve failure-alert policies when editing or cloning automations [#129302](https://github.com/openclaw/openclaw/pull/129302).
+- Preserve millisecond precision when editing and displaying schedules [#136561](https://github.com/openclaw/openclaw/pull/136561).
+- Preserve tool limits and model choices when copying automations [#137419](https://github.com/openclaw/openclaw/pull/137419).
+- Preserve authorized native tools in newly created scheduled jobs [#137832](https://github.com/openclaw/openclaw/pull/137832). Thanks @jalehman, @marvinthebored, @peetiegonzalez.
+
+**Limits and compatibility**
+
+Command and script clones still become newly authored agent prompts. A custom Codex model with its shell disabled can prevent the inferred native read and command capabilities from being usable.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Cancel or finish the right scheduled job">
+
+A scheduled agent or script that is allowed to remove its own job can now delete the schedule and still finish its final result. Removing the job yourself continues to cancel it, and removing or disabling a job while it checks a condition prevents that pending check from starting the action. Effects already completed are not undone, and work already handed to the main conversation's heartbeat keeps its own lifecycle.
+
+Job management also preserves newer run results and timing when scheduling is disabled, while cleanup can remove expired idle sessions without getting stuck behind a busy one. In experimental Claws, successful installation retries clear old scheduler errors, and unchanged jobs no longer look modified merely because a status response includes extra metadata.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Limit automation runtime reads to the jobs being checked [#138418](https://github.com/openclaw/openclaw/pull/138418).
+
+**Bug fixes**
+
+- Preserve newer run results and timing when a scheduling-disabled Gateway edits jobs [#131733](https://github.com/openclaw/openclaw/pull/131733). Thanks @liuwqgit, @obviyus, @aspalagin.
+- Clean idle cron sessions while protecting busy work [#136426](https://github.com/openclaw/openclaw/pull/136426). Thanks @wangyan2026, @grynn, @obviyus.
+- Finish self-removing agent automations [#138231](https://github.com/openclaw/openclaw/pull/138231).
+- Cancel pending conditions before automation handoff [#138313](https://github.com/openclaw/openclaw/pull/138313).
+- Let scheduled scripts finish after removing their own schedule [#138337](https://github.com/openclaw/openclaw/pull/138337).
+- Clear stale scheduled-job errors after successful Claw install retries [#138949](https://github.com/openclaw/openclaw/pull/138949).
+- Ignore response-only metadata when matching Claw scheduled jobs [#139018](https://github.com/openclaw/openclaw/pull/139018).
+
+**Limits and compatibility**
+
+Separate Gateways still need separate state directories. The experimental Claws fixes leave the separate system-monitor removal policy in place.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep background checks in their conversation">
+
+[Heartbeat checks](https://docs.openclaw.ai/gateway/heartbeat) and background-command replies keep the room or topic rules that belong to their conversation, including Telegram topics. A command completion also keeps its original destination if the conversation moves elsewhere, and a successful or intentionally quiet heartbeat clears its own pending delivery state so later checks can proceed.
+
+Turning off recurring heartbeats no longer drops the spacing and flood limits for event-triggered work, and reloading settings preserves those limits while a turn is running. When OpenClaw refuses a check, its notice explains the reason without requiring verbose mode. Duplicate heartbeat and skill-review monitors can also be reconciled during startup, while large agent fleets avoid repeated heartbeat-summary work in health and status checks.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Identify background task completions as internal activity [#128165](https://github.com/openclaw/openclaw/pull/128165). Thanks @a-yeyang, @obviyus, @nova-openclaw.
+- Preserve room rules and original destinations for automated replies [#133323](https://github.com/openclaw/openclaw/pull/133323). Thanks @marvinthebored, @peetiegonzalez, @obviyus.
+- Include actionable refusal reasons in heartbeat notices [#136730](https://github.com/openclaw/openclaw/pull/136730).
+- Recover startup when system schedules have duplicate monitors [#137408](https://github.com/openclaw/openclaw/pull/137408). Thanks @omarshahine.
+- Retain event-wake limits with disabled heartbeat cadence and across reloads [#138213](https://github.com/openclaw/openclaw/pull/138213).
+- Reduce repeated heartbeat-summary work in large-fleet health and status checks [#137614](https://github.com/openclaw/openclaw/pull/137614). Thanks @ylcn91, @609nft.
+
+**Limits and compatibility**
+
+Manual wakes remain exempt from the event rate limits, and concurrent sessions can still race through admission. Failed deliveries and suppressed reminders retain retry state without guaranteeing a later send. Background completions receive an internal origin label going forward; old transcripts are unchanged.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover delegated task results">
+
+Delegated work has more ways back to its result when a conversation times out or OpenClaw restarts. Completed child results can wait through a recoverable parent timeout, overlapping groups keep their results until related work finishes, and a failed or decorated waiting message no longer prevents the parent from preparing its final reply.
+
+Eligible interrupted [subagent tasks](https://docs.openclaw.ai/tools/subagents#liveness-and-recovery) can resume after a restart without another prompt, keeping the original task and conversation while showing progress from the replacement run. Already completed tasks recover their saved result and completion time. Restored follow-ups run through a limited queue so a large backlog does not start all at once, which can make that backlog take longer to clear. Resumption notices are separate from final replies and depend on a supported original destination and bounded retries.
+
+Recovery also handles a temporary failure to save an already accepted restart attempt, adopting that same execution without another model request while its original recovery owner remains valid. Cancellation, newer work or another restart ends that particular adoption opportunity. When the assistant is simply waiting after an earlier tool error, a deliverable waiting message now shows the current state, while the error remains visible if there is no usable message to replace it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve subagent completions while the parent recovers from a timeout [#132704](https://github.com/openclaw/openclaw/pull/132704). Thanks @zhangguiping-xydt, @obviyus, @ruel225, @moerai.
+- Limit simultaneous restored subagent follow-ups after restart [#133057](https://github.com/openclaw/openclaw/pull/133057). Thanks @jjjhenriksen, @obviyus, @kritisanexa-sys.
+- Wait for the parent conversation to finish saving before handling a subagent result [#134920](https://github.com/openclaw/openclaw/pull/134920). Thanks @gaoanze888, @obviyus, @lowcode191.
+- Keep completed results through overlapping subagent work [#136390](https://github.com/openclaw/openclaw/pull/136390). Thanks @aldiz1711, @obviyus.
+- Restore completed subagent task status after Gateway restart [#136780](https://github.com/openclaw/openclaw/pull/136780). Thanks @fuller-stack-dev.
+- Carry sibling model changes into consolidated subagent results [#136807](https://github.com/openclaw/openclaw/pull/136807).
+- Deliver the final delegated-work reply after waiting-message failures [#137100](https://github.com/openclaw/openclaw/pull/137100).
+- Recover delegated-task final replies after Gateway restarts [#137606](https://github.com/openclaw/openclaw/pull/137606). Thanks @jalehman.
+- Resume interrupted delegated tasks after Gateway restarts [#138394](https://github.com/openclaw/openclaw/pull/138394). Thanks @fuller-stack-dev.
+- Keep recovered task progress attached to the current execution [#138785](https://github.com/openclaw/openclaw/pull/138785). Thanks @fuller-stack-dev.
+- Resume accepted task recovery after temporary receipt-write failures [#138862](https://github.com/openclaw/openclaw/pull/138862).
+- Avoid repeatedly loading unrelated conversations during worker recovery [#138890](https://github.com/openclaw/openclaw/pull/138890).
+- Show current waiting status after earlier tool errors [#138931](https://github.com/openclaw/openclaw/pull/138931). Thanks @fuller-stack-dev.
+
+**Limits and compatibility**
+
+Recovery remains limited to eligible work and existing retry and retention rules. A crash after a visible final reply but before completion is recorded can still produce a duplicate, and resumed work does not guarantee external actions happen only once. The separate terminal non-success settlement problem remains outside these fixes. Combined model-change notices stay bounded and follow existing local versus shared-channel visibility rules.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Stop pending and running delegated work">
+
+For ordinary Gateway-owned CLI tasks, [cancelling a task](https://docs.openclaw.ai/automation/tasks) now waits for the selected run and its pending approvals to stop before reporting success. The owning Gateway must still be running, and a timeout or missing live owner produces a refusal to confirm cancellation rather than a misleading success.
+
+Stopping a group of subagents sends stop requests to siblings without waiting for one sibling's cleanup, and includes new child branches discovered during the stop. A child launch still being prepared is also rejected if its parent loses authority before acceptance. Once accepted, children keep their independence after ordinary parent completion; a stop acknowledgment does not mean every underlying process has already finished cleaning up.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Confirm Gateway task cancellation only after the selected work stops [#118358](https://github.com/openclaw/openclaw/pull/118358). Thanks @peter3n, @obviyus.
+- Stop sibling subagents concurrently and include late child tasks [#138910](https://github.com/openclaw/openclaw/pull/138910).
+- Reject pending child launches after parent authority ends [#139020](https://github.com/openclaw/openclaw/pull/139020).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Refresh pinned widgets in the background">
+
+An eligible automation attached to a persistent session can refresh its [pinned dashboard widgets](https://docs.openclaw.ai/tools/show-widget) without keeping the browser open. It needs an explicit scheduled tool policy allowing `show_widget`, and its calls must pin the result; displaying an inline widget or opening it on a device still requires the appropriate client. When you do open Automations, bursts of activity share refresh requests while current status and run history continue to appear.
+
+If background image, video or music generation finishes but final delivery fails, the [task result](https://docs.openclaw.ai/automation/tasks) can retain output references for recovery through **Copy result** or `openclaw tasks show <lookup>`. Those references are bounded and can be truncated or filtered, and the files or URLs must still be accessible. This preserves a way to look for the output without automatically resending or hosting it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Allow authorized session automations to refresh pinned widgets in the background [#137666](https://github.com/openclaw/openclaw/pull/137666). Thanks @patrick-erichsen.
+- Combine overlapping automation-event refreshes without hiding progress [#138065](https://github.com/openclaw/openclaw/pull/138065).
+- Retain generated media references when final delivery fails [#131921](https://github.com/openclaw/openclaw/pull/131921). Thanks @vyctorbrzezowski, @jalehman.
+
+**Limits and compatibility**
+
+The widget eligibility check excludes detached cron-run sessions but still allows some private scheduler trigger sessions to write hidden dashboards. It does not establish that every private scheduler session is excluded.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Browser and Computer Use
+
+Desktop work now stays with the machine you selected through approval, reconnects, and taking control, while computer actions account for the screenshot the model actually sees. Browser connections also get clearer startup failures and more careful cleanup, so returning to a task is less likely to mean sorting out a stuck launch button or a tab that another session is still using.
+
+<AccordionGroup>
+
+<Accordion title="Keep desktop actions on the selected machine">
+
+The Desktop panel notices when an approved machine becomes available and keeps your explicit selection when the session moves or refreshes. Opening a popout carries that same desktop and control choice with it, subject to the usual authentication and permissions. You can also take control while Browser or Terminal is launching without leaving its button stuck, and a failed launch shows an error you can act on.
+
+For agents using [computer control](https://docs.openclaw.ai/nodes/computer-use), screenshot-capable CUA sessions can pause and then inspect a fresh image before continuing. Clicks and drags in CUA window images now account for resizing done by OpenClaw, so the delivered image and the requested position agree. Screenshot permission is still required, and a missing usable image prevents pixel-based actions while leaving supported element targeting available. Desktop viewing also handles the repaired clipboard case without dropping the connection, and a stalled receiver pauses further input until it can accept it again.
+
+If a paired machine goes offline, **Continue on Gateway…** lets you resume from the last synced workspace after an explicit data-loss confirmation. Unsynced files and in-flight work may be lost. The old worker loses authority over the session, but physical cleanup remains pending until it can be confirmed, so continuing locally does not mean the offline process has already stopped. The [cloud worker recovery guidance](https://docs.openclaw.ai/gateway/cloud-workers#dispatching-a-session) explains that choice.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve desktop selection, repair clipboard framing, retain dispatched worker execution budgets, and continue offline sessions from synced workspaces [#136297](https://github.com/openclaw/openclaw/pull/136297)
+- Finish app-launch controls correctly during Desktop takeover [#138142](https://github.com/openclaw/openclaw/pull/138142)
+- Pause desktop input when receivers stall and resume on drain [#138173](https://github.com/openclaw/openclaw/pull/138173)
+- Pause screenshot-capable desktops between actions [#138230](https://github.com/openclaw/openclaw/pull/138230)
+- Keep clicks and drags aligned with resized window images [#138271](https://github.com/openclaw/openclaw/pull/138271)
+
+**Limits and compatibility**
+
+The coordinate repair covers OpenClaw's image resizing for providers using image-pixel coordinates. Peekaboo logical points and browser CSS coordinates keep their own contracts; upstream native zoom and crop limitations remain. Worker cancellation is also reported as an abort when a transport error accompanies it.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Explain desktop connection failures">
+
+When Desktop disconnects, the browser console keeps the original failure without adding a misleading error from closing an already closed viewer. [Desktop stream logs](https://docs.openclaw.ai/nodes/computer-use#desktop-stream-troubleshooting) also retain the first known local shutdown trigger separately from the observed connection close code, giving you more useful context when comparing the Gateway and device logs. The intermittent disconnect remains unexplained, and code `1006` on its own does not tell you whether a network, proxy, or local shutdown caused it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Avoid duplicate console errors after a Desktop connection closes [#137724](https://github.com/openclaw/openclaw/pull/137724)
+- Retain desktop stream shutdown context in Gateway and node logs, and repair Mac source-build mounts on affected external APFS volumes [#137787](https://github.com/openclaw/openclaw/pull/137787)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Scroll and control Mac windows">
+
+On macOS, authorized Peekaboo computer-control requests can scroll at a screen position or at the pointer without requiring modifier keys or hitting an incorrect stale-snapshot refusal. Background scrolling still needs a window and an element from its current observation, so a background request does not silently become a foreground scroll. The Mac integration also adopts Peekaboo 4.3.0's native automation and Bridge repairs while retaining the existing computer-control settings and permissions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Adopt Peekaboo 4.3.0 native automation fixes on Mac [#136718](https://github.com/openclaw/openclaw/pull/136718)
+
+**Bug fixes**
+
+- Restore unmodified global-screen scrolling on macOS [#136948](https://github.com/openclaw/openclaw/pull/136948)
+
+**Limits and compatibility**
+
+The dependency update does not add Peekaboo's CLI agent or browser stack. Scroll validation covered the service boundary, not a complete physical-device workflow.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Connect to existing Chrome sessions">
+
+Connecting to your [existing Chrome session](https://docs.openclaw.ai/tools/browser#existing-session-via-chrome-devtools-mcp) no longer waits for npm's optional install audit when the default Chrome MCP helper needs to be downloaded. Chrome still needs remote debugging enabled and someone at the computer to approve its connection prompt. Custom launcher arguments retain their existing behavior.
+
+If attachment fails, the browser logs retain available startup errors and late shutdown warnings with the existing redaction and size limits. A replacement connection waits for the previous helper and its verified child processes to close, and uncertain cleanup reports an error. Your already-running browser stays open, while cancellation during startup prevents initialization from continuing afterward.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Skip optional npm install audits during default Chrome MCP startup [#137847](https://github.com/openclaw/openclaw/pull/137847)
+- Capture Chrome MCP startup diagnostics before initialization [#137993](https://github.com/openclaw/openclaw/pull/137993)
+- Include late browser-bridge warnings after connection failure [#138399](https://github.com/openclaw/openclaw/pull/138399)
+- Wait for Chrome MCP helper cleanup after failed attachment [#138524](https://github.com/openclaw/openclaw/pull/138524), fixing [issue #138486](https://github.com/openclaw/openclaw/issues/138486)
+
+**Limits and compatibility**
+
+The attachment deadline is unchanged, and diagnostics depend on the helper emitting error output. After a helper restart, list tabs again, choose the current target, and take a new snapshot before using references. Existing-session browser capabilities remain narrower than managed browser capabilities, and an in-process browser-context replacement can still retarget an action between calls. Native Windows cleanup was not demonstrated by the retained validation.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Navigate and retire browser sessions">
+
+Browser navigation now has time to return its result or its own error before the surrounding connection gives up. That matters when the browser is still responding but a page fails to load, because a generic connection timeout no longer hides the more specific navigation failure. On a connected node, the next command can also restart a stopped browser-control service under the existing profile and authentication rules; commands arriving during shutdown remain rejected.
+
+Session cleanup protects tabs that have been reassigned or used again, avoids overlapping duplicate close attempts, and skips loading browser components when there are no tabs to clean up. Sandbox browser startup and cleanup load a smaller part of the browser code and yield during activation, reducing the cold-path pauses while some loading remains blocking. Desktop-node setup guidance also removes an unnecessary Gateway restart under the default reload mode, while keeping the required node restart and pairing approval.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Allow navigation results to arrive before proxy deadlines expire [#137023](https://github.com/openclaw/openclaw/pull/137023), fixing [issue #136769](https://github.com/openclaw/openclaw/issues/136769). Thanks @obviyus and @clouddevops.
+- Preserve tab ownership during asynchronous browser cleanup [#137671](https://github.com/openclaw/openclaw/pull/137671)
+- Yield during browser bridge activation for start and stop [#138152](https://github.com/openclaw/openclaw/pull/138152)
+- Restart node browser control after service shutdown [#138293](https://github.com/openclaw/openclaw/pull/138293)
+- Load a smaller browser bridge artifact during cold startup and cleanup [#138583](https://github.com/openclaw/openclaw/pull/138583)
+
+**Documentation**
+
+- Clarify that desktop node policy setup needs only a node restart under the default reload mode, with pairing reapproval retained [#137859](https://github.com/openclaw/openclaw/pull/137859)
+
+**Limits and compatibility**
+
+A failed tab close can still be retried by a later independent cleanup. The navigation repair does not add retries or repair stale targets. Cold bridge measurements cover a bounded loading change, not every hosted timeout, real Chrome or Docker startup, or reduced memory use.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Extract readable web content">
+
+Reading a prose-heavy web page through Readability now spends less work scanning the HTML before extracting the article. The change skips unnecessary passes through ordinary text while keeping the extracted text and Markdown, along with the existing size and nesting limits, intact.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce scanning overhead when extracting web articles [#138243](https://github.com/openclaw/openclaw/pull/138243)
+
+**Limits and compatibility**
+
+The reported checks used synthetic extraction workloads. They do not establish faster network fetches, faster complete agent turns, or lower memory use; the retained benchmark's memory gate failed.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Plugins and Integrations
+
+Trusted experimental plugins can put custom pages and controls into the web workspace, while MCP tools keep their connections when an unrelated server changes. For work that reaches another machine or another person, cloud coding sessions can push directly to GitHub and shared Beam snapshots can become new conversations with a Team agent.
+
+<AccordionGroup>
+
+<Accordion title="Build trusted custom plugin interfaces">
+
+[Feature plugins](https://docs.openclaw.ai/plugins/feature-plugins) can give your Claw its own pages, panels, widgets, and session actions, or replace parts of the conversation interface and the whole workspace. An agent can build a plugin archive and propose that exact archive for your review before installation, giving you a way to shape the interface around your work without changing OpenClaw itself.
+
+Native interfaces from user-installed plugins are experimental and off by default. Enable **Settings → Labs → Custom plugin UI**, restart the Gateway, and reload your browser tabs, using the connected Gateway's own HTTPS or trusted localhost address. Install only code you trust because it runs with your signed-in operator permissions, without a plugin sandbox. Authors should pin and test their OpenClaw host version.
+
+Normal layouts currently hide the floating **Customize UI** entry, limiting access to replacement selection and **Reload plugin UI**. A full plugin workspace still offers **Built-in** recovery. Disabling the lab keeps installed plugins and their saved state, and enabled bundled interfaces such as Workboard remain available.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Customize web workspace and chat views with trusted feature plugins [#134943](https://github.com/openclaw/openclaw/pull/134943)
+
+**Limits and compatibility**
+
+- Hide Customize UI in built-in layouts while retaining full-workspace recovery [#138678](https://github.com/openclaw/openclaw/pull/138678) Thanks @patrick-erichsen.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep MCP tools connected through changes">
+
+Editing one [MCP server](https://docs.openclaw.ai/tools/mcp) no longer needs to disconnect the other tools your agent is using. With Gateway hot reload enabled, unchanged servers keep their connections and cached tools, and an active call to one of those servers can finish while a different server is replaced. Changed or removed servers are revoked immediately, with updated definitions discovered on the next turn and requester sign-in tools refreshed on the next message.
+
+OAuth-connected tools also remain available to CLI agents after credentials refresh, and loading a multi-page tool, resource, or prompt list no longer times out just because the computer's clock jumps forward. In Settings, deleting an MCP server or Cloud Worker profile with list-valued settings, or clearing a worker's Setup field, no longer fails on those lists.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep OAuth MCP tools available after credential refresh in CLI agents [#136331](https://github.com/openclaw/openclaw/pull/136331) Thanks @nianjiuzst, @obviyus, @volevanius.
+- Keep paginated MCP listings within elapsed-time deadlines [#137206](https://github.com/openclaw/openclaw/pull/137206) Thanks @coderdailyone, @obviyus.
+- Preserve healthy MCP servers and in-flight calls when a sibling configuration changes [#138694](https://github.com/openclaw/openclaw/pull/138694)
+- Allow Cloud Worker and MCP deletions with array-valued settings [#137040](https://github.com/openclaw/openclaw/pull/137040)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue coding with cloud workers">
+
+A coding agent on an OpenClaw [cloud worker](https://docs.openclaw.ai/gateway/cloud-workers) or paired session host can commit, push, and open a GitHub pull request during its turn, so it can see the result and respond before handing the work back. This needs GitHub CLI on the worker and an available shared Gateway GitHub account with access to the repository. It uses that shared identity, not the paired computer's personal login.
+
+When a replacement worker starts behind the session's pushed branch, it brings in those commits while preserving local edits and deletions, allowing the agent to continue with an ordinary push. Divergent history still needs attention. File reconciliation back to the Gateway remains separate from Git history, and Codex remote-exec keeps its own publication path. Use a dedicated worker account where required by the setup guide because per-turn credentials do not isolate processes sharing an operating-system account or revoke tokens already held by background processes.
+
+Cloud startup now rejects unusable local-only callback addresses before allocating a machine. At the other end of a session, SSH workspace cleanup can finish after the worker's RPC credential expires, with ownership and SSH checks still enforced. Stop and Move show the current provider cleanup cause and any supplied retry guidance when release remains pending, while local checks of larger returned workspaces do less repeated file work.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Let cloud-worker agents push and open PRs through the shared GitHub account [#136583](https://github.com/openclaw/openclaw/pull/136583)
+- Check cloud workspace files with bounded parallel reads [#138073](https://github.com/openclaw/openclaw/pull/138073)
+
+**Bug fixes**
+
+- Advance replacement worker checkouts to the pushed session branch [#137392](https://github.com/openclaw/openclaw/pull/137392)
+- Finish SSH cloud-session cleanup after RPC credential expiry [#138494](https://github.com/openclaw/openclaw/pull/138494)
+- Reject unusable local Gateway addresses before cloud-worker allocation [#137002](https://github.com/openclaw/openclaw/pull/137002)
+- Show current redacted provider guidance when cloud cleanup remains pending [#138526](https://github.com/openclaw/openclaw/pull/138526)
+- Reject delayed transcript writes after a worker turn loses ownership [#138538](https://github.com/openclaw/openclaw/pull/138538)
+- Keep completed worker downloads from closing reused HTTP connections [#137981](https://github.com/openclaw/openclaw/pull/137981)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue a shared Beam snapshot">
+
+A shared [Beam snapshot](https://docs.openclaw.ai/plugins/beam) can now become the start of a conversation with a Team agent. Write a message in its composer and OpenClaw copies the retained history into a new session belonging to you, using the source model when it is available and allowed, or explaining the switch to the agent's configured model.
+
+The copy follows the Team agent's normal permissions and treats imported history as untrusted reference material. It does not resume the source computer, inherit its tools, or synchronize later changes. Shared Beams are visible to Gateway operators with read permission; continuation also requires write or admin permission and access to the chosen agent. Delayed uploads no longer replace a newer snapshot or turn a completed snapshot live again at the same revision, keeping the saved history used for continuation intact.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Continue shared Beam snapshots with a Team agent [#135654](https://github.com/openclaw/openclaw/pull/135654) Thanks @fuller-stack-dev.
+
+**Bug fixes**
+
+- Preserve newer Beam snapshots and completed-session history [#138038](https://github.com/openclaw/openclaw/pull/138038) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve Workboard work through reloads">
+
+Reloading or disabling Workboard now stops its retired background services and lets already accepted operations finish before closing their database connection. Saved cards remain available when Workboard reopens, without each reload accumulating another set of open database handles or leaving old polling services writing warnings.
+
+Commenting on a blocked card, refreshing its claim, or releasing that claim also reports a successful saved update correctly through the plugin-tools MCP bridge. Custom integrations consuming heartbeat, release, comment, or unblock results should read the returned card under `card`. The Workboard registration helper again supports integrations that let it create and manage the store.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Release retired Workboard database connections after plugin reloads [#122146](https://github.com/openclaw/openclaw/pull/122146) Thanks @nianjiuzst, @obviyus, @alfred429.
+- Report successful blocked-card updates correctly [#138384](https://github.com/openclaw/openclaw/pull/138384) Thanks @ylcn91, @obviyus, @rileysheehan.
+- Stop retired Workboard polling and restore optional-store registration [#138810](https://github.com/openclaw/openclaw/pull/138810)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Save accepted Logbook work">
+
+Logbook now lets accepted captures, activity analysis, and generated standups finish saving before it closes their database during an orderly restart or disable. That also preserves the original analysis error when work fails, instead of covering it with a database-closed error. Shutdown can wait within the host's existing deadline, and forced termination can still interrupt that work.
+
+Questions about a busy day now load only the latest 200 eligible observations already used for the answer context, keeping their chronological order without first loading the whole day's observations.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Save accepted Logbook work before closing SQLite during restart or disable [#138754](https://github.com/openclaw/openclaw/pull/138754)
+
+**Improvements**
+
+- Bound Logbook day-question reads to the existing 200-observation context [#138816](https://github.com/openclaw/openclaw/pull/138816)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Inspect, repair and update plugins">
+
+[Plugin updates](https://docs.openclaw.ai/cli/plugins#update) give a clearer account of what is installed and what can change. If an official plugin is pinned to an older version, update and dry-run output can show the newer registry release and the explicit command to replace the pin. Existing pins stay in place until you choose otherwise. Repairing missing plugin files and updating a package now use its current contents, including removing settings for children that the replacement package has retired while preserving unrelated disabled plugins.
+
+Doctor also separates configuration problems from plugin problems. It keeps the original invalid-setting diagnostic instead of blaming whichever plugin happened to encounter it, and an absent plugin with an exact `enabled: false` marker no longer attracts contradictory installation advice just because it remains allowed. Real warnings still appear when console logging is set to warn.
+
+For valid retired `plugins.installs` records, `openclaw doctor --fix` preserves installation details before removing the old setting so service startup can proceed. It can also repair catalog-proven legacy official ClawHub provenance and explain the installation and storage paths behind a trust refusal. Malformed records still need correction, and trust rules remain in force. If an unreadable native service definition blocks an update, follow the [service recovery guide](https://docs.openclaw.ai/cli/gateway#recover-an-unreadable-native-service-definition), preserving and resupplying any values stored only in that service's environment.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep plugin warnings visible in warning-level logs [#136411](https://github.com/openclaw/openclaw/pull/136411) Thanks @zeroaltitude, @vincentkoc.
+- Complete missing-plugin repairs using fresh installed-package metadata [#136806](https://github.com/openclaw/openclaw/pull/136806)
+- Show newer official plugin releases while preserving version pins [#137578](https://github.com/openclaw/openclaw/pull/137578) Thanks @pandaaigc.
+- Keep invalid configuration diagnostics from blaming unrelated plugin tools [#137738](https://github.com/openclaw/openclaw/pull/137738) Thanks @sunnyshu0925, @altaywtf, @anyech.
+- Repair legacy ClawHub provenance and explain trusted plugin-state refusals [#138746](https://github.com/openclaw/openclaw/pull/138746) Thanks @maxpcuser.
+- Suppress install advice for missing plugins whose only entry setting is enabled: false [#138813](https://github.com/openclaw/openclaw/pull/138813) Thanks @nianjiuzst, @obviyus, @miguelarios.
+- Repair retired plugin installation settings before service startup [#138914](https://github.com/openclaw/openclaw/pull/138914) Thanks @obviyus, @worldtrading520.
+
+**Improvements**
+
+- Reduce repeated ownership checks while preparing plugin lists [#136759](https://github.com/openclaw/openclaw/pull/136759)
+- Reuse normalized plugin policy within provider-listing operations [#138003](https://github.com/openclaw/openclaw/pull/138003)
+- Reduce local inventory processing for installations with many plugins [#138535](https://github.com/openclaw/openclaw/pull/138535)
+- Reuse package ownership facts during populated plugin update planning [#138716](https://github.com/openclaw/openclaw/pull/138716)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep plugin tools and schemas compatible">
+
+Plugin tools now keep their supported input preparation and required one-at-a-time execution behavior in later sessions, using the current session's tool factory. A tool unavailable in that session can be omitted without taking healthy sibling tools with it, and literal names such as `constructor` work in tool permission rules while existing deny rules continue to apply.
+
+For replacement messaging plugins, settings validation, form metadata, and sensitive-field hints follow the plugin actually selected to run. This does not combine every inactive plugin's redaction hints, and sensitive fields belonging to an unselected schema can still remain visible.
+
+Plugin authors should check one registration change before upgrading. A directly registered channel must declare a nonempty `capabilities.chatTypes` list using supported values. The channel builder still defaults omitted capabilities to direct messages; group, channel, and thread support must be declared explicitly. Narrow [SDK compatibility repairs](https://docs.openclaw.ai/plugins/sdk-migration#retained-helper-contracts) also retain positional text-chunking ranges and legacy provider-wrapper retry inputs. The latter remain deprecated and are ignored by built-in text transports, so new wrappers should omit `maxRetries`.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Use the active channel plugin's settings schema and redaction hints [#132729](https://github.com/openclaw/openclaw/pull/132729) Thanks @xydt-juyaohui, @obviyus, @marmar9615-cloud.
+- Preserve plugin argument preparation and execution ordering in warm sessions [#137898](https://github.com/openclaw/openclaw/pull/137898)
+- Allow inspection and freezing of public channel schemas [#138266](https://github.com/openclaw/openclaw/pull/138266)
+- Avoid unrelated startup work for plugins using nodes and preserve runtime property assignment [#138284](https://github.com/openclaw/openclaw/pull/138284)
+- Handle literal names such as constructor in tool rules [#138330](https://github.com/openclaw/openclaw/pull/138330) Thanks @teddytennant, @obviyus, @kaxo-io.
+
+**Limits and compatibility**
+
+- Require valid conversation types from raw channel plugins [#136690](https://github.com/openclaw/openclaw/pull/136690) Thanks @romneyda.
+- Remove undeclared generated helpers from strict tool-plugin declarations, retaining the repair already present in v2026.9.1 [#137012](https://github.com/openclaw/openclaw/pull/137012) Thanks @leilei3167, @obviyus, @anordick.
+- Restore positional range inputs for Plugin SDK text chunking [#137510](https://github.com/openclaw/openclaw/pull/137510)
+- Retain deprecated, ignored maxRetries inputs and correct the provider custom-header wrapper example [#137521](https://github.com/openclaw/openclaw/pull/137521)
+
+**Documentation**
+
+- Clarify when plugin changes need a Gateway restart [#136740](https://github.com/openclaw/openclaw/pull/136740) Thanks @liuwqgit, @obviyus, @ourcoms2018.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Package plugin icons locally">
+
+Plugin branding now comes from artwork included in the installed package, so displaying its icon does not contact an arbitrary outside image host. Channel gallery rows, details, and setup screens use matching names and locally bundled icons, making the integration you are configuring easier to recognize.
+
+Authors must include [`assets/icon.png`](https://docs.openclaw.ai/plugins/manifest#plugin-icon) to retain custom branding. URL-only packages show a generic fallback until updated, and missing or invalid artwork does not disable the plugin. Empty icon requests also close their file handles correctly instead of accumulating open files on repeated views.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show consistent channel names and packaged icons across setup screens [#131511](https://github.com/openclaw/openclaw/pull/131511) Thanks @patrick-erichsen.
+
+**Limits and compatibility**
+
+- Load plugin icons from package assets instead of remote URLs [#131510](https://github.com/openclaw/openclaw/pull/131510) Thanks @patrick-erichsen.
+
+**Bug fixes**
+
+- Close file handles after empty plugin icon requests [#137652](https://github.com/openclaw/openclaw/pull/137652)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep hooks with the current session">
+
+Session-aware command integrations can now receive the current session UUID through the `resolve_exec_env` hook, letting a plugin pass it to scripts for attribution or callbacks. Exporting an environment variable still requires a plugin that chooses to do so.
+
+Configured prompt and model-input hooks also remain active when HTTP scripts or local agent work selects a non-default model, while disabled and excluded plugins stay inactive. Installing an npm hook pack no longer requires changing inherited npm dry-run or download-directory settings; the installer keeps its archive in its own temporary workspace.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Supply session IDs to command-environment plugin hooks [#136912](https://github.com/openclaw/openclaw/pull/136912) Thanks @onevcat, @obviyus, @larrylhollan, @zhipingzhang.
+- Preserve configured hooks when switching away from the default model [#138979](https://github.com/openclaw/openclaw/pull/138979) Thanks @xialonglee, @obviyus, @syncword.
+- Keep npm hook-pack downloads in the installer workspace [#137955](https://github.com/openclaw/openclaw/pull/137955)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue external-agent tasks within their permissions">
+
+[A2A tasks](https://docs.openclaw.ai/channels/a2a#security) that need an execution approval now keep their original task and reply path through the operator's decision, including peers without an outbound URL. Ordinary text such as “Explain /help please” reaches the agent unchanged.
+
+A2A integrations must send plain-text tasks for agent work and use an authorized human command surface for slash commands. Leading-slash requests are rejected, even with permissive command allowlists or a `ROLE_USER` message value. The routed agent keeps its permitted tools, and approval still belongs to an authorized operator.
+
+For IDEs using the Gateway-backed ACP bridge, an externally stopped run can show its carried error cause instead of only an unexplained cancellation. Recording long ACP sessions also avoids repeatedly loading previous message payloads while preserving saved replay. On MCP process tools and Codex's OpenClaw sandbox process tool, accepted final results clear their matching completion notice so it is not repeated later.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Explain externally aborted ACP runs with their carried error cause [#132378](https://github.com/openclaw/openclaw/pull/132378) Thanks @wangmiao0668000666, @obviyus.
+- Clear matching completion notices after MCP HTTP writes or accepted Codex sandbox results; native Codex execution and /tools/invoke remain separate [#138523](https://github.com/openclaw/openclaw/pull/138523)
+
+**Improvements**
+
+- Record ACP updates without repeatedly loading saved conversation history [#138631](https://github.com/openclaw/openclaw/pull/138631)
+
+**Security and trust**
+
+- Reserve slash commands for users and retain A2A task completion after approval [#138731](https://github.com/openclaw/openclaw/pull/138731) Thanks @eleqtrizit.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read directory results and locate fetched files">
+
+Direct calls to [File Transfer directory tools](https://docs.openclaw.ai/nodes#agent-file-transfers) now give the agent usable filenames and distinguish files from directories. A listing can continue after its last displayed entry, and fetched directories show the saved root and relative paths needed to open the files locally. Large fetched trees remain saved even when only part of their manifest fits in the text result; the result explains how to inspect omitted files, and reports when an unrepresentable path prevents text pagination from advancing.
+
+Successful individual file fetches also expose both their saved path and a reusable media ID, so an authorized write tool can copy those bytes without guessing at a hidden identifier. Restricted tool sets receive self-contained Bitable and search guidance without being sent to unavailable companion tools. If Bitable creates an application but cannot retrieve its table metadata, the guidance now tells the agent to keep the successfully created application.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Make restricted-tool guidance self-contained and file fetch receipts reusable [#137213](https://github.com/openclaw/openclaw/pull/137213)
+- Expose bounded directory names, text pagination, and saved file paths in direct tool results [#138542](https://github.com/openclaw/openclaw/pull/138542) Thanks @igs-rogenlo.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve plugin state through cleanup">
+
+Restoring a plugin registry now cancels obsolete cleanup that was still queued, preserving its saved session state and reporting only cleanup changes that actually committed. Choosing cleanup targets also avoids decoding large saved prompts, reducing that particular source of pauses while keeping retained content intact.
+
+Looking up or listing saved plugin artifacts reads committed data without creating an absent shared store. Missing storage produces an empty result, while damaged or unsupported storage still reports an error. Cleanup that writes to storage remains a separate operation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Read plugin artifacts without creating shared storage [#138505](https://github.com/openclaw/openclaw/pull/138505)
+- Use session metadata to reduce plugin cleanup pauses [#138946](https://github.com/openclaw/openclaw/pull/138946)
+- Cancel obsolete queued cleanup when plugin state is restored [#138957](https://github.com/openclaw/openclaw/pull/138957)
+- Return unclaimed webhook and API retry or not-found responses without waiting for dashboard startup [#138894](https://github.com/openclaw/openclaw/pull/138894)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Set up the Lobster plugin">
+
+The [Lobster setup guide](https://docs.openclaw.ai/tools/lobster#enable) now includes the missing prerequisite. Install the optional official plugin with `openclaw plugins install @openclaw/lobster`, restart with `openclaw gateway restart`, then allow its tool. The tool remains unavailable in sandboxed tool contexts. These are corrected setup instructions for the existing integration.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Document the missing Lobster plugin installation and restart steps [#138563](https://github.com/openclaw/openclaw/pull/138563) Thanks @miguelbranco80.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Security and Privacy
+
+If you run several agents on one Gateway, review their conversation access before upgrading. Where the settings were previously omitted, agents with session tools now gain access to other agents’ conversations, including other users’ transcripts. Choose narrower session visibility, restrict the participating agents, or disable ordinary cross-agent access if that sharing is not what you intend. Alongside this change, approvals follow current permissions through more of a task, switching Gateways retires the previous Gateway’s automatic skill trust, and conversation cleanup preserves data belonging to other agents.
+
+<AccordionGroup>
+
+<Accordion title="Review shared conversation access after upgrading">
+
+Agents can now cooperate across one Gateway without first enabling two settings. Omitted `tools.sessions.visibility` changes from `agent` to `all`, and omitted `tools.agentToAgent.enabled` changes from `false` to `true`, allowing agents with the relevant tools to list, read, search, message, and inspect other agents’ sessions. Existing explicit restrictions still apply, but leaving these settings unset on an older installation now permits broader access on upgrade.
+
+The [session visibility settings](https://docs.openclaw.ai/gateway/config-tools#tools-sessions) let you set `tools.sessions.visibility` to `agent` for the current agent’s conversations or `self` for only the current conversation. `agent` can still include other users’ conversations under that agent. To keep selected agents working together, set an explicit `tools.agentToAgent.allow` list that includes both the requesting and receiving agents, or set `tools.agentToAgent.enabled` to `false` to block ordinary cross-agent access. An omitted or empty allowlist permits all agent pairs when access is enabled, and deleting an agent can empty that list, so check it again after removal.
+
+There are important boundaries to those choices. Under `tree` or `all`, requester-owned native subagent and ACP child sessions remain reachable even when agent-to-agent access is disabled. `tree` also lets the canonical main session reach all same-agent conversations, while `self` stays limited to its current conversation. Sandboxing restricts what the sandboxed caller can reach; it does not hide its transcripts from another permitted caller. Incognito sessions remain hidden from these tools, and `memory_search` remains agent-scoped while `sessions_search` searches transcripts within the permitted scope.
+
+Run `openclaw security audit` to identify agents that retain unrestricted cross-agent session-tool access and see narrowing guidance. These are controls within [one trusted Gateway](https://docs.openclaw.ai/gateway/security#scope-one-trust-boundary-per-gateway), not isolation from its administrators. Mutually untrusted users need separate Gateways and credentials, ideally under separate OS users or on separate hosts.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Default to shared cross-agent session access with narrowing controls and audit guidance [#136755](https://github.com/openclaw/openclaw/pull/136755)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep administrative and app approvals with current authority">
+
+When you ask an agent to change an OpenClaw setting, [effective Full Access](https://docs.openclaw.ai/gateway/permission-modes#delegated-setup-and-repair) can now carry that permitted change through without a redundant approval card, including when Full Access comes from the configured default. Restricted runs still need approval, and operation restrictions, tool policy, and live permission checks continue to apply. In Guarded mode, the requesting tool waits for the actual result of Allow, Deny, expiry, or failure, so dismissing a card no longer leaves the agent reporting that it is waiting for a change that already finished. Stop cancels the pending request, and a late approval cannot revive it.
+
+Codex connected-app actions in ask mode also request approval within the current native thread, including resumed conversations and side questions, without rewriting saved app preferences. If an ordinary app-inventory check times out, chat can continue with those app tools disabled; their availability is separate from permission to use them, and scheduled work retains its stricter authority checks. Native administrative requirements still apply. Managed ACP sessions using the optional plugin-tools bridge now hide denied plugin tools and reject direct calls to them.
+
+For updates requested through an external chat channel, OpenClaw checks the requester’s current owner access again after service shutdown and immediately before starting the updater. Revocation at that point prevents the launch and restores the stopped service. It does not cancel an updater that has already started.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Honor effective Full Access for delegated OpenClaw changes, preserve setup artifact selection, and finish chat metadata work before shutdown [#136036](https://github.com/openclaw/openclaw/pull/136036)
+- Keep delegated approvals attached to their final outcome [#137017](https://github.com/openclaw/openclaw/pull/137017). Thanks @kevinheneveld, @benmillerat, @fray-ai
+
+**Security and trust**
+
+- Enforce agent restrictions on ACP plugin tool calls [#136546](https://github.com/openclaw/openclaw/pull/136546). Thanks @mmaps
+- Recheck chat ownership before detached updates start [#137312](https://github.com/openclaw/openclaw/pull/137312)
+- Scope Codex app approvals to native threads and recover ordinary inventory timeouts [#137383](https://github.com/openclaw/openclaw/pull/137383). Legacy managed-layer app settings may need moving to a supported user or project configuration layer.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep identities and device credentials separate">
+
+The shared Gateway owner profile now stays separate from personal profiles and their GitHub connections. Shared-token or password access cannot absorb a person’s identity through an owner-profile merge, and adding the first personal identity no longer imposes multi-person catalog restrictions on an otherwise solo Gateway. If an unreleased build left a malformed owner profile, `openclaw doctor --fix` followed by reconnecting repairs supported cases while preserving the person’s data. GitHub-backed Cloudflare Access sign-ins also reuse verified public profile metadata and respect quota retry deadlines, while current identity bindings and permissions remain checked.
+
+On a Mac, the local node now reuses credentials belonging to the selected Gateway, and switching Gateways retires the previous Gateway’s automatic skill permissions. The Exec Approvals pane refreshes its trusted commands and agent choices while keeping unfinished allowlist edits. Older Mac credentials with unknown Gateway ownership may require pairing again through the existing **Approve on gateway** prompt. On Windows, an approved device can move among the CLI, TUI, and Node Host without another approval solely for equivalent platform metadata; genuine identity and permission changes still go through their checks.
+
+[Device token rotation and revocation](https://docs.openclaw.ai/cli/devices) now complete for authorized callers and return the final result before self-management disconnects the client. Self-rotation can return the replacement token, but CLI output does not automatically save it for the next connection. Shared-secret callers and callers rotating another device receive metadata without the replacement bearer token. Removing a paired device also runs its worker cleanup if the requesting connection loses authorization after removal is committed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Avoid repeat Windows approvals when switching core clients, and preserve unlisted Node Host runtime names [#127177](https://github.com/openclaw/openclaw/pull/127177). Thanks @wszkxlllll, @obviyus, @borjaruizm
+- Report pairing-store read failures in allowlist results while retaining configured entries and retry guidance [#132397](https://github.com/openclaw/openclaw/pull/132397). Thanks @sebtardif, @obviyus, @shojikumaru
+- Reuse verified GitHub profile metadata and respect sign-in quota cooldowns [#137949](https://github.com/openclaw/openclaw/pull/137949). Public profile metadata can be up to 15 minutes old; first-time sign-ins still require successful verification.
+- Complete authorized token rotation and revocation with final replies [#138492](https://github.com/openclaw/openclaw/pull/138492). Thanks @obviyus. Existing grant ceilings remain, and the separate retained-scope approval mismatch remains unresolved.
+- Reconcile removed-device workers even after the requesting caller retires [#138625](https://github.com/openclaw/openclaw/pull/138625). Thanks @obviyus. Provider cleanup can still fail, and the committed-removal success diagnostic can still be missing in this race.
+
+**Security and trust**
+
+- Prevent shared owner profiles from absorbing personal identity and GitHub access [#137022](https://github.com/openclaw/openclaw/pull/137022). Ambiguous legacy UUID-only owner bindings remain outside the repair.
+- Isolate Mac node credentials by Gateway ownership [#137048](https://github.com/openclaw/openclaw/pull/137048). Thanks @vincentkoc, @bastero
+- Retire automatic skill trust when changing Gateways [#137563](https://github.com/openclaw/openclaw/pull/137563). Manual allowlists and local policies remain independent, and a failed same-Gateway refresh can retain trust. The final application check does not provide atomic authorization at OS process spawn.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Protect current conversations during reads and removal">
+
+On shared installations with operator roles, knowing another person’s draft session key no longer lets a view, suggest, or write caller read its details or messages. Transcript reads check access again after loading, so revocation or replacement of the conversation during the read prevents disclosure; creators and administrators retain access. Managed image, thumbnail, and artifact downloads also follow the current conversation history, closing access when a reset or branch change removes the attachment from that history, even if an old archive still contains it.
+
+Deleting a conversation now retains current and historical data if the original caller loses authority before the deletion commits. Deleting one agent’s global session also preserves other agents’ saved plugin state and timestamps. Selected-agent global-session reads, delivery, boards, run lookup, search checks, and GitHub publication keep the explicitly selected agent, although retained-global links and unscoped session-list ownership still have separate unresolved cases.
+
+[Agent and experimental Claw removal](https://docs.openclaw.ai/cli/claws#remove-an-installed-claw) refuses to proceed while a database is actively in use and preserves directories containing another agent’s registered data. If session cleanup or transcript archiving fails after configuration removal, the result reports partial cleanup instead of completion. Correct the reported error, preview and retry removal, and finish cleanup before recreating the agent. Conversation deletion can still wait on native cleanup or database settlement, so these permission checks do not establish a total deletion timeout.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Enforce draft visibility for exact-session reads and recheck access after loading [#136900](https://github.com/openclaw/openclaw/pull/136900). Thanks @vincentkoc. Deployments without configured operator roles retain their existing policy.
+- Reject session deletion when the original caller is no longer authorized [#137672](https://github.com/openclaw/openclaw/pull/137672)
+- Stop serving attachments absent from current conversation history [#138377](https://github.com/openclaw/openclaw/pull/138377). Malformed visible history rejects access without deleting attachment records or files; full-history checks still run per request.
+
+**Bug fixes**
+
+- Protect active and shared agent data and report partial removal cleanup [#138693](https://github.com/openclaw/openclaw/pull/138693)
+- Keep other agents’ plugin state when deleting a global session [#138925](https://github.com/openclaw/openclaw/pull/138925)
+- Keep global-session actions and publication on the selected agent, including fresh-session creation and initial mentions [#138930](https://github.com/openclaw/openclaw/pull/138930). An updated custom UI paired with an older Gateway is unsupported.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Limit credentials and preserve structured redaction">
+
+Local utilities used to inspect busy ports, identify processes, and clear a port now receive a limited operating-system environment instead of inheriting unrelated provider credentials, application tokens, proxy settings, and runtime overrides. This is scoped to those diagnostic helpers. Redacted logs and sanitized tool results also keep valid JSON fields that could previously disappear, including literal `__proto__` fields, while still hiding nested secrets.
+
+[Doctor recovery reports](https://docs.openclaw.ai/cli/doctor#session-sqlite-migration) keep report-bearing links out of terminal and JSON output and preserve the approved report when a GitHub submission has an uncertain outcome. A later run checks for the same report instead of automatically posting again, and declining consent keeps reporting local. Sanitized report bodies can still appear in JSON. Once a submission receipt is claimed, its version-4 recovery manifest cannot be read by older Doctor writers that only understand versions 1–3, even if the claim is later cleared.
+
+Remote workers now reclaim abandoned private skill copies before preparing their next turn, including a turn that selects no skills. Cleanup failures stop preparation for retry, and disconnected workers have no cleanup deadline. Private credential-file writes also retain automatic repair of overly permissive OpenClaw directories with the filesystem-library update, while transcript repair preserves directory permissions and file-transfer refusals retain destination details where available.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Keep Doctor recovery-report links private and prevent automatic duplicate submissions [#137527](https://github.com/openclaw/openclaw/pull/137527). Thanks @fuller-stack-dev, @obviyus. Uncertain submissions can remain unresolved and do not authorize resubmission.
+- Recover abandoned private skill copies when remote workers start another turn [#137800](https://github.com/openclaw/openclaw/pull/137800). Thanks @fuller-stack-dev. Background commands cannot rely on these paths beyond their turn’s lifetime.
+- Restrict environment inheritance for port and process diagnostics [#138047](https://github.com/openclaw/openclaw/pull/138047). Normal agent, Gateway, and updater environments and separate Doctor/TUI probes are outside this change.
+
+**Bug fixes**
+
+- Preserve own JSON fields when redacting logs and tool results [#138118](https://github.com/openclaw/openclaw/pull/138118)
+- Preserve private-file writes and permission repair with fs-safe 0.8.1 [#138500](https://github.com/openclaw/openclaw/pull/138500). The documented ancestor-replacement limitation remains for processes already able to modify the user’s directory tree.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Validate installed packages and HTTP inputs">
+
+Installing an npm plugin with an expected integrity checksum now stops with a clear error if the registry omits the checksum needed to verify it. Those registries must supply integrity metadata for pinned installs to succeed; unpinned installations and the existing consent flow for a present but mismatched checksum keep their behavior.
+
+Crafted SVG site icons that could freeze conversations and web requests are now rejected without triggering that validation freeze, and valid self-closing SVG roots pass the repaired check. HTTP-client dependencies also receive security updates, while [proxy exception matching](https://docs.openclaw.ai/tools/web-fetch#trusted-env-proxy) handles a single trailing DNS dot consistently in either the destination or `NO_PROXY` entry. Requests that bypass the proxy retain the normal direct-connection DNS checks.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Reject checksum-pinned plugins when registry integrity is missing [#136725](https://github.com/openclaw/openclaw/pull/136725). Thanks @eleqtrizit
+- Prevent crafted SVG icons from freezing the Gateway [#136826](https://github.com/openclaw/openclaw/pull/136826). Thanks @lzhan011, @obviyus
+- Align trailing-dot proxy exceptions and update HTTP-client security fixes [ebba786b](https://github.com/openclaw/openclaw/commit/ebba786b022386664e73583ae7df7e447dffafe8)
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Quality-of-Life Improvements
+
+Swarm is now available to eligible agents without a separate enablement step, so your Claw can divide a job among helpers and collect their answers using the tools you already allow. Code Mode can also keep working after a tool error, inspecting what happened and completing the remaining changes in the same conversation. Around that work, conversations are easier to organize, long histories interfere less with other activity, and command results give you more useful information when something stops or fails.
+
+<AccordionGroup>
+
+<Accordion title="Use Swarm without enabling a separate lab">
+
+[Swarm](https://docs.openclaw.ai/tools/swarm) lets an agent coordinate several helpers and collect their results, and eligible agents now have it available by default. It remains experimental and follows your existing tool permissions and limits, with an explicit opt-out in **Settings → Agents & Tools → Labs → Swarm**. OpenClaw Code Mode remains a separate opt-in.
+
+Larger Swarm jobs in Code Mode now queue calls when the bridge is full, allowing accepted work to advance as space opens without manually splitting the job into batches. Stopping the run prevents its remaining queued calls from launching, and pauses within the same process preserve the original arguments. Result collection also preserves the text or structured format requested when each helper started, while agents sharing global sessions can use the same group name without sharing one another's concurrency allowance or retention schedule.
+
+Existing Codex chats keep the tools they started with. Use `/new` or `/reset` in an ordinary unlocked chat to get the current tools; keep a supervised chat intact and start a separate ordinary session from the global **New Session** page with a concrete Codex-backed model. Saved Codex scripts that call `tools.openclaw__agents_wait` must change to `tools.agents_wait`.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Enable eligible Swarm coordination by default with explicit opt-out, preserve custom limits and authored settings, and cache missing avatars briefly [#136514](https://github.com/openclaw/openclaw/pull/136514). Addresses [#136472](https://github.com/openclaw/openclaw/issues/136472).
+
+**Bug fixes**
+
+- Queue larger Code Mode Swarm fan-outs within existing limits; queued requests survive same-process snapshots, not restarts [#136845](https://github.com/openclaw/openclaw/pull/136845). Addresses [#136834](https://github.com/openclaw/openclaw/issues/136834).
+- Reduce repeated registry work while waiting for Swarm children, with local completion notifications and periodic cross-process reads [#138053](https://github.com/openclaw/openclaw/pull/138053).
+- Preserve Swarm result formats and expose `tools.agents_wait` in Codex; missing structured submissions finish with `schemaError`, while invalid submissions receive a corrective attempt [#138056](https://github.com/openclaw/openclaw/pull/138056).
+- Separate same-named Swarm groups by agent in global sessions, including restored queues and completed-group archival [#138057](https://github.com/openclaw/openclaw/pull/138057).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue Code Mode after a tool error">
+
+A failed tool call no longer puts [Code Mode](https://docs.openclaw.ai/tools/code-mode#recover-from-tool-errors) into a separate read-only recovery mode. Your agent can read the error, inspect the current files or settings, and make the remaining changes without restarting the conversation or being limited to one further edit. Failed programs are not automatically replayed, and because an earlier call may have partly succeeded, the agent needs to check what already happened before repeating an action. Normal permissions and approvals still apply to every later call.
+
+The compact tool reference now includes whole-number requirements and numeric ranges, including the reminder that file-read offsets start at one. Large results and diagnostics also take less work to fit within the existing output limits, and obsolete tool resources can be released after refreshes and reloads while descriptions for tools still in use stay current.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Fit large Code Mode output without repeatedly serializing trial prefixes, preserving existing truncation guidance and output limits [#138048](https://github.com/openclaw/openclaw/pull/138048).
+- Pre-group built-in tool definitions for catalog requests while preserving current capability filtering and fresh responses [#137237](https://github.com/openclaw/openclaw/pull/137237).
+
+**Bug fixes**
+
+- Preserve Code Mode execution time across clock rollback during approval waits; saved-run wall-clock expiry is unchanged [#134703](https://github.com/openclaw/openclaw/pull/134703). Thanks @qingminglong, @obviyus.
+- Continue Code Mode tasks after failures without a separate recovery mode or mutation budget; inspect partial effects before repeating work [#138044](https://github.com/openclaw/openclaw/pull/138044). Related tracker [#131340](https://github.com/openclaw/openclaw/issues/131340) was closed without implementing its broader effect-reconciliation proposal. Thanks @vacinc.
+- Include numeric ranges and whole-number requirements in compact tool hints; full schemas remain available through `describe()` [#138744](https://github.com/openclaw/openclaw/pull/138744).
+- Release obsolete Code Mode tool resources after refresh and reload while keeping live descriptions synchronized [#137739](https://github.com/openclaw/openclaw/pull/137739).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Organize conversations and inspect related tasks">
+
+You can ask your agent to organize the conversations it is allowed to manage through [session tools](https://docs.openclaw.ai/concepts/session-tool), including applying the same group, pin, model, or supported setting to as many as 100 sessions at once. A batch reports which changes succeeded and which failed, so one inaccessible conversation does not discard the successful changes. Interrupted group renames and deletions keep the groups needed by the remaining conversations and can be reloaded and retried; `group_set` manages the group catalog and does not move conversations between groups.
+
+The Tasks view does less repeated history reading and checks current permissions before returning a page. A conversation with only a few related background tasks can also show those tasks while unrelated work is busy elsewhere, and profile merges now ask clients to restart pagination so newly accessible tasks are included. If accepting a task suggestion fails because its source agent was removed, the suggestion stays pending so you can restore that agent and retry it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Clarify saved workspace and identity-source locations in CLI output; `--workspace` locates identity files without moving the agent, and JSON adds `storedWorkspace` [#126320](https://github.com/openclaw/openclaw/pull/126320). Addresses [#102288](https://github.com/openclaw/openclaw/issues/102288). Thanks @thinkr1, @obviyus, @erathia65.
+- Organize sessions with role-aware tools and bulk settings updates, retain retryable group changes, finish accepted resets only for the captured session, and label the shell tool “Background Shell”; self-archive remains a single deferred patch [#136952](https://github.com/openclaw/openclaw/pull/136952). Addresses [#136818](https://github.com/openclaw/openclaw/issues/136818).
+- Reduce session-history work for task lists and keep incognito lookups in their process-only store after main-agent removal [#137733](https://github.com/openclaw/openclaw/pull/137733).
+- Batch task access reads while preserving fresh final authorization and reducing unnecessary pagination retries [#137811](https://github.com/openclaw/openclaw/pull/137811).
+- Expire task cursors after committed profile-access changes, including email or GitHub profile merges and owner-profile restoration [#137966](https://github.com/openclaw/openclaw/pull/137966).
+- Keep sparse session task lists available during unrelated task activity; large candidate sets and global lists still reject unstable revisions [#138738](https://github.com/openclaw/openclaw/pull/138738).
+- Keep task suggestions retryable after temporary source-agent removal across source-session, local, worktree, and cloud modes; recovery across a Gateway restart is not established [#138653](https://github.com/openclaw/openclaw/pull/138653).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep long conversation work responsive">
+
+Preparing a long saved conversation now happens in background workers so that reading its history does not hold up unrelated Gateway activity. Context loading also batches message reads, startup can check for existing messages without decoding their full contents, and resuming an older view of a conversation uses fewer database statements when saving the next message. These changes reduce interference and unnecessary work while preserving the selected conversation branch; the amount of history still matters, and the work does not have a fixed memory cost.
+
+Branching keeps your current conversation in place until the new branch has saved, preserves current session details, and prevents an older run from writing after another run takes over. Shared databases also retain the correct agent ownership in session views and save the activity records needed to inspect non-default agents. Incognito history follows the active branch again while remaining in memory, and stopped history workers release their database leases when cleanup succeeds. A cleanup failure stays visible with restart guidance before deletion.
+
+Stopping or timing out compaction now prevents further preparation once cancellation is observed, including after a session handoff, and native CLI cancellation is reported as `compaction aborted`. An operation already in progress may still need to settle before cleanup completes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Batch eager conversation payload reads when preparing model context, preserving message order and lazy full-fidelity readers [#138168](https://github.com/openclaw/openclaw/pull/138168).
+- Check for saved conversation messages through the identity index without decoding indexed payloads; unclassified imports may still require parsing [#138200](https://github.com/openclaw/openclaw/pull/138200).
+- Reduce database work when appending to a resumed long conversation while preserving selected branches, cycles, and missing-parent handling [#138508](https://github.com/openclaw/openclaw/pull/138508).
+
+**Bug fixes**
+
+- Read long conversation history in bounded workers while keeping Gateway activity responsive; prevent canceled compaction or Workshop preparation from starting later work, suppress late Codex previews after closure, and release startup MCP resources [#138094](https://github.com/openclaw/openclaw/pull/138094).
+- Save conversation branches atomically before switching active identity, preserving current metadata and rejecting outdated writers [#138178](https://github.com/openclaw/openclaw/pull/138178).
+- Keep agent activity in shared session databases for subsequent session tail and trajectory export; events never saved cannot be recovered [#138240](https://github.com/openclaw/openclaw/pull/138240). Addresses [#138237](https://github.com/openclaw/openclaw/issues/138237).
+- Preserve agent ownership in shared session views, dashboard preparation, and parent-child filtering, including retired-agent lineage [#138380](https://github.com/openclaw/openclaw/pull/138380).
+- Keep obsolete runs from adding publication reports after session takeover, retain less transcript text during publication and cloud-workspace reporting, and keep failed writes retryable [#138511](https://github.com/openclaw/openclaw/pull/138511).
+- Restore incognito branch history and release stopped history-worker leases; cleanup can fail visibly, while sustained-append retry cadence and oversized search output remain separate work [#138585](https://github.com/openclaw/openclaw/pull/138585).
+- Stop stale compaction preparation after cancellation or session handoff and report canceled native CLI work as aborted [#138649](https://github.com/openclaw/openclaw/pull/138649). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read command outcomes and monitoring output">
+
+Command results give your agent more useful clues about what happened. A foreground command that exits unsuccessfully without printing anything now explicitly says `(no output)` beside its exit code, and background process lists distinguish an overall timeout from a command that stopped producing output. Polling a completed job clears its pending completion notice only after confirmed chat delivery or successful saving of the tool result, keeping that notice available when delivery or persistence fails.
+
+For people working in the terminal, a URL used as an initial message can appear before or after the destination session URL, as shown in the [TUI guide](https://docs.openclaw.ai/cli/tui), and unusually long wrapped table cells no longer hit the repaired argument-limit crashes. There are two small scripting changes to account for. Stopping `openclaw sessions tail --follow` now returns 130 for Ctrl-C or 143 for termination instead of success, and diagnostics exports reject empty `--log-lines` or `--log-bytes` values. Omit those flags when you want their defaults.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show timeout causes in background process lists without changing timeout enforcement or consuming completion notices [#133318](https://github.com/openclaw/openclaw/pull/133318). Addresses [#133314](https://github.com/openclaw/openclaw/issues/133314). Thanks @leon-sk668, @altaywtf.
+- Prepare live command previews only after throttle admission while preserving every activity update and final results [#138103](https://github.com/openclaw/openclaw/pull/138103).
+
+**Bug fixes**
+
+- Label empty output on unsuccessful foreground commands while preserving quiet successful results [#136682](https://github.com/openclaw/openclaw/pull/136682). Addresses [#136645](https://github.com/openclaw/openclaw/issues/136645). Thanks @liuwqgit, @vincentkoc, @obviyus, @cataldoc.
+- Release discarded command-output buffers before the child exits while preserving retained output and truncation information [#136876](https://github.com/openclaw/openclaw/pull/136876).
+- Acknowledge polled job completions after confirmed delivery or persistence, preserving unrelated notices and notices for replacement jobs [#138188](https://github.com/openclaw/openclaw/pull/138188).
+- Accept URL message values before the terminal session destination [#137818](https://github.com/openclaw/openclaw/pull/137818). Addresses [#137815](https://github.com/openclaw/openclaw/issues/137815).
+- Render oversized wrapped table cells without argument-spread crashes while preserving Unicode, styles, links, padding, and borders [#138656](https://github.com/openclaw/openclaw/pull/138656).
+
+**Limits and compatibility**
+
+- Reject empty log limits in diagnostics export commands before contacting the Gateway or creating a support ZIP; omit unset options to use defaults [#137830](https://github.com/openclaw/openclaw/pull/137830). Thanks @alix-007, @altaywtf.
+- Return exit status 130 for Ctrl-C and 143 for termination during session tail follow, after cleanup; read failures retain status 1 [#138581](https://github.com/openclaw/openclaw/pull/138581). Addresses [#127348](https://github.com/openclaw/openclaw/issues/127348). Thanks @moerai, @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use exact paths and working guide links">
+
+Folder browsing now preserves the exact path returned in a listing, including a trailing space, so selecting `Project ` opens that folder instead of a sibling named `Project`. The Files pane also accepts contained names such as `..notes`, and matching configured memory sources can discover and read those files without mistaking the name for a parent-directory traversal. This fixes directory browsing; New Session submission and saved-preference handling are separate paths.
+
+Documentation section links have been repaired across setup, troubleshooting, permissions, transcription, and skill-trust guidance. Computer-use and Podman instructions point to their intended sections, and maturity pages have unique jump targets without changing their recorded scores or implying a new QA run.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve significant whitespace when browsing Gateway and node directories while retaining containment and permission checks [#137956](https://github.com/openclaw/openclaw/pull/137956). Addresses [#137943](https://github.com/openclaw/openclaw/issues/137943).
+- Accept contained dot-prefixed paths in Files and configured memory sources, including matching change-event handling, without loosening symlink or hardlink restrictions [#138156](https://github.com/openclaw/openclaw/pull/138156).
+
+**Documentation**
+
+- Repair computer-use setup links and duplicate Podman section anchors, and correct the maturity generator's duplicate targets [#137879](https://github.com/openclaw/openclaw/pull/137879).
+- Repair documentation section links and duplicate maturity anchors, regenerating maturity output from historical evidence with unchanged scores [#138121](https://github.com/openclaw/openclaw/pull/138121).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read usage and failure information">
+
+Checking usage and costs no longer loads large saved skill or system prompts just to prepare the metrics, avoiding the associated history-processing stalls while leaving full context available where it is needed. Turn completion and usage displays also skip fallback price lookups when recorded costs already suffice, or when only token counts are being shown. The pricing calculation and displayed costs are unchanged, and estimated costs remain estimates.
+
+When a run fails without enough information to classify the cause, the message now says the agent run failed and keeps the available model context instead of blaming the provider. Recognized provider errors retain their specific guidance, so the wording reflects what OpenClaw actually knows without claiming to diagnose or repair an unknown failure.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse idle deadlines during bounded buffered response reads, including buffered media downloads, while preserving total deadlines, byte limits, and cancellation; streaming consumers retain per-chunk deadlines [#138005](https://github.com/openclaw/openclaw/pull/138005).
+- Defer fallback pricing when recorded usage costs already suffice or a footer only needs token counts [#138013](https://github.com/openclaw/openclaw/pull/138013).
+
+**Bug fixes**
+
+- Load usage metrics without full saved prompts while keeping full session-context reads available [#138428](https://github.com/openclaw/openclaw/pull/138428).
+- Avoid blaming providers for unclassified agent failures while retaining safe model context and recognized provider guidance [#138201](https://github.com/openclaw/openclaw/pull/138201). Addresses [#137845](https://github.com/openclaw/openclaw/issues/137845). Thanks @shakkernerd, @richard355168, @loulanyue.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Other Bug Fixes
+
+A task can finish its file changes and still lose the answer at the last step, or a conversation repair can fail while the chat is still open. These fixes keep completed work available through specific saving and provider failures, preserve the last committed conversation when a repair fails, and bring command startup under the same timeout and cancellation controls as the work that follows.
+
+<AccordionGroup>
+
+<Accordion title="Keep completed tool work and answer results">
+
+When a file already contains the change you asked for, the agent now treats that as a successful step and continues to the rest of the task, including its final answer. Local CLI agents also keep access to their embedded Gateway tools after starting a run.
+
+Completed work has two more paths back to a useful response. If a temporary provider failure interrupts the final summary after all tools have finished, eligible runs can try a summary without executing those tools again. When a CLI-backed turn has already returned its answer, a later session-saving failure preserves that answer and its usage information instead of automatically repeating the action. Remote computer cleanup failures likewise retain the captured result and the earlier error or interruption, so the cleanup problem remains visible. Resolve that problem and check what the tools already did before retrying work whose outcome is uncertain.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Continue agent tasks after successful no-op file changes [#137036](https://github.com/openclaw/openclaw/pull/137036). Fixes [issue #136951](https://github.com/openclaw/openclaw/issues/136951). Thanks @chelsealong, @obviyus, @deyangar.
+- Preserve completed CLI answers and usage after session-save failure, retain remote cleanup causes, and avoid reporting a successful model for a failed run [#137821](https://github.com/openclaw/openclaw/pull/137821).
+- Recover final summaries after eligible temporary provider failures once tool work has settled, without replaying tools [#138362](https://github.com/openclaw/openclaw/pull/138362). Fixes [issue #126848](https://github.com/openclaw/openclaw/issues/126848). Thanks @vacinc, @todddickerson.
+- Keep local Gateway tools available to CLI agent runs [#138477](https://github.com/openclaw/openclaw/pull/138477). Fixes [issue #138471](https://github.com/openclaw/openclaw/issues/138471).
+
+**Limits and compatibility**
+
+Summary recovery preserves intentional silence, cancellation, existing output, and unfinished asynchronous work. It does not cover every socket failure. Completed-result preservation addresses these specific failure paths; security-sensitive cleanup can still reject completion.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve accepted conversation history">
+
+A failed conversation repair now leaves both the active chat and its saved history at their last committed state, allowing the same repair to be retried once the problem is resolved. When an authorized rewrite succeeds, the message already accepted for the current turn stays in the active conversation exactly once, including through repeated rewrites and later replay.
+
+History-index rebuilds also wait for writes they have already accepted before reporting that they have finished, while keeping the database resources needed to complete them. Alongside those changes, stored messages avoid false “edited” errors caused by serialization, and damaged session metadata follows the full reader's parsing rules when it is used for listings and cleanup decisions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep live and saved history intact when transcript repair fails [#138412](https://github.com/openclaw/openclaw/pull/138412).
+- Wait for accepted history-index writes before settling rebuilds and avoid an unnecessary database reopen under cache pressure [#138429](https://github.com/openclaw/openclaw/pull/138429).
+- Keep session listings and cleanup decisions consistent with full-record parsing for metadata containing a literal NUL [#138733](https://github.com/openclaw/openclaw/pull/138733).
+- Avoid false edited-message errors when stored transcript receipts normalize optional metadata and media [#138872](https://github.com/openclaw/openclaw/pull/138872).
+- Keep accepted messages active when conversation history is rewritten [#138967](https://github.com/openclaw/openclaw/pull/138967). Thanks @fuller-stack-dev.
+
+**Limits and compatibility**
+
+These repairs preserve current history; they do not recover data lost earlier. Actual message edits, stale conversation branches, and lost run authority still block annotation or relocation. Malformed-record handling retains older Node versions' full-reader behavior and does not revalidate inventory already marked valid.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Stop stalled command preparation">
+
+Command timeouts and cancellation now apply while a process is still starting, including service-managed commands waiting for credentials, so those startup waits can return a timeout or cancellation result. The first cancellation reason stays attached to the run even if a timeout fires afterward.
+
+Cancelling a request also releases runtime state that nobody else needs and skips obsolete workspace preparation that has not started yet. Other callers can keep using shared preparation, and finished or combined queued chats release their unused cancellation listeners. Work already performing discovery is not forcibly interrupted by this cleanup, and stopping startup does not guarantee that every descendant of an interactive terminal process has been removed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Apply command timeouts and cancellation while processes are still starting, including blocked credential delivery [#136507](https://github.com/openclaw/openclaw/pull/136507). Thanks @sebtardif, @obviyus.
+- Fail and clean up POSIX commands on oversized private control messages [#136805](https://github.com/openclaw/openclaw/pull/136805). Thanks @sebtardif, @obviyus.
+- Avoid question-answer errors for cancelled ordinary messages when no eligible question is pending [#137899](https://github.com/openclaw/openclaw/pull/137899).
+- Release unused runtime state after cancelled requests and skip their queued preparation [#138458](https://github.com/openclaw/openclaw/pull/138458). Thanks @vincentkoc.
+- Detach retired queued-chat cancellation listeners [#137741](https://github.com/openclaw/openclaw/pull/137741).
+- Stop late tool events after completed-run subscriptions expire while preserving delivery to current session subscribers [#137148](https://github.com/openclaw/openclaw/pull/137148).
+
+**Limits and compatibility**
+
+The POSIX control-message safeguard applies to the private command-management channel, not the amount of ordinary command output. The terminal startup repair retains a known gap in PTY descendant cleanup.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue after a device is permanently offline">
+
+If a paired computer will not reconnect, **Continue on Gateway…** can now move its session back to the computer running OpenClaw so you can resume from the last synced workspace. This is an explicit recovery choice that discards changes still held only on the offline device, so use it when waiting for that device to return is no longer the right option.
+
+The [cloud-session recovery guide](https://docs.openclaw.ai/gateway/cloud-sessions#what-stays-with-the-gateway) explains what remains on the Gateway. Physical cleanup can still be pending after the session becomes available again, and moving the session does not confirm that an old process on the disconnected computer has stopped.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Continue on Gateway when a paired device cannot reconnect, including disconnection during forced cleanup [#137088](https://github.com/openclaw/openclaw/pull/137088).
+
+**Limits and compatibility**
+
+Retrying a historical failed abandonment is available through the RPC in this change, without a corresponding Control UI retry control. Ordinary recovery continues to wait for reconnection and workspace reconciliation; cloud-provider machines retain their physical teardown requirements.
+
+</details>
+
+</Accordion>
+
+<Accordion title="File reads, agent recreation, and runtime housekeeping">
+
+Agents can read from the beginning of a blank line without receiving a false end-of-line error, including when an ordinary Markdown or memory file starts that way. Operators can also delete an agent with file cleanup, recreate the same ID, and create new sessions without restarting the Gateway.
+
+Several narrower changes remove work that no longer needs to be retained. Code Mode can release completed calls' inputs while slower calls continue, compute workers no longer require the parent process to hold their input copies throughout execution, and session-list refreshes can let go of obsolete cached pages. Long-conversation preparation avoids repeated validation and unnecessary copies, while voice processing skips debug-capture filesystem checks when capture is disabled. These changes reduce specific processing and retention costs; total history loading can still be dominated by database reads.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show a conversation's previous runtime accurately in status without false transitions between equivalent Codex names [#136410](https://github.com/openclaw/openclaw/pull/136410). Thanks @zeroaltitude, @obviyus.
+- Keep `openclaw node identity --json` from initializing shared storage or altering configuration during inspection [#136735](https://github.com/openclaw/openclaw/pull/136735). Fixes [issue #136732](https://github.com/openclaw/openclaw/issues/136732).
+- Release parent copies of active compute-worker inputs used by Code Mode and conversation compaction [#137072](https://github.com/openclaw/openclaw/pull/137072).
+- Release obsolete session-list pages during pending refreshes without interrupting their original callers [#137104](https://github.com/openclaw/openclaw/pull/137104).
+- Release settled Code Mode inputs and idle-worker results [#137168](https://github.com/openclaw/openclaw/pull/137168).
+- Keep audio and video metadata-probe deadlines stable through system-clock adjustments, preserving completed partial results [#137185](https://github.com/openclaw/openclaw/pull/137185). Thanks @coderdailyone, @obviyus.
+- Reinitialize session storage when an agent ID is reused after deletion [#137424](https://github.com/openclaw/openclaw/pull/137424). Thanks @ceckert, @obviyus.
+- Reduce long-history preparation costs and skip filesystem discovery for disabled voice debug capture [#138485](https://github.com/openclaw/openclaw/pull/138485).
+- Allow file reads to begin at an empty first or later line [#138641](https://github.com/openclaw/openclaw/pull/138641). Fixes [issue #138610](https://github.com/openclaw/openclaw/issues/138610). Thanks @liuwqgit, @obviyus, @benmillerat.
+- Honor existing foreground Gateway ambient-channel, no-color, and log-level flags while preserving values that resemble flags [#138765](https://github.com/openclaw/openclaw/pull/138765). Fixes [issue #138762](https://github.com/openclaw/openclaw/issues/138762).
+
+**Limits and compatibility**
+
+Node identity inspection may still write configured diagnostic logs. Agent recreation does not change transcript-purge policy or the separate `purgeFailed` reporting issue. Media metadata remains best-effort, with the existing cleanup grace and separate ffprobe compatibility limits. Cache cleanup happens on cache operations, and the object-lifetime fixes do not establish a fixed reduction in whole-process memory.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Report empty replies and finish Apple Talk playback">
+
+If final filtering removes everything from a reply, OpenClaw now reports a failure instead of leaving the conversation looking successful with nothing to read, including when a fallback model also produces no visible answer. Deliberate silence and valid delivery or continuation paths keep their existing behavior.
+
+On Apple clients, [Talk relay playback](https://docs.openclaw.ai/nodes/talk#realtime-talk-over-the-gateway-relay-macos) now follows the audio player's actual completion. The speaking state, playback acknowledgments, and microphone echo suppression stay active until queued audio finishes, while pause, interruption, and cancellation can still stop playback earlier.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report empty final replies as failures and wait for actual Apple Talk playback completion; refresh eligible bundled dependencies and matching TypeBox examples [#135177](https://github.com/openclaw/openclaw/pull/135177).
+
+**Limits and compatibility**
+
+Playback coverage used controlled player tests; physical Apple-device playback was not verified in the retained evidence.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Maintainer and Internal Changes
+
+These 514 maintainer-only changes cover repository upkeep, release verification, test infrastructure, and internal code cleanup. The collapsed change list below preserves the complete maintenance record.
+
+<AccordionGroup>
+
+<Accordion title="Repository maintenance and verification">
+
+Release checks now bind more of their evidence to the exact package candidate and preserve the boundaries around older releases, prepared test workspaces, and reviewed exceptions. Dependency audits retry temporary advisory-service failures within a bounded deadline. Under the final policy, incomplete advisory coverage still blocks ordinary CI.
+
+Test cleanup, fixture isolation, and clearer failure reports make repository checks easier to diagnose. CI changes reduce repeated preparation and combine compatible jobs while retaining their checks. Internal refactors reduce repeated work in parsing, rendering, and database access without establishing a general user-facing speedup. The paired Vitest benchmark supports comparison of candidate versions; it does not establish acceptance of a Vitest upgrade.
+
+Contributors running declaration builds must use dependencies owned by the selected checkout. Shared external toolchains are rejected, so affected setups may need a standalone checkout with its own pnpm install.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Verify platform filesystem bindings across package and Docker installs [#132240](https://github.com/openclaw/openclaw/pull/132240). Thanks @romneyda.
+- Share equivalent model-provider projection across compaction paths [#135241](https://github.com/openclaw/openclaw/pull/135241). Thanks @vincentkoc.
+- Share proof-script option parsing without changing command behavior [#135387](https://github.com/openclaw/openclaw/pull/135387). Thanks @vincentkoc.
+- Share session-root lookup logic across discovery paths [#135537](https://github.com/openclaw/openclaw/pull/135537). Thanks @vincentkoc.
+- Simplify service PATH selection and protect the Windows audit bypass [#135646](https://github.com/openclaw/openclaw/pull/135646). Thanks @vincentkoc.
+- Share required SQLite number conversion across storage readers [#135666](https://github.com/openclaw/openclaw/pull/135666). Thanks @vincentkoc.
+- Share existing state-version checks without changing compatibility policy [#135673](https://github.com/openclaw/openclaw/pull/135673). Thanks @vincentkoc.
+- Share diagnostic filename timestamp formatting [#135686](https://github.com/openclaw/openclaw/pull/135686). Thanks @vincentkoc.
+- Share Claude model-reference parsing across plugin paths [#135707](https://github.com/openclaw/openclaw/pull/135707). Thanks @vincentkoc.
+- Share stable mobile release-version validation [#135709](https://github.com/openclaw/openclaw/pull/135709). Thanks @vincentkoc.
+- Share Signal delivered-message key recovery [#135714](https://github.com/openclaw/openclaw/pull/135714). Thanks @vincentkoc.
+- Share replay-context identity matching across transports [#135727](https://github.com/openclaw/openclaw/pull/135727). Thanks @vincentkoc.
+- Share iMessage message-ID normalization while preserving poll matching [#135732](https://github.com/openclaw/openclaw/pull/135732). Thanks @vincentkoc.
+- Share text-and-media presence checks across delivery paths [#135762](https://github.com/openclaw/openclaw/pull/135762). Thanks @vincentkoc.
+- Share runtime-pair defaults across QA reports [#135768](https://github.com/openclaw/openclaw/pull/135768). Thanks @vincentkoc.
+- Share bounded-response cleanup across repository scripts [#135780](https://github.com/openclaw/openclaw/pull/135780). Thanks @vincentkoc.
+- Reuse shared Telegram edit-error classification [#135879](https://github.com/openclaw/openclaw/pull/135879). Thanks @vincentkoc.
+- Share deterministic release sorting while preserving bootstrap checks [#135886](https://github.com/openclaw/openclaw/pull/135886). Thanks @vincentkoc.
+- Share timeout error construction across test and review tools [#135907](https://github.com/openclaw/openclaw/pull/135907). Thanks @vincentkoc.
+- Share MxC lexical path comparison and Windows prefix coverage [#135984](https://github.com/openclaw/openclaw/pull/135984). Thanks @vincentkoc.
+- Remove redundant pairing timestamp adapters [#136009](https://github.com/openclaw/openclaw/pull/136009). Thanks @vincentkoc.
+- Remove redundant Teams timestamp wrappers [#136016](https://github.com/openclaw/openclaw/pull/136016). Thanks @vincentkoc.
+- Simplify test-artifact size-limit parsing [#136034](https://github.com/openclaw/openclaw/pull/136034). Thanks @vincentkoc.
+- Retain WhatsApp event types across socket listeners [#136691](https://github.com/openclaw/openclaw/pull/136691). Thanks @romneyda.
+- Derive configuration response types from Gateway contracts [#136692](https://github.com/openclaw/openclaw/pull/136692). Thanks @romneyda.
+- Share typed browser command sending across CDP callers [#136693](https://github.com/openclaw/openclaw/pull/136693). Thanks @romneyda.
+- Unify existing device-presence reason definitions [#136697](https://github.com/openclaw/openclaw/pull/136697). Thanks @romneyda.
+- Exercise cron evaluator caching through scheduling behavior [#136723](https://github.com/openclaw/openclaw/pull/136723).
+- Increase runner capacity for existing Control UI test shards [#136728](https://github.com/openclaw/openclaw/pull/136728).
+- Consolidate usage-template watcher lifetime regressions [#136743](https://github.com/openclaw/openclaw/pull/136743).
+- Avoid worker preparation in focused skill command tests [#136746](https://github.com/openclaw/openclaw/pull/136746).
+- Consolidate Node and Control UI CI jobs while retaining coverage [#136776](https://github.com/openclaw/openclaw/pull/136776).
+- Refresh Control UI translation memory and completeness metadata [#136787](https://github.com/openclaw/openclaw/pull/136787).
+- Record optional Windows and Mac release checks as advisory [#136788](https://github.com/openclaw/openclaw/pull/136788).
+- Separate package release finalization from later native app attachments [#136790](https://github.com/openclaw/openclaw/pull/136790).
+- Disable local-network discovery for benchmark Gateways [#136793](https://github.com/openclaw/openclaw/pull/136793).
+- Require the exact prior daily occurrence in cron tests [#136799](https://github.com/openclaw/openclaw/pull/136799).
+- Update the measured Control UI startup bundle baseline [#136817](https://github.com/openclaw/openclaw/pull/136817). Thanks @vincentkoc, @fuller-stack-dev.
+- Write QR PNG buffers directly to temporary files [#136823](https://github.com/openclaw/openclaw/pull/136823).
+- Use owned hook cleanup in diagnostic tests [#136825](https://github.com/openclaw/openclaw/pull/136825).
+- Remove redundant collections from Tool Search ranking [#136839](https://github.com/openclaw/openclaw/pull/136839).
+- Validate recovery-upgrade baselines without a fixed historical package pin [#136843](https://github.com/openclaw/openclaw/pull/136843).
+- Scan diagnostic tool-call candidates lazily [#136846](https://github.com/openclaw/openclaw/pull/136846).
+- Simplify package basename extraction without changing identity matching [#136849](https://github.com/openclaw/openclaw/pull/136849).
+- Simplify backup JSON-output test scaffolding [#136855](https://github.com/openclaw/openclaw/pull/136855).
+- Avoid temporary path arrays when identifying file references [#136861](https://github.com/openclaw/openclaw/pull/136861).
+- Assert queued input survives a failed Android health refresh [#136867](https://github.com/openclaw/openclaw/pull/136867).
+- Consolidate Kimi search configuration and citation tests [#136871](https://github.com/openclaw/openclaw/pull/136871). Thanks @romneyda.
+- Exercise Grok search behavior without private helper exports [#136872](https://github.com/openclaw/openclaw/pull/136872). Thanks @romneyda.
+- Test MiniMax routing and authorization through the search tool [#136873](https://github.com/openclaw/openclaw/pull/136873). Thanks @romneyda.
+- Consolidate Exa request and result coverage at the tool boundary [#136874](https://github.com/openclaw/openclaw/pull/136874). Thanks @romneyda.
+- Collect strongest device-name matches in one pass [#136877](https://github.com/openclaw/openclaw/pull/136877).
+- Build usage rollup arrays directly from maps [#136902](https://github.com/openclaw/openclaw/pull/136902).
+- Reuse replay-history eviction order while trimming byte limits [#136904](https://github.com/openclaw/openclaw/pull/136904).
+- Normalize progress redraws without intermediate line arrays [#136909](https://github.com/openclaw/openclaw/pull/136909).
+- Report dependency freshness as advisory during release publication checks [#136918](https://github.com/openclaw/openclaw/pull/136918).
+- Resolve shared hook state once per module [#136920](https://github.com/openclaw/openclaw/pull/136920).
+- Remove temporary paragraph-index arrays from Matrix list formatting [#136921](https://github.com/openclaw/openclaw/pull/136921).
+- Consolidate model-catalog fixture resets [#136925](https://github.com/openclaw/openclaw/pull/136925).
+- Skip inactive Code Mode source scans [#136928](https://github.com/openclaw/openclaw/pull/136928).
+- Prepare scheduler alias lookup when the MCP handler is created [#136929](https://github.com/openclaw/openclaw/pull/136929).
+- Extract bundle command descriptions without scanning every prompt line [#136930](https://github.com/openclaw/openclaw/pull/136930).
+- Consolidate settled-turn validation and fallback tests [#136933](https://github.com/openclaw/openclaw/pull/136933).
+- Simplify the existing Doctor browser-warning assertion [#136942](https://github.com/openclaw/openclaw/pull/136942).
+- Avoid idle predecessor promises in FIFO leases [#136944](https://github.com/openclaw/openclaw/pull/136944).
+- Remove redundant plugin auto-enable fingerprints [#136947](https://github.com/openclaw/openclaw/pull/136947).
+- Short-circuit plugin capability classification [#136953](https://github.com/openclaw/openclaw/pull/136953).
+- Reuse character arrays while compacting progress text [#136955](https://github.com/openclaw/openclaw/pull/136955).
+- Skip discarded reasoning collection for BTW side questions [#136959](https://github.com/openclaw/openclaw/pull/136959).
+- Separate UI artifact builds from comparative CSS budget enforcement [#136972](https://github.com/openclaw/openclaw/pull/136972).
+- Consolidate CI checks and reduce runner fanout [#136973](https://github.com/openclaw/openclaw/pull/136973).
+- Remove duplicate Windows restart-test assertion helpers [#136992](https://github.com/openclaw/openclaw/pull/136992).
+- Reuse shared assertions for npm installation warnings [#136994](https://github.com/openclaw/openclaw/pull/136994).
+- Simplify diagnostics translation registration [#137000](https://github.com/openclaw/openclaw/pull/137000).
+- Verify saved mobile credentials reconnect after Gateway restart [#137005](https://github.com/openclaw/openclaw/pull/137005). Thanks @vincentkoc, @bastero.
+- Include Slack QA response and approval timing in structured results [#137013](https://github.com/openclaw/openclaw/pull/137013). Thanks @vincentkoc.
+- Separate interactive Windows lifecycle qualification from headless CI [#137018](https://github.com/openclaw/openclaw/pull/137018).
+- Remove a redundant text-file attachment test [#137019](https://github.com/openclaw/openclaw/pull/137019).
+- Remove the cron execution test proxy and duplicate result type [#137020](https://github.com/openclaw/openclaw/pull/137020).
+- Share documentation anchor and redirect contracts with the publisher [#137038](https://github.com/openclaw/openclaw/pull/137038).
+- Cover cleanup ordering before missing-password supervisor exit [#137045](https://github.com/openclaw/openclaw/pull/137045). Thanks @vincentkoc, @bastero.
+- Reuse shared guards across image-understanding tests [#137047](https://github.com/openclaw/openclaw/pull/137047).
+- Refresh stored translations and locale metadata for device guidance [#137054](https://github.com/openclaw/openclaw/pull/137054).
+- Reuse canonical call guards in heartbeat tests [#137057](https://github.com/openclaw/openclaw/pull/137057).
+- Test Android auth recovery and Wear relay readiness [#137062](https://github.com/openclaw/openclaw/pull/137062). Thanks @vincentkoc, @bastero.
+- Replace duplicate dotenv warning-test guards [#137064](https://github.com/openclaw/openclaw/pull/137064).
+- Simplify diagnostic event privacy and size assertions [#137066](https://github.com/openclaw/openclaw/pull/137066).
+- Remove redundant configuration-directory existence probes [#137073](https://github.com/openclaw/openclaw/pull/137073).
+- Reuse shared recorded-call assertions in approval tests [#137077](https://github.com/openclaw/openclaw/pull/137077).
+- Remove duplicate Code Mode return-value normalization [#137078](https://github.com/openclaw/openclaw/pull/137078).
+- Shared background authorization and scheduling helpers [#137086](https://github.com/openclaw/openclaw/pull/137086).
+- Avoid redundant Unicode budget scans for tool results [#137093](https://github.com/openclaw/openclaw/pull/137093).
+- Reuse reserved tool names during Code Mode catalog construction [#137096](https://github.com/openclaw/openclaw/pull/137096).
+- Avoid copying newly built session rows before publication [#137117](https://github.com/openclaw/openclaw/pull/137117).
+- Clarify deleted-job hook coverage and reuse the call guard [#137119](https://github.com/openclaw/openclaw/pull/137119).
+- Share per-operation plugin activation preparation [#137128](https://github.com/openclaw/openclaw/pull/137128).
+- Snapshot tool namespace metadata without discarded schema hints [#137130](https://github.com/openclaw/openclaw/pull/137130).
+- Reuse encoded text during Code Mode output fitting [#137132](https://github.com/openclaw/openclaw/pull/137132).
+- Share approval subscription cleanup across teardown paths [#137133](https://github.com/openclaw/openclaw/pull/137133).
+- Avoid unused channel metadata processing during plugin setup [#137140](https://github.com/openclaw/openclaw/pull/137140).
+- Split node-host runner coverage into focused test files [#137149](https://github.com/openclaw/openclaw/pull/137149).
+- Check documentation anchors using the publishing parser [#137157](https://github.com/openclaw/openclaw/pull/137157).
+- Combine body-less HTTP response byte-limit test cases [#137158](https://github.com/openclaw/openclaw/pull/137158).
+- Prepare node subscription sends directly from membership maps [#137161](https://github.com/openclaw/openclaw/pull/137161).
+- Reuse result guards across audio, video and image tests [#137162](https://github.com/openclaw/openclaw/pull/137162).
+- Replace the local respawn mock-call assertion with the shared guard [#137163](https://github.com/openclaw/openclaw/pull/137163).
+- Share session subscriber delivery without intermediate arrays [#137172](https://github.com/openclaw/openclaw/pull/137172).
+- Remove redundant plugin entrypoint deduplication [#137173](https://github.com/openclaw/openclaw/pull/137173).
+- Snapshot tool references directly while preserving diagnostics [#137175](https://github.com/openclaw/openclaw/pull/137175).
+- Collect effective plugin IDs into a single final set [#137178](https://github.com/openclaw/openclaw/pull/137178).
+- Unify pull-request subscription replacement ownership [#137187](https://github.com/openclaw/openclaw/pull/137187).
+- Simplify MCP namespace construction while preserving dispatch [#137193](https://github.com/openclaw/openclaw/pull/137193).
+- Reuse runtime marker patterns during reply cleanup [#137195](https://github.com/openclaw/openclaw/pull/137195).
+- Add paired-Watch upgrade and restart survival coverage [#137203](https://github.com/openclaw/openclaw/pull/137203). Thanks @vincentkoc.
+- Consolidate isolated-state coverage through the SDK test entrypoint [#137205](https://github.com/openclaw/openclaw/pull/137205).
+- Use the shared call guard in pairing approval tests [#137210](https://github.com/openclaw/openclaw/pull/137210).
+- Reuse canonical call assertions in cron fast-mode tests [#137228](https://github.com/openclaw/openclaw/pull/137228).
+- Simplify stderr spies in logging and rotation tests [#137238](https://github.com/openclaw/openclaw/pull/137238).
+- Reuse the npm test call-presence guard [#137254](https://github.com/openclaw/openclaw/pull/137254).
+- Reuse runtime-context delimiter patterns across parser calls [#137256](https://github.com/openclaw/openclaw/pull/137256).
+- Declare the respawn exit mock's signature directly [#137258](https://github.com/openclaw/openclaw/pull/137258).
+- Cover native approval finalization and reload recovery in the browser [#137259](https://github.com/openclaw/openclaw/pull/137259). Thanks @jalehman.
+- Share strict boolean parsing for publication artifact options [#137260](https://github.com/openclaw/openclaw/pull/137260). Thanks @vincentkoc.
+- Share Voice Call test guards and asynchronous gates [#137262](https://github.com/openclaw/openclaw/pull/137262).
+- Centralize invalid conversation-replay classification [#137271](https://github.com/openclaw/openclaw/pull/137271). Thanks @vincentkoc.
+- Remove duplicate Ollama node invocation policy [#137272](https://github.com/openclaw/openclaw/pull/137272). Thanks @vincentkoc.
+- Reuse the shared chat-send timing helper [#137276](https://github.com/openclaw/openclaw/pull/137276). Thanks @vincentkoc.
+- Share provider replay identity construction and hashing [#137280](https://github.com/openclaw/openclaw/pull/137280). Thanks @vincentkoc.
+- Share initial model-thinking setup across cron tests [#137284](https://github.com/openclaw/openclaw/pull/137284).
+- Test structured approval errors independently of message wording [#137285](https://github.com/openclaw/openclaw/pull/137285).
+- Share outbound send-result normalization [#137289](https://github.com/openclaw/openclaw/pull/137289). Thanks @vincentkoc.
+- Load Browser dependencies only when workers request Browser tools [#137290](https://github.com/openclaw/openclaw/pull/137290).
+- Reuse shared call guards in channel setup tests [#137296](https://github.com/openclaw/openclaw/pull/137296).
+- Share WebSocket close formatting across network test helpers [#137297](https://github.com/openclaw/openclaw/pull/137297). Thanks @vincentkoc.
+- Pack compatible plugin and Node tests onto fewer runners [#137298](https://github.com/openclaw/openclaw/pull/137298).
+- Prepare the default outbound destination pattern once [#137305](https://github.com/openclaw/openclaw/pull/137305).
+- Reuse deferred helpers in stale-call cleanup tests [#137309](https://github.com/openclaw/openclaw/pull/137309).
+- Use runner-owned exit types in process tests [#137310](https://github.com/openclaw/openclaw/pull/137310).
+- Consolidate bundled schema checks in loader coverage [#137315](https://github.com/openclaw/openclaw/pull/137315).
+- Route macOS dead-code scans to hosted runners [#137318](https://github.com/openclaw/openclaw/pull/137318). Thanks @vincentkoc.
+- Schedule historical mobile pairing upgrade checks [#137321](https://github.com/openclaw/openclaw/pull/137321). Thanks @vincentkoc.
+- Reuse the canonical call guard in transcript checks [#137325](https://github.com/openclaw/openclaw/pull/137325).
+- Strengthen token-warning assertions and consolidate policy tests [#137333](https://github.com/openclaw/openclaw/pull/137333).
+- Reuse deferred fixtures in queue and transcript tests [#137338](https://github.com/openclaw/openclaw/pull/137338).
+- Reuse skill name and location patterns during catalog parsing [#137340](https://github.com/openclaw/openclaw/pull/137340).
+- Reuse isolated-cron suite lifecycle hooks [#137341](https://github.com/openclaw/openclaw/pull/137341).
+- Replace local indexed-call guards in channel setup tests [#137350](https://github.com/openclaw/openclaw/pull/137350).
+- Consolidate type-check jobs and simplify complete-byte test comparisons [#137352](https://github.com/openclaw/openclaw/pull/137352).
+- Share mention Inbox request ownership and revision tracking [#137375](https://github.com/openclaw/openclaw/pull/137375).
+- Share streamed response-cancellation fixtures across SMS and voice tests [#137384](https://github.com/openclaw/openclaw/pull/137384).
+- Refresh locale coverage records and presence-label translation mappings [#137420](https://github.com/openclaw/openclaw/pull/137420).
+- Reduce repeated QA setup and reuse the CLI regression fixture [#137421](https://github.com/openclaw/openclaw/pull/137421).
+- Simplify mocks in command-line help failure tests [#137423](https://github.com/openclaw/openclaw/pull/137423).
+- Deduplicate Doctor platform-warning test assertions [#137426](https://github.com/openclaw/openclaw/pull/137426).
+- Reuse deferred-response fixtures in chat subscription tests [#137429](https://github.com/openclaw/openclaw/pull/137429).
+- Prune unused model-label translation records [#137445](https://github.com/openclaw/openclaw/pull/137445).
+- Check generated configuration and plugin documentation in regular CI [#137455](https://github.com/openclaw/openclaw/pull/137455). Thanks @vincentkoc.
+- Reduce startup overhead in the CLI session-recovery regression [#137460](https://github.com/openclaw/openclaw/pull/137460).
+- Consolidate repeated SDK packaging and registration test setup [#137468](https://github.com/openclaw/openclaw/pull/137468).
+- Remove obsolete Android pairing-label translation resources [#137480](https://github.com/openclaw/openclaw/pull/137480).
+- Share logging mock-call checks across test suites [#137481](https://github.com/openclaw/openclaw/pull/137481).
+- Reuse the shared assertion for plugin cleanup timer calls [#137482](https://github.com/openclaw/openclaw/pull/137482).
+- Remove duplicate mock-call guards from cron regressions [#137498](https://github.com/openclaw/openclaw/pull/137498).
+- Reuse the default plan across CI planner regression checks [#137501](https://github.com/openclaw/openclaw/pull/137501).
+- Reuse common session fixtures across web UI tests [#137511](https://github.com/openclaw/openclaw/pull/137511).
+- Skip model-capability discovery in the synthetic command-construction fixture [#137512](https://github.com/openclaw/openclaw/pull/137512).
+- Simplify ElevenLabs transcription and speech request fixtures [#137515](https://github.com/openclaw/openclaw/pull/137515).
+- Share note assertions in Claude CLI health tests [#137522](https://github.com/openclaw/openclaw/pull/137522).
+- Remove duplicate Twilio test call guards [#137538](https://github.com/openclaw/openclaw/pull/137538).
+- Reuse the shared mock-call guard in logging-level tests [#137546](https://github.com/openclaw/openclaw/pull/137546).
+- Reuse call guards in past-due schedule listing tests [#137556](https://github.com/openclaw/openclaw/pull/137556).
+- Share delayed-request fixtures in Logbook and plugin-page tests [#137558](https://github.com/openclaw/openclaw/pull/137558).
+- Simplify OpenAI speech request test fixtures [#137559](https://github.com/openclaw/openclaw/pull/137559).
+- Remove redundant session recovery and browser setup from Gateway tests [#137564](https://github.com/openclaw/openclaw/pull/137564).
+- Skip unused browser cleanup discovery in agent test fixtures [#137582](https://github.com/openclaw/openclaw/pull/137582).
+- Inline captured-note reads in workspace repair tests [#137590](https://github.com/openclaw/openclaw/pull/137590).
+- Avoid duplicate normalization when Responses histories match exactly [#137617](https://github.com/openclaw/openclaw/pull/137617).
+- Trim oversized Tool Search batches with a stable single scan [#137619](https://github.com/openclaw/openclaw/pull/137619).
+- Reuse normalized strings during streamed tool-name matching [#137623](https://github.com/openclaw/openclaw/pull/137623).
+- Select prepared plugin manifests without an intermediate list [#137626](https://github.com/openclaw/openclaw/pull/137626).
+- Prepare skill watcher source paths without duplicate filesystem checks [#137635](https://github.com/openclaw/openclaw/pull/137635).
+- Reuse the backup archive idle watchdog across progress events [#137638](https://github.com/openclaw/openclaw/pull/137638).
+- Keep provider discovery out of MCP replacement regression tests [#137639](https://github.com/openclaw/openclaw/pull/137639).
+- Reuse recorded-call assertions in directory command tests [#137640](https://github.com/openclaw/openclaw/pull/137640).
+- Select retained output tail lines without repeated prepending [#137645](https://github.com/openclaw/openclaw/pull/137645).
+- Reduce live-digest scheduling allocations and retire terminal bookkeeping [#137655](https://github.com/openclaw/openclaw/pull/137655).
+- Reuse result encoding across Code Mode budget trials [#137670](https://github.com/openclaw/openclaw/pull/137670).
+- Reuse normalized diagnostic field names during redaction [#137676](https://github.com/openclaw/openclaw/pull/137676).
+- Reuse backup asset records for symbolic-link validation [#137698](https://github.com/openclaw/openclaw/pull/137698).
+- Inline equivalent web search and fetch enablement checks [#137700](https://github.com/openclaw/openclaw/pull/137700).
+- Reuse unchanged executor entries during tool catalog preparation [#137703](https://github.com/openclaw/openclaw/pull/137703).
+- Carry generated-skill root policy into loading [#137708](https://github.com/openclaw/openclaw/pull/137708).
+- Reuse prepared memory prompts with fewer comparison allocations [#137715](https://github.com/openclaw/openclaw/pull/137715).
+- Use storage staging when publishing large official plugins to ClawHub [#137727](https://github.com/openclaw/openclaw/pull/137727).
+- Reuse backup archive indexing for duplicate-path checks [#137730](https://github.com/openclaw/openclaw/pull/137730).
+- Skip unused description lines when building compact tool summaries [#137735](https://github.com/openclaw/openclaw/pull/137735).
+- Replace duplicated security-test finding guards with shared assertions [#137737](https://github.com/openclaw/openclaw/pull/137737).
+- Consolidate checkpoint request validation and recovery responses [#137814](https://github.com/openclaw/openclaw/pull/137814).
+- Extend Gateway load probes with task, cron, history, and shutdown evidence [#137835](https://github.com/openclaw/openclaw/pull/137835).
+- Inline redundant private protocol subgroup maps into their owners [#137852](https://github.com/openclaw/openclaw/pull/137852).
+- Avoid redundant column-metadata allocation for typed SQLite SELECT reads [#137862](https://github.com/openclaw/openclaw/pull/137862).
+- Make heartbeat and Workshop reconciliation ownership explicit [#137875](https://github.com/openclaw/openclaw/pull/137875).
+- Separate package update preparation from activation and discard [#137885](https://github.com/openclaw/openclaw/pull/137885). Thanks @fuller-stack-dev.
+- Use the shared screen-snapshot validator directly in screenshot consumers [#137891](https://github.com/openclaw/openclaw/pull/137891).
+- Remove redundant clock preloading from candidate-reuse subprocess tests [#137938](https://github.com/openclaw/openclaw/pull/137938).
+- Consolidate redundant Telegram Markdown chunking coverage [#137950](https://github.com/openclaw/openclaw/pull/137950).
+- Reuse the shared active-call assertion in closed-loop Voice Call tests [#137951](https://github.com/openclaw/openclaw/pull/137951).
+- Avoid sanitizing already-normalized assembled tool-result text twice [#137977](https://github.com/openclaw/openclaw/pull/137977).
+- Pack compatible precise plugin test groups into fewer CI jobs [#137985](https://github.com/openclaw/openclaw/pull/137985).
+- Reuse the existing image optimizer across media loaders [#138001](https://github.com/openclaw/openclaw/pull/138001).
+- Avoid temporary field entries during bounded JSON byte measurement [#138017](https://github.com/openclaw/openclaw/pull/138017).
+- Remove duplicate update-finalization subprocess scenarios [#138020](https://github.com/openclaw/openclaw/pull/138020).
+- Exercise browser helper startup with two megabytes of diagnostic output [#138022](https://github.com/openclaw/openclaw/pull/138022).
+- Reuse callable-tool presence during planning and catalog refresh [#138024](https://github.com/openclaw/openclaw/pull/138024).
+- Consolidate avatar and geolocation credential selection [#138032](https://github.com/openclaw/openclaw/pull/138032).
+- Load the pure token formatter directly in TUI and reply diagnostics [#138052](https://github.com/openclaw/openclaw/pull/138052).
+- Stream large installed-skill files into compatible fingerprints [#138058](https://github.com/openclaw/openclaw/pull/138058).
+- Share callable bindings without building discarded execution metadata [#138060](https://github.com/openclaw/openclaw/pull/138060).
+- Build terminal viewer snapshots directly from current recipients [#138061](https://github.com/openclaw/openclaw/pull/138061).
+- Keep assistant replay text as strings until structured parts are needed [#138069](https://github.com/openclaw/openclaw/pull/138069).
+- Select the final carriage-return write without allocating overwritten segments [#138080](https://github.com/openclaw/openclaw/pull/138080).
+- Count prompt context and skill blocks without intermediate text copies [#138081](https://github.com/openclaw/openclaw/pull/138081).
+- Prepare trajectory payloads only when recording worker events [#138086](https://github.com/openclaw/openclaw/pull/138086).
+- Guide translation generation to preserve syntax and localize sentence punctuation [#138100](https://github.com/openclaw/openclaw/pull/138100).
+- Use viewport screenshots in the session-host recording scenario [#138104](https://github.com/openclaw/openclaw/pull/138104).
+- Count bounded tool-directory rows before rendering them once [#138105](https://github.com/openclaw/openclaw/pull/138105).
+- Share the common session-prompt suffix across default and custom prompts [#138106](https://github.com/openclaw/openclaw/pull/138106).
+- Remove unused fallback handling from the shared web model catalog [#138107](https://github.com/openclaw/openclaw/pull/138107).
+- Resolve requested plugin capability owners together [#138111](https://github.com/openclaw/openclaw/pull/138111).
+- Remove the placeholder timer from Watch HTTP session construction [#138117](https://github.com/openclaw/openclaw/pull/138117).
+- Derive bundled skill status from loader provenance [#138122](https://github.com/openclaw/openclaw/pull/138122).
+- Use the shared isolated memory-tool factory in recall tests [#138123](https://github.com/openclaw/openclaw/pull/138123).
+- Reuse compact home-path prefixes within each skill catalog [#138124](https://github.com/openclaw/openclaw/pull/138124).
+- Share closed-execution status across reply outcome reporting [#138127](https://github.com/openclaw/openclaw/pull/138127).
+- Consolidate equivalent session transcript target resolution [#138130](https://github.com/openclaw/openclaw/pull/138130).
+- Own temporary database closure inside the memory reindex context [#138145](https://github.com/openclaw/openclaw/pull/138145).
+- Decode plugin blob records inside their SQLite persistence owner [#138149](https://github.com/openclaw/openclaw/pull/138149).
+- Share timed and unlimited scheduled-job execution [#138158](https://github.com/openclaw/openclaw/pull/138158).
+- Type cron transaction hooks directly on the internal store writer [#138164](https://github.com/openclaw/openclaw/pull/138164).
+- Target test-only type checks and update build-lock handling to fs-safe 0.7.1 [#138165](https://github.com/openclaw/openclaw/pull/138165).
+- Bind delivery queue claims and settlement to their transaction owner [#138179](https://github.com/openclaw/openclaw/pull/138179).
+- Use shared SQLite ownership for plugin keyed-state writes [#138180](https://github.com/openclaw/openclaw/pull/138180).
+- Share lazy provider method forwarding and recognize it in export checks [#138191](https://github.com/openclaw/openclaw/pull/138191).
+- Reuse text-filter descriptors without sharing stream state [#138194](https://github.com/openclaw/openclaw/pull/138194).
+- Reuse resolved default redaction patterns while retaining custom-pattern behavior [#138195](https://github.com/openclaw/openclaw/pull/138195).
+- Retire the obsolete status proof harness and stale Knip paths [#138206](https://github.com/openclaw/openclaw/pull/138206). Thanks @vincentkoc.
+- Pin mock-history and inline-project semantics for Vitest compatibility [#138208](https://github.com/openclaw/openclaw/pull/138208). Thanks @vincentkoc.
+- Remove unused private plugin facade and testing adapters [#138216](https://github.com/openclaw/openclaw/pull/138216).
+- Share Responses text and thinking delta projection helpers [#138218](https://github.com/openclaw/openclaw/pull/138218). Thanks @vincentkoc.
+- Share Linux state-mount resolution across Doctor storage checks [#138220](https://github.com/openclaw/openclaw/pull/138220). Thanks @vincentkoc.
+- Consolidate Gateway configuration reload completion paths [#138222](https://github.com/openclaw/openclaw/pull/138222).
+- Select the final nonblank assistant text directly [#138223](https://github.com/openclaw/openclaw/pull/138223). Thanks @sylvesterkaczmarek.
+- Check locale wiring against current catalogs [#138235](https://github.com/openclaw/openclaw/pull/138235).
+- Share call lookup assertions in voice-call tests [#138246](https://github.com/openclaw/openclaw/pull/138246).
+- Consolidate Doctor confirmation handling [#138252](https://github.com/openclaw/openclaw/pull/138252).
+- Remove duplicate state-database bookkeeping [#138258](https://github.com/openclaw/openclaw/pull/138258).
+- Consolidate validated hook archive installation [#138267](https://github.com/openclaw/openclaw/pull/138267).
+- Share CI jobs and preparation for compatible CLI tests [#138297](https://github.com/openclaw/openclaw/pull/138297).
+- Sort newly deduplicated string arrays without copying [#138305](https://github.com/openclaw/openclaw/pull/138305).
+- Reuse timeline event lookup assertions [#138311](https://github.com/openclaw/openclaw/pull/138311).
+- Reuse allowed-source preparation within each catalog filter [#138312](https://github.com/openclaw/openclaw/pull/138312).
+- Assemble agent JSON results at the delivery boundary [#138332](https://github.com/openclaw/openclaw/pull/138332).
+- Simplify connected-device change reporting [#138343](https://github.com/openclaw/openclaw/pull/138343).
+- Reuse index fingerprints during database validation [#138359](https://github.com/openclaw/openclaw/pull/138359).
+- Stream large diffs into release preparation fingerprints [#138367](https://github.com/openclaw/openclaw/pull/138367).
+- Reuse exact matches during tool search ranking [#138371](https://github.com/openclaw/openclaw/pull/138371).
+- Simplify child-process startup event handling [#138390](https://github.com/openclaw/openclaw/pull/138390).
+- Prepare plugin Doctor artifact candidates once [#138393](https://github.com/openclaw/openclaw/pull/138393).
+- Remove test-only update campaign construction inputs [#138398](https://github.com/openclaw/openclaw/pull/138398).
+- Bound Unicode preparation for presentation splitting [#138414](https://github.com/openclaw/openclaw/pull/138414).
+- Reduce quota bookkeeping for large plugin artifact stores [#138417](https://github.com/openclaw/openclaw/pull/138417).
+- Reuse prepared model overrides while building provider routes [#138423](https://github.com/openclaw/openclaw/pull/138423).
+- Prepare Vydra media URL keys once per extraction [#138433](https://github.com/openclaw/openclaw/pull/138433).
+- Use shared queries for delivery completion and receipt cleanup [#138506](https://github.com/openclaw/openclaw/pull/138506).
+- Keep lease transactions on their acquired database [#138507](https://github.com/openclaw/openclaw/pull/138507).
+- Check synchronous cron and delivery storage callbacks during compilation [#138509](https://github.com/openclaw/openclaw/pull/138509).
+- Batch memory search provenance reads after selecting results [#138510](https://github.com/openclaw/openclaw/pull/138510).
+- Share bounded SQLite worker error-code formatting [#138520](https://github.com/openclaw/openclaw/pull/138520).
+- Collect plugin device commands without repeated intermediate lists [#138521](https://github.com/openclaw/openclaw/pull/138521).
+- Run both Mac Swift CI phases on hosted runners from the first attempt [#138527](https://github.com/openclaw/openclaw/pull/138527).
+- Avoid intermediate base64 conversions during HEIC image normalization [#138574](https://github.com/openclaw/openclaw/pull/138574).
+- Skip redundant serialization of unchanged messages during recovery [#138577](https://github.com/openclaw/openclaw/pull/138577).
+- Keep loaded skill records paired with their parsed frontmatter [#138582](https://github.com/openclaw/openclaw/pull/138582).
+- Stop mixed-destination queue scans once separation is established [#138586](https://github.com/openclaw/openclaw/pull/138586).
+- Verify fallback delivery ownership and visible acknowledgments in subagent QA [#138598](https://github.com/openclaw/openclaw/pull/138598). Thanks @obviyus.
+- Remove unreachable footer implementation while preserving extension types [#138600](https://github.com/openclaw/openclaw/pull/138600).
+- Skip impossible image-prefix candidates during tool-result trimming [#138601](https://github.com/openclaw/openclaw/pull/138601).
+- Limit string casing to the media directive prefix [#138605](https://github.com/openclaw/openclaw/pull/138605).
+- Reuse skill catalog rendering when optional remote notes exceed the prompt budget [#138606](https://github.com/openclaw/openclaw/pull/138606).
+- Bound paragraph-spacing checks at Claude CLI stream boundaries [#138607](https://github.com/openclaw/openclaw/pull/138607).
+- Avoid repeated byte sizing of completed command-output lines [#138608](https://github.com/openclaw/openclaw/pull/138608).
+- Defer response-buffer copying until accepted content is needed [#138609](https://github.com/openclaw/openclaw/pull/138609).
+- Skip provider route preparation when no routing hook exists [#138615](https://github.com/openclaw/openclaw/pull/138615).
+- Use binary lookup for code-span membership in streaming Markdown [#138622](https://github.com/openclaw/openclaw/pull/138622).
+- Bound progress-text compaction and preserve authored-turn boundaries in QA [#138624](https://github.com/openclaw/openclaw/pull/138624).
+- Avoid rereading resolved embeddings across equivalent model identities [#138628](https://github.com/openclaw/openclaw/pull/138628).
+- Read Workboard boards, subscriptions, and attachments with single ordered queries [#138636](https://github.com/openclaw/openclaw/pull/138636).
+- Reduce temporary allocation in weighted multilingual tool-text counting [#138646](https://github.com/openclaw/openclaw/pull/138646).
+- Reuse prepared subagent context when rendering compact status details [#138647](https://github.com/openclaw/openclaw/pull/138647).
+- Fit long CLI text cells without materializing every grapheme [#138648](https://github.com/openclaw/openclaw/pull/138648).
+- Batch Canvas preview attachment when projecting conversation history [#138654](https://github.com/openclaw/openclaw/pull/138654).
+- Verify structured consolidation payloads and selected-owner provenance in release tests [#138671](https://github.com/openclaw/openclaw/pull/138671).
+- Simplify declaration hooks and consolidate scanner regression fixtures [#138683](https://github.com/openclaw/openclaw/pull/138683).
+- Remove a private interactive-handler registration alias [#138708](https://github.com/openclaw/openclaw/pull/138708). Thanks @vincentkoc.
+- Avoid discarded memory source-state lookup maps [#138709](https://github.com/openclaw/openclaw/pull/138709).
+- Reacquire data-free Node coordinators without redundant filesystem writes [#138710](https://github.com/openclaw/openclaw/pull/138710). Thanks @fuller-stack-dev, @obviyus.
+- Reuse Logbook timeline cards and limit status and revision payload reads [#138711](https://github.com/openclaw/openclaw/pull/138711).
+- Route iOS and shared OpenClawKit Periphery scans directly to hosted macOS [#138718](https://github.com/openclaw/openclaw/pull/138718). Thanks @vincentkoc.
+- Centralize post-admission ownership checks for delegated-task cleanup [#138720](https://github.com/openclaw/openclaw/pull/138720).
+- Consolidate desktop session ownership and dispatch helpers [#138728](https://github.com/openclaw/openclaw/pull/138728).
+- Batch plugin eviction and reuse bounded delivery and Cron query results [#138740](https://github.com/openclaw/openclaw/pull/138740).
+- Share ordered Tencent provider registration without merging credential ownership [#138752](https://github.com/openclaw/openclaw/pull/138752). Thanks @vincentkoc.
+- Reuse compiled plugin-state point reads without caching returned values [#138758](https://github.com/openclaw/openclaw/pull/138758).
+- Exercise Full Access restart recovery in nightly QA [#138764](https://github.com/openclaw/openclaw/pull/138764).
+- Reuse width calculations when wrapping terminal notes [#138772](https://github.com/openclaw/openclaw/pull/138772).
+- Prune excess audit history with one scoped database statement [#138792](https://github.com/openclaw/openclaw/pull/138792).
+- Type chat-loading fixtures and cover dashboard-gallery reloads [#138793](https://github.com/openclaw/openclaw/pull/138793).
+- Reuse Doctor test startup and consolidate core lint jobs [#138796](https://github.com/openclaw/openclaw/pull/138796).
+- Derive delivery queue row types from selected database columns [#138801](https://github.com/openclaw/openclaw/pull/138801).
+- Reuse provider alias ordering during credential lookup preparation [#138805](https://github.com/openclaw/openclaw/pull/138805).
+- Share cache writes between memory indexing and rebuilds [#138827](https://github.com/openclaw/openclaw/pull/138827).
+- Reuse installed-plugin lookups within an inventory operation [#138832](https://github.com/openclaw/openclaw/pull/138832).
+- Separate plugin metadata reads from install and removal handlers [#138840](https://github.com/openclaw/openclaw/pull/138840).
+- Skip redundant timing variants and opt-in browser proof capture [#138855](https://github.com/openclaw/openclaw/pull/138855).
+- Remove redundant web search and fetch provider forwarding helpers [#138859](https://github.com/openclaw/openclaw/pull/138859).
+- Share Claw manifest and profile YAML validation [#138863](https://github.com/openclaw/openclaw/pull/138863).
+- Consolidate root command and option scanning [#138875](https://github.com/openclaw/openclaw/pull/138875).
+- Reuse current-run selection within activity snapshots [#138889](https://github.com/openclaw/openclaw/pull/138889).
+- Type remaining Logbook writes and retention queries [#138895](https://github.com/openclaw/openclaw/pull/138895).
+- Remove styling for retired lists and sidebar layouts [#138898](https://github.com/openclaw/openclaw/pull/138898).
+- Stream transcript archive reads through shared typed queries [#138902](https://github.com/openclaw/openclaw/pull/138902).
+- Share validated directory installation for hooks and hook packs [#138907](https://github.com/openclaw/openclaw/pull/138907).
+- Read agent identity overrides without full configuration merging [#138911](https://github.com/openclaw/openclaw/pull/138911).
+- Remove unused agent-deletion lifecycle tracking [#138912](https://github.com/openclaw/openclaw/pull/138912).
+- Reuse normalized plugin configuration within loader lookups [#138916](https://github.com/openclaw/openclaw/pull/138916).
+- Type Claw package and MCP adoption updates [#138921](https://github.com/openclaw/openclaw/pull/138921).
+- Stream metadata while summarizing QA capture coverage [#138927](https://github.com/openclaw/openclaw/pull/138927).
+- Type Claw provenance writes and package replacement checks [#138932](https://github.com/openclaw/openclaw/pull/138932).
+- Add paired Vitest comparison runs with fixed acceptance thresholds [#138937](https://github.com/openclaw/openclaw/pull/138937). Thanks @vincentkoc.
+- Share session identity reads for collaboration mutations [#138941](https://github.com/openclaw/openclaw/pull/138941).
+- Test supported bounded Gateway client shutdown [#138942](https://github.com/openclaw/openclaw/pull/138942). Thanks @obviyus.
+- Type Claw workspace provenance and removal queries [#138960](https://github.com/openclaw/openclaw/pull/138960).
+- Type proxy-capture session, event and payload writes [#138962](https://github.com/openclaw/openclaw/pull/138962).
+- Reduce row copying in suggestion counts and retention [#138974](https://github.com/openclaw/openclaw/pull/138974).
+
+**Bug fixes**
+
+- Preserve focused-test arguments and signal exit handling [#133449](https://github.com/openclaw/openclaw/pull/133449).
+- Repair session-toolbar and Workboard screenshot selectors [#135897](https://github.com/openclaw/openclaw/pull/135897). Thanks @vincentkoc.
+- Preserve readable trailing output in CLI test overflow failures [#136673](https://github.com/openclaw/openclaw/pull/136673). Thanks @vincentkoc.
+- Isolate documentation example validation from local runtime state [#136731](https://github.com/openclaw/openclaw/pull/136731).
+- Package incomplete optional probe metadata without false missing-file failures [#136737](https://github.com/openclaw/openclaw/pull/136737).
+- Finish blocked playback test jobs before teardown [#136752](https://github.com/openclaw/openclaw/pull/136752).
+- Handle legacy plugin consent in Telegram package tests [#136753](https://github.com/openclaw/openclaw/pull/136753). Thanks @vincentkoc, @vacinc.
+- Test cron cleanup failures without bypassing production throttling [#136763](https://github.com/openclaw/openclaw/pull/136763).
+- Restore representative built-plugin generation fixtures [#136770](https://github.com/openclaw/openclaw/pull/136770).
+- Start candidate package registries with Windows archive paths [#136771](https://github.com/openclaw/openclaw/pull/136771).
+- Repair candidate registry and configuration setup in Docker upgrade checks [#136796](https://github.com/openclaw/openclaw/pull/136796).
+- Settle scheduled-work fixtures before resetting tests [#136809](https://github.com/openclaw/openclaw/pull/136809).
+- Preserve Discord reply-latency measurements in QA evidence [#136814](https://github.com/openclaw/openclaw/pull/136814). Thanks @vincentkoc.
+- Accept repeated help flags in Vitest profiling commands [#136830](https://github.com/openclaw/openclaw/pull/136830).
+- Allow terminal formatting when release tooling fetches child-job logs [#136856](https://github.com/openclaw/openclaw/pull/136856).
+- Restore startup CSS budget and artifact-restore checks [#136878](https://github.com/openclaw/openclaw/pull/136878). Thanks @fuller-stack-dev.
+- Drain deferred cron test runs before teardown [#136901](https://github.com/openclaw/openclaw/pull/136901).
+- Preserve section fragments in generated maturity-document links [#136910](https://github.com/openclaw/openclaw/pull/136910).
+- Allow queued validation parents when binding artifact producers [#136932](https://github.com/openclaw/openclaw/pull/136932).
+- Stabilize progress-card disconnect lifecycle coverage [#136936](https://github.com/openclaw/openclaw/pull/136936).
+- Authenticate and retry performance-source fetches [#136962](https://github.com/openclaw/openclaw/pull/136962).
+- Retry legacy GitHub CLI log reads without the unsupported flag [#137016](https://github.com/openclaw/openclaw/pull/137016). Thanks @vincentkoc.
+- Capture readable retained authentication screenshots after presentation settles [#137031](https://github.com/openclaw/openclaw/pull/137031).
+- Use target-declared worker files when validating frozen packages [#137035](https://github.com/openclaw/openclaw/pull/137035).
+- Remove ineffective dynamic-route preparation from new-session navigation [#137042](https://github.com/openclaw/openclaw/pull/137042).
+- Run Telegram marker QA in direct messages and match direct replies [#137046](https://github.com/openclaw/openclaw/pull/137046). Thanks @obviyus.
+- Wait for dialog imports and subprocess readiness in tests [#137101](https://github.com/openclaw/openclaw/pull/137101).
+- Synchronize diff-highlighting tests and simplify Talk fixtures [#137186](https://github.com/openclaw/openclaw/pull/137186).
+- Restore update-tool and command assertions for system dispatch [#137196](https://github.com/openclaw/openclaw/pull/137196).
+- Align the update test's thread field with the request shape [#137199](https://github.com/openclaw/openclaw/pull/137199).
+- Reuse PowerShell matching patterns and settle the color-test animation [#137223](https://github.com/openclaw/openclaw/pull/137223).
+- Compile the restart-test fixture and report child startup failures [#137227](https://github.com/openclaw/openclaw/pull/137227).
+- Resolve Slack Web API from isolated private-QA builds [#137283](https://github.com/openclaw/openclaw/pull/137283). Thanks @vincentkoc.
+- Use the candidate registry throughout first-upgrade validation [#137286](https://github.com/openclaw/openclaw/pull/137286).
+- Preserve conversation kind in implicit QA-channel actions [#137343](https://github.com/openclaw/openclaw/pull/137343).
+- Load private Slack QA through the plugin-owned test facade [#137346](https://github.com/openclaw/openclaw/pull/137346). Thanks @vincentkoc.
+- Settle unfinished Stop and device-token dialogs during test cleanup [#137393](https://github.com/openclaw/openclaw/pull/137393).
+- Restore the trusted checkout dependency for plugin package preparation [#137405](https://github.com/openclaw/openclaw/pull/137405).
+- Keep reply-time measurement provenance in QA evidence [#137406](https://github.com/openclaw/openclaw/pull/137406). Thanks @vincentkoc.
+- Bind test plugin loading to the selected source or packaged candidate [#137449](https://github.com/openclaw/openclaw/pull/137449). Thanks @vincentkoc, @fuller-stack-dev.
+- Carry package publication status into candidate validation [#137487](https://github.com/openclaw/openclaw/pull/137487). Thanks @vincentkoc.
+- Allow delayed GitHub child-run titles to converge during release validation [#137518](https://github.com/openclaw/openclaw/pull/137518). Thanks @fuller-stack-dev.
+- Preserve historical candidate state during setup and Slack capture reads [#137535](https://github.com/openclaw/openclaw/pull/137535). Thanks @vincentkoc, @artyomkun.
+- Restore Android's previously shipped version baseline on main [#137554](https://github.com/openclaw/openclaw/pull/137554).
+- Resolve eligible baselines for the first frozen extended-stable candidate [#137575](https://github.com/openclaw/openclaw/pull/137575). Thanks @romneyda.
+- Stop plugin security scanner descendants on cancellation [#137597](https://github.com/openclaw/openclaw/pull/137597).
+- Keep QA log cursors valid after rollover and drop unsafe partial lines [#137622](https://github.com/openclaw/openclaw/pull/137622). Thanks @vincentkoc.
+- Make managerless update port tests independent of host timing [#137692](https://github.com/openclaw/openclaw/pull/137692). Thanks @vincentkoc.
+- Join reconnect fixture shutdown before restoring exit handling [#137707](https://github.com/openclaw/openclaw/pull/137707).
+- Prepare Chrome MCP before timed browser-extension tests [#137711](https://github.com/openclaw/openclaw/pull/137711). Thanks @patrick-erichsen.
+- Keep unstaged changes out of formatted commits [#137723](https://github.com/openclaw/openclaw/pull/137723).
+- Check surviving Linux threads before declaring test process groups finished [#137726](https://github.com/openclaw/openclaw/pull/137726).
+- Drain gateway session-tool fixtures before resetting shared test state [#137743](https://github.com/openclaw/openclaw/pull/137743). Thanks @patrick-erichsen.
+- Detect hidden import references after regular-expression literals [#137804](https://github.com/openclaw/openclaw/pull/137804).
+- Wait for picker animations before capturing geometry assertions [#137844](https://github.com/openclaw/openclaw/pull/137844). Thanks @patrick-erichsen.
+- Retry pnpm store-path setup in the shared cache action [#137854](https://github.com/openclaw/openclaw/pull/137854). Thanks @patrick-erichsen.
+- Keep translation model metadata private and support availability-only fallback [#137882](https://github.com/openclaw/openclaw/pull/137882).
+- Isolate locale translation runs and honor explicit full refreshes [#137884](https://github.com/openclaw/openclaw/pull/137884).
+- Pass compound help requests through native Vitest parsing [#137906](https://github.com/openclaw/openclaw/pull/137906).
+- Isolate build memory-admission scenarios from busy runner memory [#137909](https://github.com/openclaw/openclaw/pull/137909).
+- Drain failed Gateway test acquisitions and parallel fixture resources [#137924](https://github.com/openclaw/openclaw/pull/137924).
+- Prepare consistent mobile versions and validate Android notes before writes [#137930](https://github.com/openclaw/openclaw/pull/137930).
+- Allow more time for large ClawHub package publication requests [#137941](https://github.com/openclaw/openclaw/pull/137941).
+- Keep implicit QA-channel replies in their source threads [#137964](https://github.com/openclaw/openclaw/pull/137964).
+- Adopt shared failed-socket cleanup in server-suite and webchat tests [#137982](https://github.com/openclaw/openclaw/pull/137982).
+- Simplify status-poll cleanup while covering cleanup rejection [#137986](https://github.com/openclaw/openclaw/pull/137986).
+- Publish fixture-registry readiness files atomically [#137988](https://github.com/openclaw/openclaw/pull/137988).
+- Run configuration-doc validation for relevant changed schema dependencies [#137994](https://github.com/openclaw/openclaw/pull/137994).
+- Distinguish orphan rebase refs from active Git operations during formatting [#137997](https://github.com/openclaw/openclaw/pull/137997). Thanks @nxmxbbd.
+- Record fixture exits before Codex client shutdown observers [#138000](https://github.com/openclaw/openclaw/pull/138000).
+- Repair release-test fixtures and animation and cron completion checks [#138021](https://github.com/openclaw/openclaw/pull/138021).
+- Keep later queue failures out of earlier successful flushes [#138026](https://github.com/openclaw/openclaw/pull/138026).
+- Run npm digest regression tests with Bash 5 on macOS [#138029](https://github.com/openclaw/openclaw/pull/138029).
+- Link existing dependencies before validating cold-worktree declarations [#138030](https://github.com/openclaw/openclaw/pull/138030).
+- Retain redacted exception chains for CI Git ownership failures [#138034](https://github.com/openclaw/openclaw/pull/138034).
+- Hold Gateway test resources through authentication and failed shutdown [#138037](https://github.com/openclaw/openclaw/pull/138037).
+- Acknowledge simulated restarts so plugin lifecycle tests can close [#138054](https://github.com/openclaw/openclaw/pull/138054). Thanks @vincentkoc.
+- Expose original launch errors when nested process tests time out [#138075](https://github.com/openclaw/openclaw/pull/138075).
+- Isolate Doctor persistence fixtures from bundled plugins [#138088](https://github.com/openclaw/openclaw/pull/138088).
+- Retain launch errors in escaped-output subprocess fixtures [#138108](https://github.com/openclaw/openclaw/pull/138108).
+- Prevent canceled QA runs from contaminating later cleanup diagnostics [#138126](https://github.com/openclaw/openclaw/pull/138126).
+- Queue Swift fixture replies and provide matching managed-service readiness evidence [#138132](https://github.com/openclaw/openclaw/pull/138132).
+- Require process-group completion before declaring Gateway fixture cleanup successful [#138135](https://github.com/openclaw/openclaw/pull/138135).
+- Keep newer Unreleased drafts intact during older-release closeout [#138162](https://github.com/openclaw/openclaw/pull/138162).
+- Synchronize catalog-change notifications in MCP regression fixtures [#138172](https://github.com/openclaw/openclaw/pull/138172).
+- Replace removed sequential suite syntax while preserving serial execution [#138175](https://github.com/openclaw/openclaw/pull/138175). Thanks @vincentkoc.
+- Accept unchanged generated mobile release outputs during candidate validation [#138182](https://github.com/openclaw/openclaw/pull/138182). Thanks @vincentkoc.
+- Build Android Mermaid assets through their package-local pnpm context [#138186](https://github.com/openclaw/openclaw/pull/138186). Thanks @vincentkoc.
+- Stop test Gateways after client cleanup failures without discarding owned state [#138187](https://github.com/openclaw/openclaw/pull/138187).
+- Exit CI checkout owners after leaving cyclic exception handlers [#138189](https://github.com/openclaw/openclaw/pull/138189).
+- Fence canceled Apple socket fixtures and synchronize journal and configuration tests [#138207](https://github.com/openclaw/openclaw/pull/138207). Thanks @obviyus.
+- Await question registration and join MCP fixture cleanup [#138214](https://github.com/openclaw/openclaw/pull/138214).
+- Remove misleading lifecycle test failures [#138238](https://github.com/openclaw/openclaw/pull/138238).
+- Preserve ClawHub links in generated maturity pages [#138241](https://github.com/openclaw/openclaw/pull/138241).
+- Refresh cached test modules after dependency and cache changes [#138248](https://github.com/openclaw/openclaw/pull/138248).
+- Produce combined test reports from grouped and empty runs [#138250](https://github.com/openclaw/openclaw/pull/138250).
+- Retain Teams test webhook listeners through setup [#138276](https://github.com/openclaw/openclaw/pull/138276).
+- Limit temporary-directory reports to relevant test patches [#138282](https://github.com/openclaw/openclaw/pull/138282).
+- Keep rendering checks compatible with refreshed translations [#138283](https://github.com/openclaw/openclaw/pull/138283). Thanks @kaxo-io.
+- Run mock-retention fixtures before broad imports [#138294](https://github.com/openclaw/openclaw/pull/138294).
+- Control animation and legacy database setup in browser tests [#138296](https://github.com/openclaw/openclaw/pull/138296).
+- Ignore superseded failures while watching replacement PR runs [#138307](https://github.com/openclaw/openclaw/pull/138307). Thanks @obviyus.
+- Prepare Testbox leases for large dirty checkouts [#138317](https://github.com/openclaw/openclaw/pull/138317).
+- Isolate chat-view test clocks and fixtures [#138325](https://github.com/openclaw/openclaw/pull/138325).
+- Control clocks in synthetic Vydra response tests [#138361](https://github.com/openclaw/openclaw/pull/138361).
+- Scope Git cleanup process inspection to its owner [#138420](https://github.com/openclaw/openclaw/pull/138420).
+- Wait for background command completion in QA scenarios [#138431](https://github.com/openclaw/openclaw/pull/138431).
+- Explain stale Linux release requests before checkout [#138450](https://github.com/openclaw/openclaw/pull/138450).
+- Coordinate delayed-worker process lifecycle tests [#138453](https://github.com/openclaw/openclaw/pull/138453).
+- Control clocks in authenticated Codex hook tests [#138456](https://github.com/openclaw/openclaw/pull/138456).
+- Respect newly observed draft status during CI sweeps [#138467](https://github.com/openclaw/openclaw/pull/138467).
+- Scope reclamation test faults to their connection [#138481](https://github.com/openclaw/openclaw/pull/138481). Thanks @obviyus.
+- Keep ready PR checks running after delayed draft events [#138482](https://github.com/openclaw/openclaw/pull/138482).
+- Preserve separate lists during documentation translation [#138484](https://github.com/openclaw/openclaw/pull/138484).
+- Avoid duplicate browser test execution and success artifacts [#138496](https://github.com/openclaw/openclaw/pull/138496).
+- Repair cold release fixtures and readiness checks [#138498](https://github.com/openclaw/openclaw/pull/138498).
+- Bind CI replacement runs to the correct pull request and retain cancelled checks [#138533](https://github.com/openclaw/openclaw/pull/138533).
+- Compare Android French status text with packaged locale resources [#138539](https://github.com/openclaw/openclaw/pull/138539).
+- Isolate delayed draft events in ancillary validation workflow concurrency groups [#138572](https://github.com/openclaw/openclaw/pull/138572).
+- Measure Azure and Inworld timeout tests from observed request startup [#138611](https://github.com/openclaw/openclaw/pull/138611).
+- Separate native Testbox synchronization from the prepared runtime workspace [#138612](https://github.com/openclaw/openclaw/pull/138612).
+- Record retry schedules without real waits in PR metadata tests [#138617](https://github.com/openclaw/openclaw/pull/138617).
+- Publish plugin SDK declarations before strict smoke export checks [#138621](https://github.com/openclaw/openclaw/pull/138621).
+- Retain Testbox failure artifacts per attempt and record UI test shard metadata [#138651](https://github.com/openclaw/openclaw/pull/138651).
+- Use recorded run intent when publishing and superseding Periphery findings [#138665](https://github.com/openclaw/openclaw/pull/138665).
+- Move cold Slack action imports into QA suite preparation [#138681](https://github.com/openclaw/openclaw/pull/138681).
+- Use full-buffer byte equality to avoid Codex release-test worker exhaustion [#138743](https://github.com/openclaw/openclaw/pull/138743).
+- Publish complete PID files in Gmail shutdown regression fixtures [#138747](https://github.com/openclaw/openclaw/pull/138747). Thanks @obviyus.
+- Check fresh approval listings and connection ownership after Mac test reconnects [#138748](https://github.com/openclaw/openclaw/pull/138748). Thanks @obviyus.
+- Stabilize stream and mobile recovery browser checks [#138776](https://github.com/openclaw/openclaw/pull/138776).
+- Retire verified obsolete source when testing older revisions [#138782](https://github.com/openclaw/openclaw/pull/138782).
+- Honor required command failure in Matrix progress scenarios [#138824](https://github.com/openclaw/openclaw/pull/138824).
+- Handle GitHub's 100-label limit across labeling jobs [#138841](https://github.com/openclaw/openclaw/pull/138841).
+- Wait for destination chat ownership in model-picker tests [#138858](https://github.com/openclaw/openclaw/pull/138858).
+- Supply shared mobile candidate release-note input [#138866](https://github.com/openclaw/openclaw/pull/138866). Thanks @vincentkoc.
+- Respect plugin-owned loaders during package dependency checks [#138935](https://github.com/openclaw/openclaw/pull/138935).
+- Wait for submenu opening before testing hide interruption [#138968](https://github.com/openclaw/openclaw/pull/138968). Thanks @vincentkoc.
+- Allow the exact LAN host in SSH-pairing test fixtures [#138969](https://github.com/openclaw/openclaw/pull/138969). Thanks @vincentkoc.
+- Check final stream output after target EOF settles [#138970](https://github.com/openclaw/openclaw/pull/138970). Thanks @vincentkoc.
+- Isolate tests that import stateful mock helpers [#138971](https://github.com/openclaw/openclaw/pull/138971). Thanks @vincentkoc.
+- Keep transcript test timer mocks from disrupting background workers [#138980](https://github.com/openclaw/openclaw/pull/138980).
+
+**Security and trust**
+
+- Bind screenshot evidence parsing to the workflow revision [#136334](https://github.com/openclaw/openclaw/pull/136334). Thanks @vincentkoc.
+- Add guarded internal mobile beta dispatch and release receipts [#136610](https://github.com/openclaw/openclaw/pull/136610). Thanks @vincentkoc.
+- Validate frozen package credentials against their schema-era store [#136828](https://github.com/openclaw/openclaw/pull/136828). Thanks @romneyda, @vincentkoc.
+- Bind upgrade validation to immutable package candidates and predecessor releases [#136914](https://github.com/openclaw/openclaw/pull/136914). Thanks @vincentkoc, @fuller-stack-dev.
+- Bind plugin scan identity to trusted candidate resolution [#137003](https://github.com/openclaw/openclaw/pull/137003).
+- Generalize stable-release Telegram waiver declarations by version [#137050](https://github.com/openclaw/openclaw/pull/137050). Thanks @vincentkoc.
+- Test restored artifact execution under restrictive file permissions [#137076](https://github.com/openclaw/openclaw/pull/137076).
+- Continue npm stable validation under its approved coverage policy [#137109](https://github.com/openclaw/openclaw/pull/137109).
+- Restrict Telegram release-test exceptions to reviewed declarations [#137118](https://github.com/openclaw/openclaw/pull/137118). Thanks @vincentkoc.
+- Validate Codex packages against the candidate's declared version [#137136](https://github.com/openclaw/openclaw/pull/137136). Thanks @vincentkoc.
+- Record child-side approval for manual ClawHub publication recovery [#137598](https://github.com/openclaw/openclaw/pull/137598).
+- Check publication prerequisites and clarify release closeout failures [#137637](https://github.com/openclaw/openclaw/pull/137637).
+- Retry a transient npm advisory timeout once in shared audit tooling [#137716](https://github.com/openclaw/openclaw/pull/137716). Thanks @vincentkoc, @romneyda.
+- Retry transient npm advisory requests without granting clearance on exhaustion [#137825](https://github.com/openclaw/openclaw/pull/137825). Thanks @romneyda, @vincentkoc.
+- Report unavailable advisory coverage distinctly and drain browser-test cleanup [#137881](https://github.com/openclaw/openclaw/pull/137881).
+- Validate advisory responses and add bounded CI audit summaries and scheduled checks [#137960](https://github.com/openclaw/openclaw/pull/137960). Thanks @vincentkoc.
+- Restore blocking CI audits and honor bounded advisory retry deadlines [#137989](https://github.com/openclaw/openclaw/pull/137989).
+- Verify complete source snapshots before remote checks [#138404](https://github.com/openclaw/openclaw/pull/138404).
+- Bind ClawHub recovery approval receipts to the original publishing attempt [#138578](https://github.com/openclaw/openclaw/pull/138578).
+- Harden diagnostic artifact copying and preserve the original validation failure status [#138715](https://github.com/openclaw/openclaw/pull/138715).
+
+**Documentation**
+
+- Add and index the v2026.9.1 release page [#136579](https://github.com/openclaw/openclaw/pull/136579). Thanks @hannesrudolph.
+- Correct the v2026.9.1 release reference and source accounting [#136913](https://github.com/openclaw/openclaw/pull/136913). Thanks @hannesrudolph.
+- Align main with the 2026.9.1 version and changelog record [#137506](https://github.com/openclaw/openclaw/pull/137506). Thanks @patrick-erichsen.
+- Document contracts for future database backends [#138463](https://github.com/openclaw/openclaw/pull/138463).
+- Update the macOS appcast for the prior 2026.9.1 release [f1eb466](https://github.com/openclaw/openclaw/commit/f1eb466dad6494ce0fabf63dbecedba35e881e60).
+- Add the 2026.9.2 changelog overview and contribution record [2542d48](https://github.com/openclaw/openclaw/commit/2542d48dc9c2a81beb6a9480f21bdec21dc0224a).
+- Finalize the 2026.9.2 changelog summary and accounting [3928bad](https://github.com/openclaw/openclaw/commit/3928bad9badfcb6c7d140530435e806fb8092190).
+
+**Limits and compatibility**
+
+- Keep declaration builds on checkout-local dependencies [#138440](https://github.com/openclaw/openclaw/pull/138440).
+- Reject native declaration inputs and shared toolchains outside the selected checkout [#138742](https://github.com/openclaw/openclaw/pull/138742).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>


### PR DESCRIPTION
## What Problem This Solves

Reviewers need a temporary rendered preview of the detailed v2026.9.2 release notes in the docs site's current renderer.

## Why This Change Was Made

**TEMPORARY PREVIEW ONLY — DO NOT MERGE.** The user explicitly authorized this draft PR as an exception to the docs mirror's normal source-only editing rule. This is not approval of the release copy, a production publication, or a change to mirror ownership. Canonical publication, if later authorized, belongs in `openclaw/openclaw/docs/**`.

The PR adds the exact independently reviewed English candidate and one navigation entry. It preserves the review-draft marker and changes no translations, sync metadata, renderer, CI or hosting configuration. The branch is in this repository, so maintainers retain normal repository branch access; GitHub's fork-collaboration checkbox is not applicable to this same-repository PR.

## User Impact

Reviewers can inspect concrete reliability improvements, OpenAI GPT-6 Astra and Meta Muse Spark 1.3 support in the complete release page. There is no intended production-site change. The existing Mintlify integration started an automatic preview build. Vercel is not verified; the repository's production deployment tooling is Cloudflare.

## Evidence

- Exact candidate SHA-256: `1b1f89b936efc4fe90727b6e5894edc57ee55e9ddd50035e48558bfe5a0a5d04` (381,070 bytes). Copied unchanged from retained artifact `6b4c42c947b5569267ac2bc29e345fde8459d5693e077bee0649d8f5f36e9dd3`.
- Independent full-page/evidence review: `APPROVED_FOR_HUMAN_REVIEW`, no material findings. Human approval and publication authorization remain false.
- Frozen release target: `3928bad9badfcb6c7d140530435e806fb8092190`; fresh v2026.9.2 tag and `release/2026.9.2` branch reads match.
- Exact accounting: 1,245 PRs + 6 direct commits, 232 eligible contributors.
- Focused English build passed: `DOCS_SITE_ARTIFACT_MODE=shell DOCS_SITE_PREVIEW_LOCALE=en DOCS_SITE_PREVIEW_PAGES_PER_GROUP=2 node scripts/docs-site/build.mjs`. The normal 30-page cap was omitted so the release route is included; 113 preview pages were built.
- Verified `/releases/2026.9.2/index.html`, all 151 topic accordions, all 151 source disclosures, every PR/direct-commit source link, the review marker, and source files for the page's root-relative documentation routes. `git diff --check` passed.
- Focused local Chrome review of this exact commit passed: opening layout, Models TOC navigation, Astra expansion and nested categorized sources. Reliability/Astra/Muse are visible, with Astra first and Muse second. This is local proof; the existing hosted Mintlify preview remains building. No production deploy or hosting reconfiguration was invoked.
