### PR TITLE
improve: publish small docs updates without rerendering every article

### DIFF
--- a/.github/workflows/r2-pages.yml
+++ b/.github/workflows/r2-pages.yml
@@ -215,6 +215,16 @@ jobs:
         if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
         run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
 
+      - name: Restore rendered articles
+        if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
+        id: article-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: .cache/docs-render
+          key: docs-articles-v1-${{ runner.os }}-${{ hashFiles('scripts/docs-site/render-cache.mjs', 'scripts/docs-site/mdx-ish.mjs', '.openclaw-sync/lib/docs-markdown.mjs', 'package-lock.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            docs-articles-v1-${{ runner.os }}-${{ hashFiles('scripts/docs-site/render-cache.mjs', 'scripts/docs-site/mdx-ish.mjs', '.openclaw-sync/lib/docs-markdown.mjs', 'package-lock.json') }}-
+
       - name: Build R2 artifact
         if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
         env:
@@ -393,3 +403,11 @@ jobs:
           BEFORE_SHA: ${{ github.event.before || '' }}
           SMOKE_COMMIT_RANGE: ${{ inputs.smoke_commit_range || '' }}
         run: node scripts/docs-site/head-drift.mjs catch-up
+
+      # Cache storage must not hold up this run's publication or live smoke.
+      - name: Save rendered articles
+        if: ${{ !cancelled() && steps.upload-r2.outcome == 'success' }}
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: .cache/docs-render
+          key: ${{ steps.article-cache.outputs.cache-primary-key }}

--- a/CLOUDFLARE.md
+++ b/CLOUDFLARE.md
@@ -98,7 +98,28 @@ The global `r2-pages` queue serializes admission, build, and publication. After 
 
 After successful R2 publication (or a Worker-only deployment), the same head/successor helper checks main again and dispatches a full successor for artifact-relevant drift with no verified run. This catches changes whose push did not trigger R2, including `GITHUB_TOKEN` and skip-ci pushes during the build. API lookup failure biases to dispatch; dispatch failure fails the job without undoing publication. Catch-up also runs if live-smoke scheduling failed after publication. It never changes the admission verdict or gates the completed upload. This ordering applies to the automatic R2 queue without relying on FIFO ordering; manual Pages router deployment remains operator-owned outside that queue.
 
-Production router deploy:
+### Incremental article rendering
+
+R2 upload already skips unchanged objects; the builder also reuses unchanged
+rendered articles from `.cache/docs-render`. The deployment restores this cache
+before building and saves it after publication and live-smoke scheduling. A cold
+or evicted cache still builds the complete site normally.
+
+Cache identity includes the raw page, its source-relative path and route, the
+renderer/parser source, locked dependencies, and Node version/platform. It does
+not include the source commit, so a one-page edit does not invalidate all locales.
+Pages containing `<Snippet` always render afresh, including nested or newly
+available snippet dependencies. Removed pages' entries are pruned.
+
+Only article HTML is cached. Navigation, locale-aware links, page chrome, edit
+links, redirects, Markdown exports, OG cards, and search indexes are rebuilt from
+the current snapshot. Deletions and publication ordering are unchanged. Logs
+report article hits, misses, and snippet bypasses. For an uncached comparison,
+run `DOCS_SITE_RENDER_CACHE=0 npm run docs:build:r2`; preview builds bypass the
+cache automatically. This optimization does not remove the upstream source-sync
+queue or full MDX validation, and the first deployment must populate the cache.
+
+### Router deployment
 
 1. On a main push that changes `workers/**` or `wrangler.toml`, `r2-pages.yml` deploys the matching Worker after any required R2 upload, provided that snapshot passed admission before the build.
 2. `pages.yml` pushes validate the Worker bundle with `wrangler deploy --dry-run`; they do not deploy it.

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -8,6 +8,7 @@ import { ignoredDocDirs, ignoredDocFiles, localeFlags, localeLabels, mintlifyLoc
 import { siteCss, siteJs } from "./assets.mjs";
 import { chromeStringsForLocale } from "./chrome-strings.mjs";
 import { createMarkdownRenderer, renderMdxish } from "./mdx-ish.mjs";
+import { createRenderCache } from "./render-cache.mjs";
 import { editSourceUrlForPage, frontmatterSourcePath, readSourceMetadata } from "./edit-source.mjs";
 import { elementsFixture } from "./elements-fixture.mjs";
 import { parseFrontmatter } from "../../.openclaw-sync/lib/docs-markdown.mjs";
@@ -25,6 +26,7 @@ fs.rmSync(redirectMetadataPath, { force: true });
 const config = JSON.parse(fs.readFileSync(path.join(docsDir, "docs.json"), "utf8"));
 const sourceMetadata = readSourceMetadata(root);
 const md = createMarkdownRenderer();
+const renderArticle = (markdown, options) => renderMdxish(markdown, md, options);
 const basePath = normalizeBasePath(process.env.DOCS_SITE_BASE_PATH ?? "");
 const legacyBasePath = normalizeBasePath(process.env.DOCS_SITE_LEGACY_BASE_PATH ?? "/docs");
 const canonicalOrigin = (process.env.DOCS_SITE_CANONICAL_ORIGIN
@@ -59,6 +61,9 @@ const previewPagesPerGroup = parseOptionalPositiveInt(
 const previewMaxPages = parseOptionalPositiveInt(process.env.DOCS_SITE_PREVIEW_MAX_PAGES, "DOCS_SITE_PREVIEW_MAX_PAGES");
 const previewLocale = process.env.DOCS_SITE_PREVIEW_LOCALE;
 const previewMode = Boolean(previewPagesPerGroup || previewMaxPages || previewLocale);
+const renderCache = !previewMode && process.env.DOCS_SITE_RENDER_CACHE !== "0"
+  ? createRenderCache(path.join(root, ".cache", "docs-render"), renderArticle)
+  : null;
 const includeElementsFixture = !previewMode || process.env.DOCS_SITE_PREVIEW_INCLUDE_FIXTURE === "1";
 if (!["full", "shell"].includes(artifactMode)) {
   throw new Error(`DOCS_SITE_ARTIFACT_MODE must be full or shell, got ${artifactMode}`);
@@ -90,6 +95,11 @@ const localePickerLabels = {
 copyPublicFiles();
 if (!previewMode) await renderPageOgCards();
 for (const page of pages) writePage(page);
+if (renderCache) {
+  renderCache.prune();
+  const { hits, misses, bypassed } = renderCache.stats;
+  console.log(`article cache: ${hits} reused, ${misses} rendered, ${bypassed} snippet owners rendered`);
+}
 if (!shellOnly) {
   writeLlmsIndex();
   writeRobotsTxt();
@@ -257,7 +267,9 @@ function writePage(page) {
   const activeTab = activeTabTitle(nav, page.slug);
   const prev = activeIndex > 0 ? flat[activeIndex - 1] : null;
   const next = activeIndex >= 0 && activeIndex < flat.length - 1 ? flat[activeIndex + 1] : null;
-  const html = rewriteInternalUrls(renderMdxish(page.raw, md, { sourceFile: page.file, root, pageRoute: pageRoute(page) }), page.locale);
+  const options = { sourceFile: page.file, root, pageRoute: pageRoute(page) };
+  const article = renderCache ? renderCache.render(page.raw, options) : renderArticle(page.raw, options);
+  const html = rewriteInternalUrls(article, page.locale);
   const toc = tableOfContents(html);
   const outPath = path.join(outDir, pageRoute(page).replace(/^\//, ""), "index.html");
   fs.mkdirSync(path.dirname(outPath), { recursive: true });

--- a/scripts/docs-site/render-cache.mjs
+++ b/scripts/docs-site/render-cache.mjs
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+// Cache the rendered article, never the surrounding navigation or locale links.
+// Those depend on the complete current page set and are rebuilt on every run.
+export function createRenderCache(directory, render, signature = rendererSignature()) {
+  fs.mkdirSync(directory, { recursive: true });
+  const used = new Set();
+  const stats = { hits: 0, misses: 0, bypassed: 0 };
+  return {
+    stats,
+    render(markdown, options) {
+      // Snippets can read arbitrary files (including nested snippets). Render
+      // their owners afresh instead of maintaining another dependency graph.
+      if (markdown.includes("<Snippet")) {
+        stats.bypassed++;
+        return render(markdown, options);
+      }
+      const identity = JSON.stringify([path.relative(options.root, options.sourceFile), options.pageRoute]);
+      const filename = `${digest(identity)}.json`;
+      const file = path.join(directory, filename);
+      const input = digest(JSON.stringify([signature, identity, markdown]));
+      used.add(filename);
+      try {
+        const cached = JSON.parse(fs.readFileSync(file, "utf8"));
+        if (cached?.input === input && typeof cached.html === "string") {
+          stats.hits++;
+          return cached.html;
+        }
+      } catch (error) {
+        // A missing or interrupted cache write is a miss, not missing content.
+        if (error.code !== "ENOENT" && !(error instanceof SyntaxError)) throw error;
+      }
+      stats.misses++;
+      const html = render(markdown, options);
+      fs.writeFileSync(file, JSON.stringify({ input, html }));
+      return html;
+    },
+    prune() {
+      // Keep one entry per current page, not every historical content version.
+      for (const entry of fs.readdirSync(directory)) {
+        if (/^[a-f0-9]{64}\.json$/.test(entry) && !used.has(entry)) {
+          fs.rmSync(path.join(directory, entry));
+        }
+      }
+    },
+  };
+}
+
+function digest(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function rendererSignature() {
+  const hash = createHash("sha256").update(JSON.stringify([process.version, process.platform]));
+  // Include the renderer's source closure and locked dependencies, not the
+  // source commit or docs tree: unrelated edits must not evict every article.
+  for (const file of [
+    new URL("./render-cache.mjs", import.meta.url),
+    new URL("./mdx-ish.mjs", import.meta.url),
+    new URL("../../.openclaw-sync/lib/docs-markdown.mjs", import.meta.url),
+    new URL("../../package-lock.json", import.meta.url),
+  ]) {
+    hash.update(fs.readFileSync(file)).update("\0");
+  }
+  return hash.digest("hex");
+}

--- a/scripts/docs-site/render-cache.test.mjs
+++ b/scripts/docs-site/render-cache.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createMarkdownRenderer, renderMdxish } from "./mdx-ish.mjs";
+import { createRenderCache } from "./render-cache.mjs";
+import { fixture, write } from "./test-helpers/redirect-fixture.mjs";
+
+test("article cache reuses exact input, invalidates changes and recovers interrupted writes", (t) => {
+  const f = fixture(t);
+  const directory = path.join(f.root, ".cache/docs-render");
+  const md = createMarkdownRenderer();
+  let calls = 0;
+  const render = (source, options) => { calls++; return renderMdxish(source, md, options); };
+  const options = { root: f.root, sourceFile: path.join(f.root, "docs/guide.md"), pageRoute: "/guide" };
+  const source = "## Heading\n\n[Next](./next.md)\n\n```js\nconst value = 1;\n```\n";
+  const cache = createRenderCache(directory, render, "renderer-1");
+  assert.equal(cache.render(source, options), renderMdxish(source, md, options));
+  const restored = createRenderCache(directory, render, "renderer-1");
+  assert.equal(restored.render(source, options), renderMdxish(source, md, options));
+  assert.equal(calls, 1, "a new cache instance reuses the on-disk entry");
+  const changed = source.replace("value = 1", "value = 2");
+  assert.equal(restored.render(changed, options), renderMdxish(changed, md, options));
+  assert.equal(calls, 2);
+  for (const altered of [{ ...options, pageRoute: "/nested/guide" }, { ...options, sourceFile: path.join(f.root, "docs/moved.md") }]) {
+    assert.equal(restored.render(changed, altered), renderMdxish(changed, md, altered));
+  }
+  assert.equal(calls, 4, "route and source path are part of cache identity");
+  const upgraded = createRenderCache(directory, render, "renderer-2");
+  upgraded.render(changed, options);
+  assert.equal(calls, 5, "renderer changes invalidate old entries");
+  upgraded.prune();
+  assert.equal(fs.readdirSync(directory).length, 1, "obsolete identities are pruned");
+  fs.writeFileSync(path.join(directory, fs.readdirSync(directory)[0]), '{"input":');
+  assert.equal(upgraded.render(changed, options), renderMdxish(changed, md, options));
+  assert.equal(calls, 6, "truncated entries are rendered again");
+});
+
+test("snippet owners always observe nested edits and newly created dependencies", (t) => {
+  const f = fixture(t);
+  const md = createMarkdownRenderer();
+  const cache = createRenderCache(path.join(f.root, ".cache/docs-render"), (source, options) => renderMdxish(source, md, options));
+  const options = { root: f.root, sourceFile: path.join(f.root, "docs/guide.md"), pageRoute: "/guide" };
+  const source = '<Snippet file="outer.md" />';
+  write(f.root, "docs/outer.md", '<Snippet file="inner.md" />');
+  assert.doesNotMatch(cache.render(source, options), /Current|Updated/);
+  write(f.root, "docs/inner.md", "Current snippet");
+  assert.match(cache.render(source, options), /Current snippet/);
+  write(f.root, "docs/inner.md", "Updated snippet");
+  assert.match(cache.render(source, options), /Updated snippet/);
+  assert.deepEqual(cache.stats, { hits: 0, misses: 0, bypassed: 3 });
+});
+
+test("warm builds refresh navigation, locale links and deletions outside cached articles", (t) => {
+  const f = fixture(t, [], { "guide.md": "# Guide\n\n[Target](/target)\n", "target.md": "# Target\n", "de/guide.md": "# Anleitung\n\n[Target](/target)\n" });
+  const config = (title, slugs) => ({ name: "Cache fixture", navigation: { languages: ["en", "de"].map((language) => ({ language, tabs: [{ tab: title, groups: [{ group: "Guides", pages: slugs }] }] })) } });
+  write(f.root, "docs/docs.json", JSON.stringify(config("Before", ["guide", "target"])));
+  let built = f.build();
+  assert.equal(built.status, 0, built.stderr);
+  const html = (rel) => fs.readFileSync(path.join(f.root, "dist/docs-site", rel, "index.html"), "utf8");
+  assert.match(html("de/guide"), /href="\/target">Target/);
+  write(f.root, "docs/de/target.md", "# Ziel\n");
+  write(f.root, "docs/docs.json", JSON.stringify(config("After", ["guide", "target"])));
+  built = f.build();
+  assert.equal(built.status, 0, built.stderr);
+  assert.match(built.stdout, /article cache: [1-9]\d* reused/);
+  assert.match(html("de/guide"), /href="\/de\/target">Target/);
+  assert.match(html("guide"), /After/);
+  assert.doesNotMatch(html("guide"), />Before</);
+  fs.rmSync(path.join(f.root, "docs/de/target.md"));
+  built = f.build();
+  assert.equal(built.status, 0, built.stderr);
+  assert.equal(fs.existsSync(path.join(f.root, "dist/docs-site/de/target/index.html")), false);
+  assert.match(html("de/guide"), /href="\/target">Target/);
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a small docs edit waits for every article in every locale to render again before it can publish. In production run [34248189234](https://github.com/openclaw/docs/actions/runs/34248189234), building the artifact took 10m07s, while uploading 154 changed objects took nine seconds (99.8% of objects were already unchanged).

## Why This Change Was Made

Reuse rendered article bodies across deployments. Cache identity follows page content, source-relative path/route, renderer/parser code, locked dependencies, and Node runtime—not the source commit. Snippet owners always render afresh, avoiding a second dependency-tracking system. Navigation and locale links are applied after cache lookup.

The R2 workflow restores the article cache before building and saves it after publication. Cold, missing, or truncated entries render normally. Old page entries are pruned. No queue cancellation, new deployment lanes, publication-order changes, skipped locales, or weakened smoke checks.

This is a bounded improvement to the dominant R2 build cost, not a claim to eliminate the upstream source-sync queue/full MDX validation or Pagefind indexing. The first deployment populates the cache.

## User Impact

Small docs updates stop paying the full article-rendering cost of the entire locale corpus. All current pages, Markdown exports, navigation, redirects, OG cards, and search indexes remain in the artifact. No content or visual changes are intended.

## Evidence

- Baseline: full 15,068-page local builder at mirror `b7ae2ddc5ca65604a1446c7913c653808b92635a` took **213.62s**, with a CPU profile. Heading transliteration/regex construction dominates the sampled CPU time.
- Warm full builder: **31.15s** for the same 15,068 pages, with **15,067 cache hits, zero misses, and one snippet-owner bypass**. That is about **6.9x faster / 85% less wall time** than the profiled local baseline. Profiling adds baseline overhead; this is a local builder comparison, not a hosted end-to-end deployment benchmark.
- Required `make docs-check` passed in **120.19s**, including the full site, Pagefind, R2 artifact preparation, and full smoke checks. Its builder also reused 15,067 articles. The original side-thread build result was unavailable, so this was a fresh successful run, not an inferred completion.
- **All 43,999 baseline-generated files are byte-for-byte unchanged**, both after the full pipeline and after the standalone warm builder. The full pipeline added 16,938 search/pipeline files outside the original builder-only baseline; those are not covered by the byte-equivalence claim. Local source indexing was explicitly skipped because this isolated checkout has no OpenClaw source checkout.
- 8 focused cache/navigation/locale tests passed. They cover persisted reuse, content/path/route/renderer invalidation, truncated-cache recovery, pruning, nested/new snippets, current navigation, translation arrival, and deletion.
- 36 existing publication-order and workflow-timeout checks passed; no production workflow was dispatched or cancelled.
- JavaScript syntax, workflow YAML parsing, and `git diff --check` passed.
- [Docs Code CI](https://github.com/openclaw/docs/actions/runs/34251251374) passed, including helper tests, Worker dry-run, shell build/smoke, and visual smoke. [CodeQL](https://github.com/openclaw/docs/actions/runs/34251251318) passed. No reviewer findings were posted at verification time.

Cold builds must still populate the cache. The local article cache is about 610 MiB; hosted cache compression/transfer overhead has not been measured. Source-sync queueing, full MDX validation, Pagefind, and the existing serialized deployment queue remain. No production dispatch, cancellation, merge, or deployment was performed to benchmark this change.

Plan: implementation, focused checks, full artifact equivalence, performance verification, and CI are complete. Ready for human review; this PR is not merged or deployed.
