### PR TITLE
chore(deps): refresh Wrangler and maintenance notes

### DIFF
--- a/.github/workflows/docs-code-ci.yml
+++ b/.github/workflows/docs-code-ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm test
 
       - name: Validate Worker bundle
-        run: npx wrangler@4.129.0 deploy --dry-run --config wrangler.toml
+        run: npx wrangler@4.130.0 deploy --dry-run --config wrangler.toml
 
       - name: Build shell artifact
         run: npm run docs:build:r2:shell

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm ci
 
       - name: Validate Worker bundle
-        run: npx wrangler@4.129.0 deploy --dry-run --config wrangler.toml
+        run: npx wrangler@4.130.0 deploy --dry-run --config wrangler.toml
 
       - name: Deploy to Cloudflare
         if: github.event_name == 'workflow_dispatch' && inputs.deploy_worker == true
@@ -61,7 +61,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx wrangler@4.129.0 deploy --config wrangler.toml \
+          npx wrangler@4.130.0 deploy --config wrangler.toml \
             --tag "${GITHUB_SHA::12}" \
             --message "openclaw/docs ${GITHUB_SHA}"
 

--- a/.github/workflows/r2-pages.yml
+++ b/.github/workflows/r2-pages.yml
@@ -378,7 +378,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx wrangler@4.129.0 deploy --config wrangler.toml \
+          npx wrangler@4.130.0 deploy --config wrangler.toml \
             --tag "${GITHUB_SHA::12}" \
             --message "openclaw/docs ${GITHUB_SHA}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Bound maintenance and translation workflow jobs, including reusable workflow callees and the incremental debounce; thanks @SebTardif.
 - Abort stalled Cloudflare hostname cutover requests, with a configurable `CLOUDFLARE_API_TIMEOUT_MS` budget; thanks @SebTardif.
 - Reject malformed and overflowing request timeout settings before network operations begin.
-- Refresh syntax highlighting, icons, Markdown and HTML parsing, and diagrams with highlight.js 11.12.0, Lucide 1.41.0, markdown-it 15.0.1, htmlparser2 12.0.0, and Mermaid 11.17.2.
+- Refresh syntax highlighting, icons, Markdown and HTML parsing, and diagrams with highlight.js 11.12.0, Lucide 1.43.0, markdown-it 15.0.1, htmlparser2 12.0.0, and Mermaid 11.17.2.
 - Refresh Markdown heading rendering with markdown-it-anchor 10.0.0 while preserving published section IDs and document isolation.
-- Refresh browser verification and Cloudflare deployment tooling with Playwright 1.63.0 and Wrangler 4.129.0.
-- Update CodeQL actions to 4.37.9 for the current analysis bundle.
+- Refresh browser verification and Cloudflare deployment tooling with Playwright 1.63.0 and Wrangler 4.130.0.
+- Update CodeQL actions to 4.38.0 for the current analysis bundle.

--- a/CLOUDFLARE.md
+++ b/CLOUDFLARE.md
@@ -237,7 +237,7 @@ After router deploy, verify repeated HTML requests remain `X-OpenClaw-Docs-Cache
    source ~/.profile
    CLOUDFLARE_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" \
    CLOUDFLARE_API_TOKEN="$OPENCLAW_CLOUDFLARE_API_TOKEN" \
-   npx wrangler@4.129.0 r2 bucket list
+   npx wrangler@4.130.0 r2 bucket list
    ```
 
 4. Run the manual `R2 Pages` workflow, or run the local upload command above.
@@ -308,7 +308,7 @@ If R2 cutover misbehaves:
 
    ```sh
    source ~/.profile
-   CLOUDFLARE_API_TOKEN="$CRABBOX_CLOUDFLARE_API_TOKEN" npx wrangler@4.129.0 deploy --config wrangler.toml
+   CLOUDFLARE_API_TOKEN="$CRABBOX_CLOUDFLARE_API_TOKEN" npx wrangler@4.130.0 deploy --config wrangler.toml
    ```
 
 3. Purge Cloudflare cache.


### PR DESCRIPTION
Refresh the pinned Cloudflare deployment tool from Wrangler 4.129.0 to 4.130.0 in validation, router deployment, and R2 deployment, with matching operator examples. The release clears the repository's two-day cooldown; newer 4.131.x releases remain held.

This is the final maintenance-notes PR for #178 (Lucide 1.43.0) and #182 (CodeQL 4.38.0). Merge those first, then this PR, so the shared Unreleased section records the final versions. No generated docs are edited.

Validation on `6127dbb521260563596d98c8eb865fe98ac61934`: all 174 local tests passed; Wrangler 4.130.0 bundled the real Worker and served initialize, ping, tools/list, and method-rejection requests over local HTTPS. Independent local and branch autoreviews are scoped-clean through P2. Docs Code CI passed, including full shell build and visual smoke (https://github.com/openclaw/docs/actions/runs/34655131531); CodeQL passed (https://github.com/openclaw/docs/actions/runs/34655131469).

The scheduled translation failure was traced to a multi-megabyte release note exceeding the six-hour job limit. Its source-owned split is already mirrored by commit 8865004fedf92b73d604b3695c9aed23ca4f4191. A fresh non-publishing French translation canary for that page passed on main: https://github.com/openclaw/docs/actions/runs/34654619948 . This proves the repaired page's translation path; a complete locale backfill remains separate verification.
