### PR TITLE
fix(docs-site): fail source-index when the stream flush errors

### DIFF
--- a/scripts/docs-site/source-index.mjs
+++ b/scripts/docs-site/source-index.mjs
@@ -2,6 +2,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { finished } from "node:stream/promises";
 
 const root = process.cwd();
 const outDir = path.join(root, "dist", "docs-site");
@@ -127,16 +128,9 @@ for (const rel of files) {
   recordCount += 1;
 }
 
-await new Promise((resolve, reject) => {
-  output.on("error", reject);
-  output.end((err) => {
-    if (err) {
-      reject(err);
-      return;
-    }
-    resolve();
-  });
-});
+const completion = finished(output, { cleanup: true });
+output.end();
+await completion;
 
 const meta = {
   repository: sourceMeta.repository ?? "openclaw/openclaw",

--- a/scripts/docs-site/source-index.mjs
+++ b/scripts/docs-site/source-index.mjs
@@ -127,7 +127,16 @@ for (const rel of files) {
   recordCount += 1;
 }
 
-await new Promise((resolve) => output.end(resolve));
+await new Promise((resolve, reject) => {
+  output.on("error", reject);
+  output.end((err) => {
+    if (err) {
+      reject(err);
+      return;
+    }
+    resolve();
+  });
+});
 
 const meta = {
   repository: sourceMeta.repository ?? "openclaw/openclaw",

--- a/scripts/docs-site/source-index.test.mjs
+++ b/scripts/docs-site/source-index.test.mjs
@@ -45,60 +45,65 @@ test("indexes a repository whose tracked-file list exceeds Node's default buffer
   }
 });
 
-test("fails the process when the source-index write stream flush errors", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-source-index-flush-"));
-  const source = path.join(root, "source");
-  fs.mkdirSync(path.join(source, "src"), { recursive: true });
+for (const operation of ["write", "writev", "close"]) {
+  test(`does not publish completion metadata when fs.${operation} fails`, () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-source-index-flush-"));
+    const source = path.join(root, "source");
+    fs.mkdirSync(path.join(source, "src"), { recursive: true });
 
-  try {
-    git(source, ["init"]);
-    for (let index = 0; index < 101; index += 1) {
+    try {
+      git(source, ["init"]);
+      for (let index = 0; index < 101; index += 1) {
+        fs.writeFileSync(
+          path.join(source, "src", `file-${String(index).padStart(3, "0")}.js`),
+          `export const value = ${index};\n`,
+        );
+      }
+      git(source, ["add", "."]);
+
+      const stub = path.join(root, "stub-flush-error.mjs");
       fs.writeFileSync(
-        path.join(source, "src", `file-${String(index).padStart(3, "0")}.js`),
-        `export const value = ${index};\n`,
-      );
+        stub,
+        `import fs from "node:fs";
+  const createWriteStream = fs.createWriteStream;
+  fs.createWriteStream = function patchedCreateWriteStream(file, options) {
+    if (!String(file).includes("source-index.jsonl")) {
+      return createWriteStream.call(this, file, options);
     }
-    git(source, ["add", "."]);
-
-    const stub = path.join(root, "stub-flush-error.mjs");
-    fs.writeFileSync(
-      stub,
-      `import fs from "node:fs";
-const createWriteStream = fs.createWriteStream;
-fs.createWriteStream = function patchedCreateWriteStream(file, options) {
-  const stream = createWriteStream.call(this, file, options);
-  if (!String(file).includes("source-index.jsonl")) {
-    return stream;
-  }
-  stream.end = function end(cb) {
-    if (typeof cb === "function") {
-      cb(Object.assign(new Error("ENOSPC: mock flush"), { code: "ENOSPC" }));
-    }
-    return this;
-  };
-  return stream;
-};
-`,
-    );
-
-    const result = spawnSync(process.execPath, ["--import", pathToFileURL(stub).href, script], {
-      cwd: root,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        DOCS_SOURCE_REPO_DIR: source,
-        DOCS_SOURCE_SHA: "test-sha",
-      },
+    const fail = (...args) => {
+      const done = () => args.at(-1)(Object.assign(new Error("ENOSPC: injected ${operation} failure"), { code: "ENOSPC" }));
+      if ("${operation}" === "close") fs.close(args[0], done);
+      else process.nextTick(done);
+    };
+    const failingFs = { ...fs, ${operation}: fail };
+    if ("${operation}" === "write") failingFs.writev = undefined;
+    return createWriteStream.call(this, file, {
+      ...options,
+      fs: failingFs,
     });
+  };
+  `,
+      );
 
-    assert.notEqual(result.status, 0, result.stdout + result.stderr);
-    assert.match(`${result.stderr}\n${result.stdout}`, /ENOSPC: mock flush/);
-    assert.doesNotMatch(result.stdout, /indexed \d+ source files/);
-    assert.equal(fs.existsSync(path.join(root, "dist", "docs-site", "source-index-meta.json")), false);
-  } finally {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
+      const result = spawnSync(process.execPath, ["--import", pathToFileURL(stub).href, script], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          DOCS_SOURCE_REPO_DIR: source,
+          DOCS_SOURCE_SHA: "test-sha",
+        },
+      });
+
+      assert.equal(result.status, 1, result.stdout + result.stderr);
+      assert.match(result.stderr, new RegExp(`ENOSPC: injected ${operation} failure`));
+      assert.doesNotMatch(result.stdout, /indexed \d+ source files/);
+      assert.equal(fs.existsSync(path.join(root, "dist", "docs-site", "source-index-meta.json")), false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
 
 function git(dir, args, options = {}) {
   return execFileSync("git", ["-C", dir, ...args], {

--- a/scripts/docs-site/source-index.test.mjs
+++ b/scripts/docs-site/source-index.test.mjs
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const script = fileURLToPath(new URL("./source-index.mjs", import.meta.url));
 
@@ -40,6 +40,61 @@ test("indexes a repository whose tracked-file list exceeds Node's default buffer
 
     const meta = JSON.parse(fs.readFileSync(path.join(root, "dist", "docs-site", "source-index-meta.json"), "utf8"));
     assert.equal(meta.filesConsidered, 14_000);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails the process when the source-index write stream flush errors", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-source-index-flush-"));
+  const source = path.join(root, "source");
+  fs.mkdirSync(path.join(source, "src"), { recursive: true });
+
+  try {
+    git(source, ["init"]);
+    for (let index = 0; index < 101; index += 1) {
+      fs.writeFileSync(
+        path.join(source, "src", `file-${String(index).padStart(3, "0")}.js`),
+        `export const value = ${index};\n`,
+      );
+    }
+    git(source, ["add", "."]);
+
+    const stub = path.join(root, "stub-flush-error.mjs");
+    fs.writeFileSync(
+      stub,
+      `import fs from "node:fs";
+const createWriteStream = fs.createWriteStream;
+fs.createWriteStream = function patchedCreateWriteStream(file, options) {
+  const stream = createWriteStream.call(this, file, options);
+  if (!String(file).includes("source-index.jsonl")) {
+    return stream;
+  }
+  stream.end = function end(cb) {
+    if (typeof cb === "function") {
+      cb(Object.assign(new Error("ENOSPC: mock flush"), { code: "ENOSPC" }));
+    }
+    return this;
+  };
+  return stream;
+};
+`,
+    );
+
+    const result = spawnSync(process.execPath, ["--import", pathToFileURL(stub).href, script], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DOCS_SOURCE_REPO_DIR: source,
+        DOCS_SOURCE_SHA: "test-sha",
+      },
+    });
+
+    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    assert.match(`${result.stderr}\n${result.stdout}`, /ENOSPC: mock flush/);
+    assert.doesNotMatch(result.stdout, /indexed \d+ source files/);
+    assert.equal(fs.existsSync(path.join(root, "dist", "docs-site", "source-index-meta.json")), false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
The source-index completion promise previously resolved even when Node supplied a write error to `end(callback)`. With a real `fs.WriteStream` and injected OS-level `write`/`writev` failures, current main prints `indexed 101 source files` and writes `source-index-meta.json` before its unhandled error exits the process with status 1. This PR uses `finished()` from `node:stream/promises` to wait for both successful writes and file closure before publishing either success signal.

The maintainer regression tests exercise the real stream `write`, `writev`, and `close` paths through Node's supported `fs` override, replacing the callback-only mock. Successful indexing is unchanged. The fix and original regression work are by @SebTardif.

Validation on macOS, Node v24.20.0:

- All three new I/O-failure regressions fail against main and pass against this PR; the existing large tracked-file-list test also passes (4/4).
- The real `source-index.mjs` indexes a synthetic 101-file Git repository successfully. With an injected ENOSPC filesystem callback, main writes completion metadata and logs success before exiting 1; this PR exits 1 without either completion signal. A genuine EISDIR output-open failure also exits 1 without metadata.
- Full `npm test`: 159 passed, including the browser anchor tests.
- Autoreview caught a late-close failure in the original patch: it resolved on `end()` and then swallowed the close error, exiting 0. The repaired script exits 1 with no metadata or success log for that same real-stream failure.
- Independent Codex autoreview and exact-head CI are recorded in the proof comment.

Scope: this prevents false completion metadata/logging; it does not claim that a real filesystem failure previously exited 0. No production disk was filled. The changelog entry is carried by the final notes PR to keep sibling branches independent.
