### PR TITLE
improve: reuse docs preview images and avoid duplicate artifact copying

### DIFF
--- a/.github/workflows/docs-code-ci.yml
+++ b/.github/workflows/docs-code-ci.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
-
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/r2-pages.yml
+++ b/.github/workflows/r2-pages.yml
@@ -211,10 +211,6 @@ jobs:
         if: steps.current-main.outputs.stale == 'false' && (steps.artifact-scope.outputs.scope != 'none' || steps.artifact-scope.outputs.deploy_worker == '1')
         run: npm ci
 
-      - name: Install librsvg2-bin
-        if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
-        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
-
       - name: Restore rendered articles
         if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
         id: article-cache
@@ -224,6 +220,16 @@ jobs:
           key: docs-articles-v1-${{ runner.os }}-${{ hashFiles('scripts/docs-site/render-cache.mjs', 'scripts/docs-site/mdx-ish.mjs', '.openclaw-sync/lib/docs-markdown.mjs', 'package-lock.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             docs-articles-v1-${{ runner.os }}-${{ hashFiles('scripts/docs-site/render-cache.mjs', 'scripts/docs-site/mdx-ish.mjs', '.openclaw-sync/lib/docs-markdown.mjs', 'package-lock.json') }}-
+
+      - name: Restore preview images
+        if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
+        id: og-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .cache/docs-og
+          key: docs-og-v1-${{ runner.os }}-${{ hashFiles('scripts/docs-site/og-cache.mjs', 'scripts/docs-site/og-render-worker.mjs', 'scripts/docs-site/fonts/**', 'package-lock.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            docs-og-v1-${{ runner.os }}-${{ hashFiles('scripts/docs-site/og-cache.mjs', 'scripts/docs-site/og-render-worker.mjs', 'scripts/docs-site/fonts/**', 'package-lock.json') }}-
 
       - name: Build R2 artifact
         if: steps.current-main.outputs.stale == 'false' && steps.artifact-scope.outputs.scope != 'none'
@@ -411,3 +417,10 @@ jobs:
         with:
           path: .cache/docs-render
           key: ${{ steps.article-cache.outputs.cache-primary-key }}
+
+      - name: Save preview images
+        if: ${{ !cancelled() && steps.upload-r2.outcome == 'success' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .cache/docs-og
+          key: ${{ steps.og-cache.outputs.cache-primary-key }}

--- a/CLOUDFLARE.md
+++ b/CLOUDFLARE.md
@@ -28,6 +28,11 @@ The repo-side pieces are in place:
 
 `r2-upload.mjs` downloads `.openclaw-docs-r2-manifest.json` from R2, compares hashes and metadata, uploads only changed objects through the R2 S3 API, and then writes the new manifest back. The first upload seeds everything; later uploads should be small.
 
+Manifest files refer directly to the checked `dist/docs-site` tree; preparation
+does not make a second `dist/docs-r2` copy. Keep that tree unchanged until upload
+finishes. Slashless aliases reuse their physical file's hashes and HTTP metadata;
+remote object comparison and deletion accounting are unchanged.
+
 ## Current Production State
 
 Production is cut over to R2-backed storage with a small Worker router in front:
@@ -111,13 +116,33 @@ not include the source commit, so a one-page edit does not invalidate all locale
 Pages containing `<Snippet` always render afresh, including nested or newly
 available snippet dependencies. Removed pages' entries are pruned.
 
-Only article HTML is cached. Navigation, locale-aware links, page chrome, edit
-links, redirects, Markdown exports, OG cards, and search indexes are rebuilt from
+Only article HTML is cached by this cache. Navigation, locale-aware links, page chrome, edit
+links, redirects, Markdown exports, and search indexes are rebuilt from
 the current snapshot. Deletions and publication ordering are unchanged. Logs
 report article hits, misses, and snippet bypasses. For an uncached comparison,
 run `DOCS_SITE_RENDER_CACHE=0 npm run docs:build:r2`; preview builds bypass the
 cache automatically. This optimization does not remove the upstream source-sync
 queue or full MDX validation, and the first deployment must populate the cache.
+
+### Preview image reuse
+
+Per-page social-preview PNGs use the separate `.cache/docs-og` cache. A hit needs
+the same generated SVG (title, summary and navigation label), renderer/options,
+font bytes, locked dependencies and Node/platform identity. Missing or damaged
+entries render again; only images selected by the current page/navigation snapshot
+are written to the output, and unselected cache entries are pruned. Preview mode
+still skips per-page OG generation.
+
+The deployment restores images before building and saves them after publication.
+Logs distinguish reused images from actual renders. `DOCS_SITE_RENDER_CACHE=0`
+also bypasses this cache, without creating or pruning it. The renderer uses the
+locked `@resvg/resvg-js` package with embedded fonts, not `rsvg-convert`, so the
+workflow does not install `librsvg2-bin`.
+
+Pagefind still builds a complete current index. Its immutable-file reuse is not
+enabled here: retaining an old output directory without an exact current-file
+inventory would also retain obsolete search fragments. Publication order, search
+coverage and old-object deletion remain unchanged.
 
 ### Router deployment
 

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -13,6 +13,7 @@ import { editSourceUrlForPage, frontmatterSourcePath, readSourceMetadata } from 
 import { elementsFixture } from "./elements-fixture.mjs";
 import { parseFrontmatter } from "../../.openclaw-sync/lib/docs-markdown.mjs";
 import { renderPageOgSvg } from "./og-card-template.mjs";
+import { createOgCache } from "./og-cache.mjs";
 import { resolveRedirects } from "../../.openclaw-sync/lib/docs-redirects.mjs";
 
 const root = process.cwd();
@@ -812,6 +813,9 @@ async function renderPageOgCards() {
     page.locale === "en" && page.slug !== "index" && navSlugs.has(page.slug)
   );
   const start = Date.now();
+  const cache = process.env.DOCS_SITE_RENDER_CACHE !== "0"
+    ? createOgCache(path.join(root, ".cache", "docs-og"), renderOgPng)
+    : null;
   const concurrency = Math.max(2, Math.min(8, Number(process.env.DOCS_SITE_OG_CONCURRENCY) || 6));
   let cursor = 0;
   let count = 0;
@@ -824,7 +828,7 @@ async function renderPageOgCards() {
       const outFile = path.join(ogDir, `${page.slug}.png`);
       fs.mkdirSync(path.dirname(outFile), { recursive: true });
       try {
-        fs.writeFileSync(outFile, await renderOgPng(svg));
+        fs.writeFileSync(outFile, await (cache ? cache.render(page.slug, svg) : renderOgPng(svg)));
         renderedPageOgCards.add(page.slug);
         count++;
       } catch (err) {
@@ -836,7 +840,13 @@ async function renderPageOgCards() {
     const details = failures.slice(0, 5).join("; ");
     throw new Error(`failed to render ${failures.length}/${targets.length} per-page og cards: ${details}`);
   }
-  console.log(`rendered ${count}/${targets.length} per-page og cards in ${Date.now() - start}ms`);
+  if (cache) {
+    cache.prune();
+    console.log(`og cache: ${cache.stats.hits} reused, ${cache.stats.misses} rendered`);
+  } else {
+    console.log(`og cache: disabled, ${count} rendered`);
+  }
+  console.log(`prepared ${count}/${targets.length} per-page og cards in ${Date.now() - start}ms`);
 }
 
 function renderOgPng(svg) {

--- a/scripts/docs-site/head-drift.test.mjs
+++ b/scripts/docs-site/head-drift.test.mjs
@@ -121,7 +121,7 @@ test("a successorless docs push during an admitted build is scheduled after the 
 
 const sourceSteps = ["Read source metadata", "Check out OpenClaw source"];
 const setupSteps = ["Set up Node", "Install"];
-const artifactSteps = ["Install librsvg2-bin", "Build R2 artifact", "Smoke generated site", "Resolve R2 credentials", "Upload changed R2 objects"];
+const artifactSteps = ["Restore rendered articles", "Restore preview images", "Build R2 artifact", "Smoke generated site", "Resolve R2 credentials", "Upload changed R2 objects"];
 
 test("push trigger paths stay in sync with the R2 Pages workflow", () => {
   assert.deepEqual(pushTriggerPaths, workflow.on.push.paths);

--- a/scripts/docs-site/og-cache.mjs
+++ b/scripts/docs-site/og-cache.mjs
@@ -1,0 +1,73 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+// One entry per selected route. The SVG already contains title, summary and
+// navigation kicker; the signature covers the renderer, its options and fonts.
+export function createOgCache(directory, render) {
+  const signature = ogRendererSignature();
+  fs.mkdirSync(directory, { recursive: true });
+  const used = new Set();
+  const stats = { hits: 0, misses: 0 };
+  return {
+    stats,
+    async render(slug, svg) {
+      const filename = `${digest(slug)}.json`;
+      const file = path.join(directory, filename);
+      const input = digest(JSON.stringify([signature, svg]));
+      used.add(filename);
+      try {
+        const cached = JSON.parse(fs.readFileSync(file, "utf8"));
+        if (cached?.input === input && typeof cached.png === "string") {
+          const png = Buffer.from(cached.png, "base64");
+          if (isPng(png) && digest(png) === cached.sha256) {
+            stats.hits++;
+            return png;
+          }
+        }
+      } catch (error) {
+        if (error.code !== "ENOENT" && !(error instanceof SyntaxError)) throw error;
+      }
+      stats.misses++;
+      const png = Buffer.from(await render(svg));
+      if (!isPng(png)) throw new Error("OG renderer returned an invalid PNG");
+      const temporary = `${file}.tmp`;
+      fs.writeFileSync(temporary, JSON.stringify({ input, sha256: digest(png), png: png.toString("base64") }));
+      fs.renameSync(temporary, file);
+      return png;
+    },
+    prune() {
+      for (const entry of fs.readdirSync(directory)) {
+        if (/^[a-f0-9]{64}\.json(?:\.tmp)?$/.test(entry) && !used.has(entry)) {
+          fs.rmSync(path.join(directory, entry));
+        }
+      }
+    },
+  };
+}
+
+function isPng(bytes) {
+  return bytes.length >= 20
+    && bytes.subarray(0, 8).equals(Buffer.from("89504e470d0a1a0a", "hex"))
+    && bytes.subarray(-12).equals(Buffer.from("0000000049454e44ae426082", "hex"));
+}
+
+function digest(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function ogRendererSignature() {
+  const hash = createHash("sha256").update(JSON.stringify([process.versions, process.platform, process.arch]));
+  for (const file of [
+    new URL("./og-cache.mjs", import.meta.url),
+    new URL("./og-render-worker.mjs", import.meta.url),
+    new URL("../../package-lock.json", import.meta.url),
+  ]) {
+    hash.update(fs.readFileSync(file)).update("\0");
+  }
+  const fonts = new URL("./fonts/", import.meta.url);
+  for (const name of fs.readdirSync(fonts).filter((name) => /\.(otf|ttf)$/.test(name)).sort()) {
+    hash.update(name).update("\0").update(fs.readFileSync(new URL(name, fonts))).update("\0");
+  }
+  return hash.digest("hex");
+}

--- a/scripts/docs-site/og-cache.test.mjs
+++ b/scripts/docs-site/og-cache.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
+import { renderPageOgSvg } from "./og-card-template.mjs";
+import { fixture, write } from "./test-helpers/redirect-fixture.mjs";
+
+test("OG cache restores exact PNGs, invalidates render inputs and repairs damaged entries", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-og-cache-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const source = path.join(root, "scripts/docs-site");
+  fs.mkdirSync(source, { recursive: true });
+  for (const name of ["og-cache.mjs", "og-render-worker.mjs", "fonts"]) {
+    fs.cpSync(new URL(name, import.meta.url), path.join(source, name), { recursive: true });
+  }
+  fs.copyFileSync(new URL("../../package-lock.json", import.meta.url), path.join(root, "package-lock.json"));
+  fs.symlinkSync(fileURLToPath(new URL("../../node_modules", import.meta.url)), path.join(root, "node_modules"), "dir");
+  const { createOgCache } = await import(pathToFileURL(path.join(source, "og-cache.mjs")));
+  const directory = path.join(root, ".cache/docs-og");
+  const workerUrl = pathToFileURL(path.join(source, "og-render-worker.mjs"));
+  let renders = 0;
+  const render = async (svg) => { renders++; return renderPng(svg, workerUrl); };
+  const input = { title: "Guide", summary: "Set up your gateway", kicker: "Start" };
+  let svg = renderPageOgSvg(input);
+  const cold = createOgCache(directory, render);
+  const original = await cold.render("guide", svg);
+  const warm = createOgCache(directory, render);
+  assert.deepEqual(await warm.render("guide", svg), original);
+  assert.equal(renders, 1, "restoring a cache in a new build does not call the renderer");
+  for (const changed of [
+    { ...input, title: "Updated guide" },
+    { ...input, summary: "Configure a remote gateway" },
+    { ...input, kicker: "Reference" },
+  ]) {
+    svg = renderPageOgSvg(changed);
+    const previousRenders = renders;
+    assert.notDeepEqual(await warm.render("guide", svg), original);
+    assert.equal(renders, previousRenders + 1);
+  }
+  fs.copyFileSync(path.join(source, "fonts/Switzer-Bold.otf"), path.join(source, "fonts/Switzer-Regular.otf"));
+  const rendererChanged = createOgCache(directory, render);
+  const beforeUpgrade = renders;
+  const latest = await rendererChanged.render("guide", svg);
+  assert.equal(renders, beforeUpgrade + 1);
+  const file = path.join(directory, fs.readdirSync(directory)[0]);
+  for (const damage of ["truncated JSON", "changed PNG", "missing PNG"]) {
+    const entry = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (damage === "changed PNG") {
+      const bytes = Buffer.from(entry.png, "base64");
+      bytes[bytes.length - 20] ^= 1;
+      entry.png = bytes.toString("base64");
+    } else if (damage === "missing PNG") {
+      delete entry.png;
+    }
+    fs.writeFileSync(file, damage === "truncated JSON" ? '{"input":' : JSON.stringify(entry));
+    const beforeRepair = renders;
+    assert.deepEqual(await rendererChanged.render("guide", svg), latest);
+    assert.equal(renders, beforeRepair + 1, damage);
+  }
+  fs.rmSync(file);
+  assert.deepEqual(await rendererChanged.render("guide", svg), latest, "an evicted entry is a cold render");
+  await rendererChanged.render("removed-route", svg);
+  const nextBuild = createOgCache(directory, render);
+  await nextBuild.render("guide", svg);
+  nextBuild.prune();
+  assert.equal(fs.readdirSync(directory).length, 1, "only current selected routes remain cached");
+});
+
+test("warm builds keep current OG selection and refresh navigation-dependent cards", (t) => {
+  const f = fixture(t, [], { "guide.md": '# Guide\n', "other.md": '# Other\n' });
+  const config = (group, pages) => ({ name: "OG fixture", navigation: { languages: [
+    { language: "en", tabs: [{ tab: "Docs", groups: [{ group, pages }] }] },
+  ] } });
+  const build = (env = {}) => {
+    const result = f.build(env);
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout;
+  };
+  const ogFile = path.join(f.root, "dist/docs-site/og/guide.png");
+  const cacheDir = path.join(f.root, ".cache/docs-og");
+  write(f.root, "docs/docs.json", JSON.stringify(config("Start", ["guide", "other"])));
+  assert.match(build({ DOCS_SITE_RENDER_CACHE: "0" }), /og cache: disabled, 2 rendered/);
+  assert.equal(fs.existsSync(cacheDir), false, "disabled builds do not create an OG cache");
+  const uncached = fs.readFileSync(ogFile);
+  assert.match(build(), /og cache: 0 reused, 2 rendered/);
+  const first = fs.readFileSync(ogFile);
+  assert.deepEqual(first, uncached);
+  write(f.root, "docs/guide.md", '# Guide\n\nA body-only update.\n');
+  assert.match(build(), /og cache: 2 reused, 0 rendered/);
+  assert.deepEqual(fs.readFileSync(ogFile), first);
+  const snapshot = () => fs.readdirSync(cacheDir).sort().map((file) => [file, fs.readFileSync(path.join(cacheDir, file))]);
+  const cached = snapshot();
+  write(f.root, "docs/docs.json", JSON.stringify(config("Reference", ["guide"])));
+  assert.match(build({ DOCS_SITE_RENDER_CACHE: "0" }), /og cache: disabled, 1 rendered/);
+  assert.notDeepEqual(fs.readFileSync(ogFile), first);
+  assert.deepEqual(snapshot(), cached, "disabled builds neither update nor prune existing OG cache entries");
+  assert.match(build(), /og cache: 0 reused, 1 rendered/);
+  assert.notDeepEqual(fs.readFileSync(ogFile), first);
+  assert.equal(fs.existsSync(path.join(f.root, "dist/docs-site/og/other.png")), false);
+  assert.equal(fs.readdirSync(cacheDir).length, 1);
+});
+
+function renderPng(svg, workerUrl) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(workerUrl, { workerData: { svg } });
+    worker.once("message", (message) => message.error ? reject(new Error(message.error)) : resolve(Buffer.from(message.png)));
+    worker.once("error", reject);
+    worker.once("exit", (code) => { if (code) reject(new Error(`OG worker exited ${code}`)); });
+  });
+}

--- a/scripts/docs-site/r2-prepare.mjs
+++ b/scripts/docs-site/r2-prepare.mjs
@@ -5,7 +5,6 @@ import path from "node:path";
 
 const root = process.cwd();
 const sourceDir = path.join(root, "dist", "docs-site");
-const outputDir = path.join(root, "dist", "docs-r2");
 const manifestPath = path.join(root, "dist", "docs-r2-manifest.json");
 const redirectMetadataPath = path.join(root, "dist", "docs-markdown-redirects.json");
 const markdownRedirects = fs.existsSync(redirectMetadataPath)
@@ -13,23 +12,23 @@ const markdownRedirects = fs.existsSync(redirectMetadataPath)
 
 if (!fs.existsSync(sourceDir)) throw new Error("dist/docs-site does not exist; run docs:build first");
 
-fs.rmSync(outputDir, { recursive: true, force: true });
-copyTree(sourceDir, outputDir);
-
+// The uploader reads entry.file directly. Keep the checked build in place
+// through upload instead of copying it into another full artifact tree.
 const entries = [];
-for (const file of walk(outputDir)) {
-  const key = toKey(path.relative(outputDir, file));
+const aliases = [];
+let physicalFiles = 0;
+for (const file of walk(sourceDir)) {
+  physicalFiles++;
+  const key = toKey(path.relative(sourceDir, file));
   if (key === "_headers") continue;
-  entries.push(entryFor(key, file, key));
+  const entry = entryFor(key, file, key);
+  entries.push(entry);
+  if (key.endsWith("/index.html")) {
+    // Aliases publish the same bytes and metadata under a second object key.
+    aliases.push({ ...entry, key: key.slice(0, -"/index.html".length) });
+  }
 }
-
-for (const file of walk(outputDir)) {
-  const rel = toKey(path.relative(outputDir, file));
-  if (rel === "_headers") continue;
-  if (!rel.endsWith("/index.html") || rel === "index.html") continue;
-  const slashlessKey = rel.slice(0, -"/index.html".length);
-  entries.push(entryFor(slashlessKey, file, rel));
-}
+entries.push(...aliases);
 
 entries.sort((a, b) => a.key.localeCompare(b.key));
 
@@ -45,28 +44,14 @@ const manifest = {
   version: 1,
   generatedAt: new Date().toISOString(),
   sourceDir: "dist/docs-site",
-  outputDir: "dist/docs-r2",
+  outputDir: "dist/docs-site",
   objectCount: entries.length,
   entries,
 };
 fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
-const physicalFiles = countFiles(outputDir);
 const virtualFiles = entries.length - physicalFiles;
 console.log(`r2 prepare ok: ${physicalFiles} files, ${virtualFiles} slashless html aliases, ${entries.length} objects`);
-
-function copyTree(from, to) {
-  fs.mkdirSync(to, { recursive: true });
-  for (const entry of fs.readdirSync(from, { withFileTypes: true })) {
-    const source = path.join(from, entry.name);
-    const target = path.join(to, entry.name);
-    if (entry.isDirectory()) {
-      copyTree(source, target);
-    } else if (entry.isFile()) {
-      fs.copyFileSync(source, target);
-    }
-  }
-}
 
 function entryFor(key, file, sourceKey) {
   const data = fs.readFileSync(file);
@@ -124,12 +109,6 @@ function cacheControlFor(key) {
     return "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400";
   }
   return "public, max-age=31536000, immutable";
-}
-
-function countFiles(dir) {
-  let count = 0;
-  for (const _file of walk(dir)) count += 1;
-  return count;
 }
 
 function* walk(dir) {

--- a/scripts/docs-site/r2-upload.test.mjs
+++ b/scripts/docs-site/r2-upload.test.mjs
@@ -84,6 +84,47 @@ test("manifest diff detects metadata additions, changes and removals with identi
   assert.deepEqual(puts(unchanged.stdout), []);
 });
 
+test("prepared artifact paths preserve uploaded bytes and reuse old manifest objects", (t) => {
+  const f = fixture(t);
+  const files = {
+    "index.html": "<html>Root</html>",
+    "guide.v2/index.html": "<html>Guide</html>",
+    "assets/image.png": Buffer.from([0, 255, 1, 128]),
+  };
+  for (const [key, body] of Object.entries(files)) write(f.root, `dist/docs-site/${key}`, body);
+  write(f.root, "dist/docs-site/_headers", "/*\n  Cache-Control: no-store\n");
+  write(f.root, "dist/docs-r2/removed.html", "old artifact");
+  const prepared = f.prepare();
+  assert.deepEqual(prepared.entries.map((entry) => entry.key), [
+    "assets/image.png", "guide.v2", "guide.v2/index.html", "index.html",
+  ]);
+  assert.equal(prepared.objectCount, 4);
+  for (const entry of prepared.entries) {
+    const expected = Buffer.from(files[entry.sourceKey]);
+    assert.deepEqual(fs.readFileSync(path.join(f.root, entry.file)), expected);
+    assert.equal(entry.size, expected.length);
+    assert.equal(entry.md5, crypto.createHash("md5").update(expected).digest("hex"));
+    assert.equal(entry.sha256, crypto.createHash("sha256").update(expected).digest("hex"));
+  }
+  const alias = prepared.entries.find((entry) => entry.key === "guide.v2");
+  assert.equal(alias.contentType, "text/html; charset=utf-8");
+  assert.equal(alias.cacheControl, "public, max-age=60, s-maxage=86400, stale-while-revalidate=604800");
+
+  // A previous publication can name different local files; only object bytes
+  // and HTTP metadata determine whether an upload is necessary.
+  const old = prepared.entries.map((entry) => ({ ...entry, file: `old-copy/${entry.sourceKey}` }));
+  old.push({ ...old[0], key: "removed.html" });
+  const result = dryUpload(f.root, prepared.entries, old);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(puts(result.stdout), []);
+  assert.match(result.stdout, /^r2 dry-run delete: removed\.html$/m);
+
+  // A cold upload must be able to open every newly prepared file as well.
+  const cold = dryUpload(f.root, prepared.entries, []);
+  assert.equal(cold.status, 0, cold.stderr);
+  assert.deepEqual(puts(cold.stdout), prepared.entries.map((entry) => entry.key));
+});
+
 for (const mode of ["manifest", "head", "head-error"]) {
   test(`${mode} audit uploads metadata add/change/remove despite unchanged ETags using only mocked fetch`, (t) => {
     const f = uploadFixture(t);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where small docs updates regenerate every social-preview image and copy/hash the entire generated artifact again before upload, even when nearly all content is unchanged. The production measurement in https://github.com/openclaw/openclaw/pull/142437 spent 15.8s generating 677 images, roughly 22s in artifact preparation/transitions, and 12s installing an unused image CLI.

## Why This Change Was Made

Companion source-validation improvement: https://github.com/openclaw/openclaw/pull/142475.

Reuse preview PNGs by their exact SVG, renderer/options, fonts, locked dependencies and runtime inputs. Keep current navigation-based output selection, corruption recovery and cache pruning. A separate pinned Actions cache preserves images without invalidating the existing article cache. The existing `DOCS_SITE_RENDER_CACHE=0` comparison switch bypasses both caches.

Prepare the R2 manifest directly from the checked `dist/docs-site` tree and reuse physical-file hashes for slashless aliases. Do not create another full artifact copy. Object keys, content, metadata, diffing and deletion behavior are unchanged. The uploader already accepts these source paths; the tree must remain unchanged through upload.

Remove the `librsvg2-bin` installation from deployment and docs-code CI: the renderer uses `@resvg/resvg-js` and embedded fonts, not `rsvg-convert`.

No page content, renderer semantics, search generation, queue policy, publication admission, upload ordering or live-service configuration changes. Pagefind output reuse is deliberately deferred: v1.5.2 does not expose a cheap current-file inventory, so simply retaining its old directory would retain obsolete search fragments. No new retention framework or dependency patch is added.

## User Impact

Small updates avoid rerendering unchanged preview images and unnecessary local artifact copying/hashing. This is a bounded build improvement, not a promise of a particular merge-to-live duration. Complete current search and the existing full-site smoke check remain.

## Evidence

- Full reference `make docs-check` passed: **93.37s**. Candidate warm `make docs-check` passed: **74.19s**, including the full 15,090-page build, Pagefind, R2 preparation and full smoke.
- This was an illustrative local comparison on an active host, not an isolated production estimate: the reference article cache had 15,011 hits / 78 misses / 1 snippet bypass, while the candidate had 15,089 hits / 0 misses / 1 bypass. Do not attribute every second of the difference solely to this PR.
- Candidate cold OG preparation rendered 677 cards in 4,259ms. Warm preparation reused all 677 with zero renders in **123ms**. The reference generated 677 cards in 3,397ms. Cold/warm renderer startup differences are not hidden.
- Compared **61,009 generated files**: **61,008 byte-identical**, with only the existing `docs-search.json` generation timestamp differing. Parsed search contents matched. All **89,121 manifest objects** had identical content/HTTP/redirect metadata after accounting for intended local file/output paths and the search timestamp hashes. **Zero unexpected differences.**
- Source indexing was explicitly skipped in both local builds because no application source checkout was supplied. Its generator and production checkout are unchanged; no source-index benchmark is claimed.
- **2 OG cache tests** passed, covering real PNG reuse, input/font changes, corruption/eviction, current selection, and cache-disabled behavior. They also passed with PATH restricted to `/usr/bin:/bin` and absolute Node, without `rsvg-convert` available.
- **45 existing uploader/dotted-route/Markdown-redirect tests** passed, including one new boundary case for old-manifest path compatibility, actual file bytes/hashes, cold uploads and stale-object deletion.
- **36 existing head-drift/timeout tests** passed. The existing artifact-admission guard now covers both cache restores after the obsolete install step was removed.
- Pinned actionlint and `git diff --check` passed. Default zizmor reports the same seven pre-existing unpinned action references as the baseline; the two new cache actions are SHA-pinned. No suppression or unrelated action upgrade was added. This repo has no `.github/zizmor.yml`; no configured-audit success is claimed.
- Fresh independent autoreview of the final candidate: scoped-clean through P1, no actionable findings.
- Hosted [Docs Code CI](https://github.com/openclaw/docs/actions/runs/34269296840) and CodeQL passed on `66001e7dd98f814d902461bb02fb61fe486fa31c`, including the shell build, smoke and visual checks with the obsolete install step removed.

Plan: implementation, local full-build/equivalence/performance proof, independent review and hosted PR checks complete. Ready for review; no production deployment was manually dispatched, cancelled, or altered, and this PR is not merged.
