### PR TITLE
fix(docs): render nested navigation groups recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Highlights:** Stable section links and more reliable translated docs, with bounded publishing requests and workflow jobs.
 
+- Render nested navigation groups recursively so protocol pages remain reachable and mirror-sync builds no longer generate `/undefined/undefined` links.
 - Preserve published heading IDs, emit unambiguous Mintlify link aliases and component targets, and open nested accordions for fragment navigation using the source-owned shared parsing and redirect contract.
 - Recover parser-diagnosed translation markup damage before validation, preserving translated prose and the existing failed-shard publication checks; thanks @hxy91819.
 - Fix redundant locale rendering by excluding locale-owned roots from English page collection, including accidental localized `AGENTS.md` pages and duplicate locale-root Markdown exports.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Source of truth lives in [`openclaw/openclaw`](https://github.com/openclaw/openc
 - `npm run docs:smoke` checks representative English and locale pages plus the Pagefind search bundle.
 - `npm run docs:check` runs both steps.
 - The generated site includes the language picker and static full-text search via Pagefind.
+- Navigation groups can nest recursively; sidebar links, section metadata, and desktop/mobile tab targets resolve to descendant pages at every depth.
 - Cloudflare deploys `workers/docs-router.ts`, which serves slashless page URLs, English markdown responses for `.md` paths or `Accept: text/markdown`, and `/api/search` through the `DOCS_BUCKET` R2 binding.
 - Cloudflare hosting details and limitations are documented in `CLOUDFLARE.md`.
 

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -567,10 +567,13 @@ function icon(name) {
 }
 
 function navGroupHtml(activePage, group) {
-  return `<section class="nav-section"><h2>${escapeHtml(group.title)}</h2>${group.pages.map((entry) => {
-    if (entry.group) return `<div class="nav-nested"><h2>${escapeHtml(entry.group)}</h2>${entry.pages.map((page) => navLink(activePage, page)).join("")}</div>`;
-    return navLink(activePage, entry);
-  }).join("")}</section>`;
+  return `<section class="nav-section"><h2>${escapeHtml(group.title)}</h2>${group.pages.map((entry) => navEntryHtml(activePage, entry)).join("")}</section>`;
+}
+
+function navEntryHtml(activePage, entry) {
+  return entry.group
+    ? `<div class="nav-nested"><h2>${escapeHtml(entry.group)}</h2>${entry.pages.map((child) => navEntryHtml(activePage, child)).join("")}</div>`
+    : navLink(activePage, entry);
 }
 
 function navLink(activePage, page) {
@@ -919,7 +922,7 @@ function activeTabTitle(nav, slug) {
 function groupForPage(nav, slug) {
   for (const tab of nav) {
     for (const group of tab.groups) {
-      if (group.pages.some((entry) => entry.group ? entry.pages.some((page) => page.slug === slug) : entry.slug === slug)) {
+      if (flattenNavEntries(group.pages).some((page) => page.slug === slug)) {
         return group.title;
       }
     }
@@ -935,10 +938,7 @@ function flattenNav(nav) {
 }
 
 function firstPage(tab) {
-  for (const group of tab.groups) {
-    for (const entry of group.pages) return entry.group ? entry.pages[0] : entry;
-  }
-  return pages[0];
+  return flattenNav([tab])[0] ?? pages[0];
 }
 
 function localeUrlForSlug(locale, slug) {

--- a/scripts/docs-site/fixtures/nested-navigation.json
+++ b/scripts/docs-site/fixtures/nested-navigation.json
@@ -1,0 +1,27 @@
+{
+  "group": "Protocols and APIs",
+  "pages": [
+    "gateway/protocol",
+    {
+      "group": "Gateway protocol",
+      "pages": [
+        "gateway/protocol/transport",
+        "gateway/protocol/handshake",
+        "gateway/protocol/presence",
+        "gateway/protocol/rpc-methods",
+        "gateway/protocol/ledgers",
+        "gateway/protocol/operator-methods",
+        "gateway/protocol/versioning",
+        "gateway/protocol/auth"
+      ]
+    },
+    "gateway/clients",
+    "gateway/embedding",
+    "gateway/openai-http-api",
+    "gateway/openresponses-http-api",
+    "gateway/tools-invoke-http-api",
+    "gateway/cli-backends",
+    "gateway/local-models",
+    "gateway/local-model-services"
+  ]
+}

--- a/scripts/docs-site/nested-navigation.test.mjs
+++ b/scripts/docs-site/nested-navigation.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fixture, write } from "./test-helpers/redirect-fixture.mjs";
+
+// Exact docs.json subtree mirrored at 60887fb76 from openclaw/openclaw@e3e2953f.
+const protocolGroup = JSON.parse(fs.readFileSync(new URL("./fixtures/nested-navigation.json", import.meta.url), "utf8"));
+const reportedPages = ["auth-credential-semantics", "gateway/1password", "gateway/audit"];
+function leaves(entries) {
+  return entries.flatMap((entry) => typeof entry === "string" ? [entry] : leaves(entry.pages));
+}
+
+for (const base of ["", "/manual"]) {
+  test(`nested upstream navigation renders only page links with base ${base || "(root)"}`, (t) => {
+    const slugs = [...reportedPages, ...leaves(protocolGroup.pages)];
+    const sources = Object.fromEntries(slugs.flatMap((slug) => [
+      [`${slug}.md`, `# Page ${slug}\n\nNavigation fixture.\n`],
+      [`fr/${slug}.md`, `# Page française ${slug}\n`],
+    ]));
+    const f = fixture(t, [], sources, base);
+    write(f.root, "docs/docs.json", JSON.stringify({
+      name: "Nested navigation fixture",
+      navigation: { languages: ["en", "fr"].map((language) => ({ language, tabs: [{
+        tab: "Gateway & Ops",
+        groups: [{ group: "Gateway", pages: [protocolGroup, ...reportedPages] }],
+      }] })) },
+    }));
+    const built = f.build();
+    assert.equal(built.status, 0, built.stderr);
+    for (const locale of ["", "fr/"]) {
+      for (const slug of reportedPages) {
+        const html = fs.readFileSync(path.join(f.root, "dist/docs-site", locale, slug, "index.html"), "utf8");
+        assert.ok(!html.includes("undefined/undefined"), `${locale}${slug} must not link a group as a page`);
+        const sidebar = html.match(/<aside class="sidebar">([\s\S]*?)<\/aside>/)[1];
+        assert.ok(sidebar.includes('<h2>Protocols and APIs</h2>'));
+        assert.ok(sidebar.includes('<h2>Gateway protocol</h2>'));
+        for (const target of leaves(protocolGroup.pages)) {
+          assert.ok(sidebar.includes(`href="${base}/${locale}${target}"`), `${locale}${slug} → ${target}`);
+        }
+        for (const match of html.matchAll(/href="(\/[^"?#]*)"/g)) {
+          const route = match[1].slice(base.length).replace(/^\//, "");
+          const site = path.join(f.root, "dist/docs-site");
+          assert.ok(fs.existsSync(path.join(site, route)) || fs.existsSync(path.join(site, route, "index.html")), match[1]);
+        }
+      }
+    }
+  });
+}
+
+test("deep first pages and section metadata use descendant pages in normal and preview builds", (t) => {
+  const f = fixture(t, [], { "guide/first.md": "# First\n", "guide/second.md": "# Second\n" });
+  write(f.root, "docs/docs.json", JSON.stringify({
+    name: "Deep navigation fixture",
+    navigation: { languages: [{ language: "en", tabs: [{ tab: "Deep docs", groups: [{
+      group: "Reference", pages: ["missing", { group: "Empty", pages: ["also-missing"] }, { group: "Outer", pages: [{ group: "Inner", pages: ["guide/first", "guide/second"] }] }],
+    }] }] }] },
+  }));
+  for (const options of [{}, { DOCS_SITE_PREVIEW_LOCALE: "en", DOCS_SITE_PREVIEW_PAGES_PER_GROUP: "1" }]) {
+    const built = f.build(options);
+    assert.equal(built.status, 0, built.stderr);
+    const html = fs.readFileSync(path.join(f.root, "dist/docs-site/guide/first/index.html"), "utf8");
+    assert.ok(!html.includes("undefined/undefined"));
+    assert.match(html, /class="tab-link active" href="\/guide\/first"/);
+    assert.match(html, /class="mobile-tab-link active" href="\/guide\/first"/);
+    assert.match(html, /class="breadcrumb-part breadcrumb-tab"><a href="\/guide\/first">Deep docs<\/a>/);
+    assert.match(html, /data-pagefind-meta="section">Reference<\/span>/);
+    assert.match(html, /class="nav-link active" href="\/guide\/first">First<\/a>/);
+  }
+});


### PR DESCRIPTION
Valid nested navigation in the upstream docs configuration makes mirror-sync builds emit `/undefined/undefined` and fail the internal route audit. The navigation loader preserves arbitrary nesting, but the sidebar renderer treats a second nested group as a page, so its missing locale and slug become the bogus URL. The three pages named by the audit are its first three examples; their Markdown is valid.

Render sidebar groups recursively and use the existing recursive flattener for tab destinations and section lookup. Desktop/mobile tab links, breadcrumbs, search metadata, and previews now resolve descendant pages correctly. Source Markdown, generated sync files, and route-audit rules remain unchanged.

Validated with the exact upstream navigation subtree, three before/after regressions, all 156 tests, full-site rendering/indexing and route audit, live Chrome navigation with synthetic screenshots, clean branch autoreview through P2, and green exact-head Docs Code CI and CodeQL. See the proof comment for run links and images.
