### PR TITLE
fix: preserve literal versions in translation summaries

### DIFF
--- a/.github/scripts/i18n/tests/test_i18n_scripts.py
+++ b/.github/scripts/i18n/tests/test_i18n_scripts.py
@@ -188,6 +188,43 @@ class I18NScriptTests(unittest.TestCase):
         for trigger in (".openclaw-sync/**", "package.json", "package-lock.json"):
             self.assertIn(f'      - "{trigger}"', text)
 
+    def test_freshness_summary_keeps_version_numbers_literal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            shells = root / "shells"
+            shells.mkdir()
+            scripts = workflow_shell_check.extract_run_blocks(
+                REPO_ROOT / ".github/workflows/translate-all.yml", shells
+            )
+            script = next(path for path in scripts if "### Toolchain freshness" in path.read_text())
+            config = root / ".github/scripts/i18n/toolchain.json"
+            config.parent.mkdir(parents=True)
+            config.write_text(json.dumps({"codex_cli": "0.153.4"}), encoding="utf-8")
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            programs = {
+                "npm": "#!/bin/sh\nprintf '0.154.0\\n'\n",
+                "jq": f"#!{sys.executable}\nimport json, sys\nprint(json.load(open(sys.argv[-1]))['codex_cli'])\n",
+                "0.153.4": '#!/bin/sh\nprintf executed >> "$VERSION_COMMAND_MARKER"\n',
+                "0.154.0": '#!/bin/sh\nprintf executed >> "$VERSION_COMMAND_MARKER"\n',
+            }
+            for name, content in programs.items():
+                executable = bin_dir / name
+                executable.write_text(content, encoding="utf-8")
+                executable.chmod(0o755)
+            summary = root / "summary.md"
+            executed = root / "executed"
+            result = subprocess.run(
+                ["bash", str(script)], cwd=root, text=True, capture_output=True, timeout=30,
+                env={**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                     "GITHUB_STEP_SUMMARY": str(summary), "VERSION_COMMAND_MARKER": str(executed)},
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertFalse(executed.exists(), "version values must not run as shell commands")
+            text = summary.read_text(encoding="utf-8")
+            self.assertIn("- Pinned Codex CLI: `0.153.4`", text)
+            self.assertIn("- Registry latest: `0.154.0`", text)
+
     def test_budget_check_accepts_current_full_batches_and_rejects_worker_over_budget(self) -> None:
         budget = budget_check.validate_budget(REPO_ROOT / ".github/workflows/translate-all.yml")
         self.assertEqual(6, budget.batch_count)

--- a/.github/workflows/translate-all.yml
+++ b/.github/workflows/translate-all.yml
@@ -102,8 +102,8 @@ jobs:
           echo "Registry latest: ${latest}"
           {
             echo "### Toolchain freshness"
-            echo "- Pinned Codex CLI: `${pinned}`"
-            echo "- Registry latest: `${latest}`"
+            printf -- "- Pinned Codex CLI: \`%s\`\n" "${pinned}"
+            printf -- "- Registry latest: \`%s\`\n" "${latest}"
           } >> "$GITHUB_STEP_SUMMARY"
           if [ "${pinned}" != "${latest}" ]; then
             echo "::warning::toolchain.json pins @openai/codex ${pinned} but npm ships ${latest}. Validate the new CLI against a translation shard, then bump toolchain.json."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Abort stalled signed R2 requests so uploads can retry instead of hanging indefinitely; configure the per-request budget with `R2_UPLOAD_FETCH_TIMEOUT_MS`; thanks @SebTardif.
 - Bound live docs smoke requests and jobs while preserving the dispatch retry window; thanks @SebTardif.
 - Bound maintenance and translation workflow jobs, including reusable workflow callees and the incremental debounce; thanks @SebTardif.
+- Preserve literal version numbers in translation freshness summaries and document the current R2 publication flow.
 - Abort stalled Cloudflare hostname cutover requests, with a configurable `CLOUDFLARE_API_TIMEOUT_MS` budget; thanks @SebTardif.
 - Reject malformed and overflowing request timeout settings before network operations begin.
 - Refresh syntax highlighting, icons, Markdown and HTML parsing, and diagrams with highlight.js 11.12.0, Lucide 1.44.0, markdown-it 15.0.1, htmlparser2 12.0.0, and Mermaid 11.17.2.

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -104,7 +104,7 @@ The weekly run is the repair mechanism for LLM flakiness, partial failures, and 
 
 English deploys from source sync commits.
 
-Translations deploy after the aggregate i18n commit. The finalizer dispatches GitHub Pages once because GitHub suppresses normal push-triggered workflow runs from `GITHUB_TOKEN` commits. The Pages workflow dispatches live smoke after deployment so the smoke test checks the deployed site instead of racing the deploy.
+Translations deploy after the aggregate i18n commit. The finalizer dispatches R2 Pages once because GitHub suppresses normal push-triggered workflow runs from `GITHUB_TOKEN` commits. The R2 Pages workflow uploads the built site and dispatches live smoke after publication so the smoke test checks the deployed content instead of racing the upload.
 
 A hot docs day should produce many fast English deploys, but only a small number of locale deploys.
 


### PR DESCRIPTION
## What Problem This Solves

The translation freshness job executed version numbers as shell commands, leaving blank values in its otherwise successful report.

## User Impact

Freshness summaries show the pinned and current versions without command-not-found errors. The workflow guide also identifies the current R2 publication flow.

## Why This Change Was Made

Write values as quoted arguments to fixed `printf` formats. Literal Markdown backticks stay escaped in the format instead of wrapping shell-expanded data.

## Evidence

A regression runs the actual extracted workflow shell block with a stub registry and executable version-name traps: it fails on the original script and passes after the fix. A separate CLI run prints both backticked versions, exits zero, and has empty stderr. Actionlint and translation shell syntax checks pass with no suppressions. Isolated Codex autoreview reports no actionable P0–P2 findings.
