### PR TITLE
feat: preview selected docs pages within a 30-page limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Publish mirror for `docs.openclaw.ai`. Source repo: `openclaw/openclaw`.
 
 ## Workflow
 
+- For a local page preview, run `npm run docs:build:preview -- --page <route>` (repeat `--page` for more pages). It builds at most 30 pages in English, including the requested pages. Use this for screenshots; do not run translation or full publishing builds just for a preview. See `scripts/docs-site/AGENTS.md` for fixture and validation options.
 - Source sync starts in `openclaw/openclaw/.github/workflows/docs-sync-publish.yml`.
 - Sync mirrors `openclaw/openclaw/docs/**` into this repo and updates `.openclaw-sync/source.json`.
 - `translate-incremental.yml` runs normal debounced docs changes.

--- a/scripts/docs-site/AGENTS.md
+++ b/scripts/docs-site/AGENTS.md
@@ -5,8 +5,10 @@ Scope: docs shell generator, hidden visual fixtures, local smoke checks, and R2 
 - Do not edit generated `dist/docs-site/**`; rebuild it.
 - Keep authored docs under `docs/**` out of this subtree. Use virtual fixtures or generator code here when testing shell UI.
 - The hidden component fixture is generated at `/__elements`; keep it `noindex` and out of `sitemap.xml` and `llms.txt`.
-- Run `make docs-check` after renderer, shell CSS, visual fixture, asset, or smoke changes.
-- For visual proof, run `DOCS_SITE_PREVIEW_INCLUDE_FIXTURE=1 npm run docs:build:preview`; do not rebuild the full locale corpus just to capture screenshots.
+- For a page preview, run `npm run docs:build:preview -- --page plugins/reference/crabbox`. Repeat `--page <route>` to include other pages, even outside navigation. Routes are relative to the locale root, without `.md` or `.mdx`.
+- Previews build at most 30 pages in English. Add `DOCS_SITE_PREVIEW_INCLUDE_FIXTURE=1` to include `/__elements` within that limit. They skip other locale trees, per-page OG rendering, redirects, and publishing indexes; do not run translation, R2 preparation, or full builds just for screenshots.
+- For a smaller or translated preview, use `DOCS_SITE_PREVIEW_MAX_PAGES=5 DOCS_SITE_PREVIEW_LOCALE=fr node scripts/docs-site/build.mjs --page <route>`.
+- Validate bounded renderer, CSS, fixture, or preview changes with focused tests and the relevant preview pages. Run `make docs-check` when the change needs full publishing validation, such as cross-locale routing, indexes, or R2 artifacts. A preview does not replace that check when it is needed.
 - After the preview build, use `make docs-serve` plus `make docs-elements-open` for visual review.
 - Add smoke coverage in `scripts/docs-site/smoke.mjs` for any new visual contract that would be annoying to catch by eye later.
 - Keep R2 uploads diff-friendly: no generated timestamp churn, randomized output, or broad rewrites unless the source docs changed.

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { Worker } from "node:worker_threads";
+import { parseArgs } from "node:util";
 
 import { ignoredDocDirs, ignoredDocFiles, localeFlags, localeLabels, mintlifyLocaleToDir, rtlLocales } from "./config.mjs";
 import { siteCss, siteJs } from "./assets.mjs";
@@ -22,8 +23,6 @@ const siteAssetsDir = path.join(root, "scripts", "docs-site");
 const shellPublicAssetsDir = path.join(siteAssetsDir, "assets");
 const outDir = path.join(root, "dist", "docs-site");
 const redirectMetadataPath = path.join(root, "dist", "docs-markdown-redirects.json");
-// Preview builds skip redirects, so never let an earlier full build's records survive.
-fs.rmSync(redirectMetadataPath, { force: true });
 const config = JSON.parse(fs.readFileSync(path.join(docsDir, "docs.json"), "utf8"));
 const sourceMetadata = readSourceMetadata(root);
 const md = createMarkdownRenderer();
@@ -53,15 +52,19 @@ const ogAssetVersion = createHash("sha256")
   .update(fs.readFileSync(new URL("./og-card.svg", import.meta.url)))
   .digest("hex")
   .slice(0, 12);
-const artifactMode = process.env.DOCS_SITE_ARTIFACT_MODE ?? "full";
-const shellOnly = artifactMode === "shell";
+const { values: { page: requestedPages } } = parseArgs({
+  options: { page: { type: "string", multiple: true, default: [] } },
+});
 const previewPagesPerGroup = parseOptionalPositiveInt(
   process.env.DOCS_SITE_PREVIEW_PAGES_PER_GROUP,
   "DOCS_SITE_PREVIEW_PAGES_PER_GROUP",
 );
-const previewMaxPages = parseOptionalPositiveInt(process.env.DOCS_SITE_PREVIEW_MAX_PAGES, "DOCS_SITE_PREVIEW_MAX_PAGES");
-const previewLocale = process.env.DOCS_SITE_PREVIEW_LOCALE;
-const previewMode = Boolean(previewPagesPerGroup || previewMaxPages || previewLocale);
+const configuredMaxPages = parseOptionalPositiveInt(process.env.DOCS_SITE_PREVIEW_MAX_PAGES, "DOCS_SITE_PREVIEW_MAX_PAGES");
+const previewMode = Boolean(requestedPages.length || previewPagesPerGroup || configuredMaxPages || process.env.DOCS_SITE_PREVIEW_LOCALE);
+const previewMaxPages = Math.min(configuredMaxPages || 30, 30);
+const previewLocale = process.env.DOCS_SITE_PREVIEW_LOCALE || "en";
+const artifactMode = previewMode ? "shell" : process.env.DOCS_SITE_ARTIFACT_MODE ?? "full";
+const shellOnly = artifactMode === "shell";
 const renderCache = !previewMode && process.env.DOCS_SITE_RENDER_CACHE !== "0"
   ? createRenderCache(path.join(root, ".cache", "docs-render"), renderArticle)
   : null;
@@ -69,11 +72,11 @@ const includeElementsFixture = !previewMode || process.env.DOCS_SITE_PREVIEW_INC
 if (!["full", "shell"].includes(artifactMode)) {
   throw new Error(`DOCS_SITE_ARTIFACT_MODE must be full or shell, got ${artifactMode}`);
 }
-fs.rmSync(outDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-fs.mkdirSync(outDir, { recursive: true });
-
 const locales = buildLocales(config);
 const localeCodes = new Set(locales.map((locale) => locale.code));
+if (previewMode && !localeCodes.has(previewLocale)) {
+  throw new Error(`Preview locale not found: ${previewLocale}`);
+}
 const allPages = [...collectPages(locales), ...(includeElementsFixture ? [elementsFixturePage()] : [])];
 const allPageByKey = new Map(allPages.map((page) => [pageKey(page.locale, page.slug), page]));
 let pages = allPages;
@@ -85,7 +88,7 @@ if (previewMode) {
     maxPages: previewMaxPages,
     pagesPerGroup: previewPagesPerGroup || 1,
   });
-  pages = allPages.filter((page) => page.hidden || previewKeys.has(pageKey(page.locale, page.slug)));
+  pages = allPages.filter((page) => previewKeys.has(pageKey(page.locale, page.slug)));
   pageByKey = new Map(pages.map((page) => [pageKey(page.locale, page.slug), page]));
   navByLocale = new Map(locales.map((locale) => [locale.code, buildNav(locale)]));
 }
@@ -93,6 +96,10 @@ const localePickerLabels = {
   "pt-BR": "Português (BR)"
 };
 
+// Preview builds skip redirects, so never let an earlier full build's records survive.
+fs.rmSync(redirectMetadataPath, { force: true });
+fs.rmSync(outDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+fs.mkdirSync(outDir, { recursive: true });
 copyPublicFiles();
 if (!previewMode) await renderPageOgCards();
 for (const page of pages) writePage(page);
@@ -141,11 +148,10 @@ function collectPages(localeList) {
   const result = [];
   const localeRoots = new Set(localeList.filter((locale) => !locale.root).map((locale) => locale.code));
   for (const locale of localeList) {
+    if (previewMode && !locale.root && locale.code !== previewLocale) continue;
     const base = locale.root ? docsDir : path.join(docsDir, locale.code);
-    for (const file of walkDocs(base)) {
+    for (const file of walkDocs(base, locale.root ? localeRoots : new Set())) {
       const rel = path.relative(base, file).replaceAll(path.sep, "/");
-      // Only the English owner excludes foreign roots; walkDocs remains an all-source traversal.
-      if (locale.root && localeRoots.has(rel.split("/")[0])) continue;
       if (ignoredDocFiles.has(rel)) continue;
       const raw = fs.readFileSync(file, "utf8");
       const parsed = parseFrontmatter(raw);
@@ -202,12 +208,12 @@ function elementsFixturePage() {
   };
 }
 
-function walkDocs(dir) {
+function walkDocs(dir, excludedRoots = new Set()) {
   if (!fs.existsSync(dir)) return [];
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     if (entry.name.startsWith(".")) return [];
     const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) return ignoredDocDirs.has(entry.name) ? [] : walkDocs(full);
+    if (entry.isDirectory()) return ignoredDocDirs.has(entry.name) || excludedRoots.has(entry.name) ? [] : walkDocs(full);
     return /\.(md|mdx)$/.test(entry.name) ? [full] : [];
   });
 }
@@ -228,13 +234,21 @@ function navGroup(locale, group) {
 
 function collectPreviewPageKeys(navByLocale, { locale, maxPages, pagesPerGroup }) {
   const keys = new Set();
+  for (const route of requestedPages) {
+    const slug = navEntrySlug(locale, route.replace(/^\/+|\/+$/g, ""));
+    const key = pageKey(locale, slug);
+    if (!allPageByKey.has(key)) throw new Error(`Preview page not found (${locale}): ${route}`);
+    keys.add(key);
+  }
+  if (includeElementsFixture) keys.add(pageKey("en", "__elements"));
+  if (keys.size > maxPages) throw new Error(`Requested pages exceed the preview limit of ${maxPages}`);
   for (const [navLocale, nav] of navByLocale) {
     if (locale && navLocale !== locale) continue;
     for (const tab of nav) {
       for (const group of tab.groups) {
         for (const page of flattenNavEntries(group.pages).slice(0, pagesPerGroup)) {
+          if (keys.size >= maxPages) return keys;
           keys.add(pageKey(page.locale, page.slug));
-          if (maxPages && keys.size >= maxPages) return keys;
         }
       }
     }
@@ -925,7 +939,11 @@ function walkPublicFiles(dir) {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     if (entry.name.startsWith(".")) return [];
     const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) return walkPublicFiles(full);
+    if (entry.isDirectory()) {
+      if (previewMode && dir === docsDir && entry.name !== "en"
+        && localeCodes.has(entry.name) && entry.name !== previewLocale) return [];
+      return walkPublicFiles(full);
+    }
     const rel = path.relative(docsDir, full).replaceAll(path.sep, "/");
     if (ignoredDocFiles.has(rel) || /\.(md|mdx|json|jsonl)$/.test(entry.name)) return [];
     return [full];

--- a/scripts/docs-site/preview-build.test.mjs
+++ b/scripts/docs-site/preview-build.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fixture, run, write } from "./test-helpers/redirect-fixture.mjs";
+
+function previewFixture(t) {
+  const slugs = Array.from({ length: 35 }, (_, i) => `guide/page-${i}`);
+  const f = fixture(t, [], {
+    ...Object.fromEntries(slugs.map((slug) => [`${slug}.md`, `# ${slug}\n`])),
+    "target.mdx": "# Requested page\n\n[Omitted page](/guide/page-34)\n",
+    "fr/target.md": "# Cible\n",
+    "guide/de/topic.md": "# Nested locale name\n",
+  });
+  write(f.root, "docs/docs.json", JSON.stringify({
+    navigation: { languages: ["en", "fr"].map((language) => ({ language, tabs: [{
+      tab: "Docs", groups: slugs.map((slug) => ({ group: slug, pages: [slug] })),
+    }] })) },
+  }));
+  const build = (args = [], env = {}, imports = []) => run(f.root, "build.mjs", env, imports, { args });
+  const site = path.join(f.root, "dist/docs-site");
+  const htmlPages = () => fs.readdirSync(site, { recursive: true }).filter((file) => file.endsWith("index.html"));
+  return { ...f, build, site, htmlPages };
+}
+
+test("requested pages outside navigation fit inside the 30-page preview, including the fixture", (t) => {
+  const f = previewFixture(t);
+  const built = f.build(["--page", "/target/", "--page", "guide/de/topic", "--page", "target"], {
+    DOCS_SITE_PREVIEW_MAX_PAGES: "100",
+    DOCS_SITE_PREVIEW_INCLUDE_FIXTURE: "1",
+  });
+  assert.equal(built.status, 0, built.stderr);
+  assert.equal(f.htmlPages().length, 30);
+  for (const route of ["target", "guide/de/topic", "__elements"]) {
+    assert.ok(fs.existsSync(path.join(f.site, route, "index.html")), route);
+  }
+  const html = fs.readFileSync(path.join(f.site, "target/index.html"), "utf8");
+  assert.match(html, /Requested page/);
+  assert.match(html, /href="https:\/\/docs\.openclaw\.ai\/guide\/page-34"/);
+  for (const file of ["fr", "sitemap.xml", "llms.txt", "robots.txt", "og"]) {
+    assert.equal(fs.existsSync(path.join(f.site, file)), false, file);
+  }
+  assert.equal(fs.existsSync(path.join(f.root, "dist/docs-markdown-redirects.json")), false);
+});
+
+test("English preview skips translated sources and assets before traversing them", (t) => {
+  const f = previewFixture(t);
+  write(f.root, "docs/fr/image.svg", "<svg/>");
+  write(f.root, "docs/images/shared.svg", "<svg/>");
+  const guard = path.join(f.root, "guard.mjs");
+  write(f.root, "guard.mjs", `import fs from "node:fs";
+const original = fs.readdirSync;
+fs.readdirSync = (dir, ...args) => {
+  if (String(dir).startsWith(${JSON.stringify(path.join(f.root, "docs/fr"))})) {
+    throw new Error("Preview traversed a translated tree");
+  }
+  return original(dir, ...args);
+};
+`);
+  const built = f.build([], { DOCS_SITE_PREVIEW_PAGES_PER_GROUP: "1" }, [guard]);
+  assert.equal(built.status, 0, built.stderr);
+  assert.equal(f.htmlPages().length, 30);
+  assert.equal(fs.existsSync(path.join(f.site, "fr")), false);
+  assert.ok(fs.existsSync(path.join(f.site, "images/shared.svg")));
+});
+
+test("a one-page preview includes only the requested page", (t) => {
+  const f = previewFixture(t);
+  const built = f.build(["--page", "target"], { DOCS_SITE_PREVIEW_MAX_PAGES: "1" });
+  assert.equal(built.status, 0, built.stderr);
+  assert.deepEqual(f.htmlPages(), ["target/index.html"]);
+});
+
+test("preview rejects missing pages and requests larger than its page budget", (t) => {
+  const f = previewFixture(t);
+  for (const [args, env, message] of [
+    [["--page", "missing"], {}, /Preview page not found/],
+    [["--page", "fr/target"], {}, /Preview page not found/],
+    [["--page", "target"], { DOCS_SITE_PREVIEW_MAX_PAGES: "1", DOCS_SITE_PREVIEW_INCLUDE_FIXTURE: "1" }, /exceed.*limit/i],
+  ]) {
+    const built = f.build(args, env);
+    assert.notEqual(built.status, 0);
+    assert.match(built.stderr, message);
+  }
+});

--- a/scripts/docs-site/test-helpers/redirect-fixture.mjs
+++ b/scripts/docs-site/test-helpers/redirect-fixture.mjs
@@ -19,6 +19,7 @@ export function run(root, script, env = {}, imports = [], options = {}) {
     "--import", pathToFileURL(path.join(root, "no-network.mjs")).href,
     ...imports.flatMap((file) => ["--import", pathToFileURL(file).href]),
     path.join(repo, "scripts/docs-site", script),
+    ...(options.args ?? []),
   ], {
     cwd: root,
     env: { PATH: process.env.PATH, ...env },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a docs preview can omit the page being reviewed. The component fixture also bypassed the existing 30-page limit, and English previews still traversed translated source and asset trees.

## Why This Change Was Made

Add repeatable `--page <route>` arguments to the existing preview command. Requested pages and the optional component fixture count toward a hard 30-page limit; remaining slots use the existing navigation sample. Missing pages and requests exceeding the limit fail before replacing the previous output.

## User Impact

```sh
npm run docs:build:preview -- --page plugins/reference/crabbox
```

This builds an English preview containing the requested page, without translated pages, per-page OG rendering, redirects, or publishing indexes. Root and renderer AGENTS.md now direct screenshot work to this command, with options for the component fixture, smaller previews, and a specific locale. Full publishing validation remains available when the change requires it.

## Evidence

| Before | After |
| --- | --- |
| A one-page preview requesting `target` generated `guide/page-0/index.html`. | The same request generates only `target/index.html`. |
| The hidden fixture was added outside the preview limit. | A real preview generated exactly 30 HTML pages, including Crabbox and `/__elements`. |
| English previews traversed translated trees. | A fixture that rejects traversal of the French tree passes; shared assets remain available. |

- Ten focused tests passed: preview selection, limits, invalid requests, locale ownership, nested navigation, and redirect sidecar cleanup. The one-page regression fails on the base builder.
- The real preview command above, with `DOCS_SITE_PREVIEW_INCLUDE_FIXTURE=1`, generated 30 pages. Crabbox returned HTTP 200 and rendered correctly in the browser.
- Real-site validation used only the 30-page preview. No full-corpus build or translation workflow was run for this change.
- `git diff --check` and fresh structured autoreview passed with no actionable findings.

Known repository CI failure: the mobile section-switcher smoke test expects 12 sections; current navigation has 14. The same failure predates this change in [run 34517212209](https://github.com/openclaw/docs/actions/runs/34517212209).
