### PR TITLE
fix: keep visual smoke aligned with current docs

### DIFF
--- a/scripts/docs-site/visual-smoke.mjs
+++ b/scripts/docs-site/visual-smoke.mjs
@@ -582,6 +582,9 @@ async function checkMobileToc(page) {
 }
 
 async function checkMobile() {
+  const docsConfig = JSON.parse(fs.readFileSync(path.join(root, "docs", "docs.json"), "utf8"));
+  const expectedTabs = docsConfig.navigation.languages.find((locale) => locale.language === "en")
+    .tabs.map((tab) => tab.tab);
   const page = await browser.newPage({ viewport: { width: 390, height: 980 }, isMobile: true });
   await page.goto(`${base}/__elements`, { waitUntil: "networkidle" });
   await page.screenshot({ path: path.join(artifacts, "elements-mobile-dark.png"), fullPage: true });
@@ -634,21 +637,6 @@ async function checkMobile() {
   if (!mobileCardColumns.length || mobileCardColumns.some((columns) => columns !== 1)) {
     throw new Error(`mobile card grids should collapse to one column: ${JSON.stringify(mobileCardColumns)}`);
   }
-  await page.evaluate(() => {
-    for (const selector of [".tabs", ".mobile-tabs"]) {
-      const container = document.querySelector(selector);
-      const links = [...container?.querySelectorAll("a") ?? []];
-      if (links.some((link) => link.textContent?.trim() === "Release & CI")) continue;
-      const help = links.find((link) => link.textContent?.trim() === "Help");
-      const release = help?.cloneNode();
-      if (!help || !(release instanceof HTMLAnchorElement)) throw new Error(`missing ${selector} Help fixture`);
-      release.href = "/releases";
-      release.textContent = "Release & CI";
-      release.removeAttribute("aria-current");
-      release.classList.remove("active");
-      help.before(release);
-    }
-  });
   await page.click("[data-nav-toggle]");
   await page.locator(".sidebar.open").waitFor({ state: "visible" });
   await page.waitForFunction(() => Math.abs(document.querySelector(".sidebar")?.getBoundingClientRect().left ?? -999) < 1);
@@ -696,48 +684,47 @@ async function checkMobile() {
   await page.locator(".mobile-tabs").waitFor({ state: "visible" });
   await page.screenshot({ path: path.join(artifacts, "elements-mobile-menu.png"), fullPage: false });
   const sections = await page.evaluate(() => {
-    const container = document.querySelector(".mobile-tabs")?.getBoundingClientRect();
     const links = [...document.querySelectorAll(".mobile-tab-link")];
     const rects = links.map((link) => link.getBoundingClientRect());
     return {
       open: document.querySelector(".mobile-section-switcher")?.hasAttribute("open"),
-      mobileTabCount: links.length,
-      desktopTabCount: document.querySelectorAll(".tab-link").length,
+      desktopLabels: [...document.querySelectorAll(".tab-link")].map((link) => link.textContent?.trim()),
       labels: links.map((link) => link.textContent?.trim()),
       activeCount: document.querySelectorAll('.mobile-tab-link[aria-current="location"]').length,
       linksVisible: rects.every((rect) => rect.width > 0 && rect.height > 0),
       linksInViewport: rects.every((rect) => rect.left >= 0 && rect.right <= innerWidth),
-      lastLinkVisible: Boolean(container && rects.at(-1)?.bottom <= container.bottom + 1),
     };
   });
   if (!sections.open
-    || sections.mobileTabCount !== 12
-    || sections.mobileTabCount !== sections.desktopTabCount
-    || sections.labels.slice(-4).join("|") !== "Gateway & Ops|Reference|Release & CI|Help"
+    || !expectedTabs.length
+    || JSON.stringify(sections.labels) !== JSON.stringify(expectedTabs)
+    || JSON.stringify(sections.desktopLabels) !== JSON.stringify(expectedTabs)
     || sections.activeCount !== 1
     || !sections.linksVisible
-    || !sections.linksInViewport
-    || !sections.lastLinkVisible) {
-    throw new Error(`mobile docs section switcher failed: ${JSON.stringify(sections)}`);
+    || !sections.linksInViewport) {
+    throw new Error(`mobile docs section switcher failed: ${JSON.stringify({ expectedTabs, ...sections })}`);
   }
-  await page.setViewportSize({ width: 390, height: 700 });
-  const shortViewport = await page.evaluate(() => {
-    const container = document.querySelector(".mobile-tabs");
-    return {
-      clientHeight: container?.clientHeight ?? 0,
-      scrollHeight: container?.scrollHeight ?? 0,
-    };
-  });
-  if (shortViewport.scrollHeight <= shortViewport.clientHeight) {
-    throw new Error(`short mobile section switcher should remain scrollable: ${JSON.stringify(shortViewport)}`);
+  for (const height of [980, 700]) {
+    await page.setViewportSize({ width: 390, height });
+    const scrollArea = await page.evaluate(() => {
+      const container = document.querySelector(".mobile-tabs");
+      return {
+        clientHeight: container?.clientHeight ?? 0,
+        scrollHeight: container?.scrollHeight ?? 0,
+      };
+    });
+    if (height === 700 && scrollArea.scrollHeight <= scrollArea.clientHeight) {
+      throw new Error(`short mobile section switcher should remain scrollable: ${JSON.stringify(scrollArea)}`);
+    }
+    await page.locator(".mobile-tab-link").last().scrollIntoViewIfNeeded();
+    const lastLinkReachable = await page.evaluate(() => {
+      const container = document.querySelector(".mobile-tabs")?.getBoundingClientRect();
+      const lastLink = [...document.querySelectorAll(".mobile-tab-link")].at(-1)?.getBoundingClientRect();
+      return Boolean(container && lastLink && lastLink.top >= container.top - 1 && lastLink.bottom <= container.bottom + 1);
+    });
+    if (!lastLinkReachable) throw new Error(`mobile section switcher did not expose its final link at height ${height}`);
+    await page.screenshot({ path: path.join(artifacts, `elements-mobile-menu-${height}-scrolled.png`), fullPage: false });
   }
-  await page.locator(".mobile-tab-link").last().scrollIntoViewIfNeeded();
-  const lastLinkReachable = await page.evaluate(() => {
-    const container = document.querySelector(".mobile-tabs")?.getBoundingClientRect();
-    const lastLink = [...document.querySelectorAll(".mobile-tab-link")].at(-1)?.getBoundingClientRect();
-    return Boolean(container && lastLink && lastLink.top >= container.top - 1 && lastLink.bottom <= container.bottom + 1);
-  });
-  if (!lastLinkReachable) throw new Error("short mobile section switcher did not expose its final link");
   await page.setViewportSize({ width: 390, height: 980 });
   await page.keyboard.press("Escape");
   const closed = await page.evaluate(() => ({

--- a/scripts/docs-site/visual-smoke.mjs
+++ b/scripts/docs-site/visual-smoke.mjs
@@ -680,6 +680,8 @@ async function checkMobile() {
     || !menu.closeFocused) {
     throw new Error(`mobile menu drawer failed (expected full-bleed on phones): ${JSON.stringify(menu)}`);
   }
+  await page.locator("[data-community-invite-dismiss]").click();
+  await page.locator(".community-invite").waitFor({ state: "hidden" });
   await page.click(".mobile-section-switcher > summary");
   await page.locator(".mobile-tabs").waitFor({ state: "visible" });
   await page.screenshot({ path: path.join(artifacts, "elements-mobile-menu.png"), fullPage: false });
@@ -717,6 +719,7 @@ async function checkMobile() {
       throw new Error(`short mobile section switcher should remain scrollable: ${JSON.stringify(scrollArea)}`);
     }
     await page.locator(".mobile-tab-link").last().scrollIntoViewIfNeeded();
+    await page.locator(".mobile-tab-link").last().click({ trial: true });
     const lastLinkReachable = await page.evaluate(() => {
       const container = document.querySelector(".mobile-tabs")?.getBoundingClientRect();
       const lastLink = [...document.querySelectorAll(".mobile-tab-link")].at(-1)?.getBoundingClientRect();
@@ -735,7 +738,7 @@ async function checkMobile() {
   if (closed.bodyOpen || closed.sidebarOpen || closed.ariaExpanded !== "false") {
     throw new Error(`mobile menu did not close on Escape: ${JSON.stringify(closed)}`);
   }
-  await page.goto(`${base}/channels/discord`, { waitUntil: "networkidle" });
+  await page.goto(`${base}/channels/discord/voice-channels`, { waitUntil: "networkidle" });
   await page.screenshot({ path: path.join(artifacts, "discord-mobile-dark.png"), fullPage: false });
   const discordOverflow = await page.evaluate(() => {
     const viewport = innerWidth;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where docs PRs fail the mobile Visual smoke after navigation changes. The test expects 12 sections and an old label suffix, while the current English navigation declares 13 sections, including Releases and Contributing. It also injects an obsolete “Release & CI” section and expects the entire list to fit without scrolling.

## Why This Change Was Made

Compare the full desktop and mobile section labels with the English navigation in `docs/docs.json`, and remove the synthetic section. Verify the last section is reachable by scrolling at both tested viewport heights. Keep active-section, drawer, horizontal bounds, short-viewport overflow, and Escape checks.

## User Impact

Navigation additions no longer require updating a duplicate tab count or suffix in the smoke test. Missing or reordered sections and inaccessible final links still fail validation. This changes only the test, not the site layout. The mobile overflow check also follows the voice documentation to its current page after the Discord page split.

## Evidence

Both unrelated PRs by @vyctorbrzezowski hit the same baseline failure:

- #180: [failed Visual smoke](https://github.com/openclaw/docs/actions/runs/34531059274/job/103051606657).
- #179: [failed Visual smoke](https://github.com/openclaw/docs/actions/runs/34529461249/job/103046352892).

The test, navigation config, and shell styles are identical on both PR heads and their current main baseline. The logs show 14 sections after fixture injection and `lastLinkVisible: false`.

Local validation passed:

- `npm run docs:build:r2:shell` built 15,478 pages; `npm run docs:smoke:shell` passed.
- The original Visual smoke reproduced the exact 14-section failure on that build.
- The corrected `npm run docs:visual` passed in full. It exposed and corrected a second stale reference: the long inline voice setting now lives at `/channels/discord/voice-channels`.
- The test dismisses the community invite through its real button after opening the drawer, then verifies the final link can receive a click at 390×980 and 390×700. Inspected captures show Help reachable at both heights.
- `node --check scripts/docs-site/visual-smoke.mjs` and `git diff --check` passed. Source review found no actionable defects.

## Risk and coverage

One test file changes. Expected labels come from the source navigation rather than the rendered page, preserving independent completeness and ordering checks. Scrolling replaces the stale all-links-fit assumption; the short-viewport overflow check remains.
