### PR TITLE
fix: share canonical metadata and traversal across publishers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Preserve published heading IDs, emit unambiguous Mintlify link aliases and component targets, and open nested accordions for fragment navigation using the source-owned shared parsing and redirect contract.
 - Recover parser-diagnosed translation markup damage before validation, preserving translated prose and the existing failed-shard publication checks; thanks @hxy91819.
 - Fix redundant locale rendering by excluding locale-owned roots from English page collection, including accidental localized `AGENTS.md` pages and duplicate locale-root Markdown exports.
+- Keep YAML titles and summaries consistent across pages, search and the LLM corpus, and retain nested English paths whose directory names match locales.
+- Generate page-specific social preview images for deeply nested navigation groups.
 - Reject malformed remote R2 manifests before scoped uploads can replace the catalog and lose unrelated pages; thanks @SebTardif.
 - Reject source-index write and file-close failures before publishing completion metadata or logging success; thanks @SebTardif.
 - Skip locale publication when the source metadata is missing, unreadable, or empty, while preserving publication for matching source snapshots; thanks @SebTardif.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Source of truth lives in [`openclaw/openclaw`](https://github.com/openclaw/openc
 
 - `npm run docs:build` renders the mirrored Mintlify-flavored docs into `dist/docs-site`.
 - English collection excludes top-level roots owned by published locales; each locale renders its own sources once, while nested or unrecognized directory names remain ordinary English paths.
+- Search titles and summaries and LLM corpus headings follow the page renderer's YAML frontmatter rules. The English corpus excludes language directories at the docs root while retaining nested paths such as `guide/fr/topic`.
+- Page-specific social preview images follow English navigation groups at every nesting depth.
 - `npm run docs:build:cloudflare` is the legacy Worker Static Assets fallback build.
 - `npm run docs:build:r2` renders the full unpruned site and prepares `dist/docs-r2-manifest.json` for R2 upload.
 - `npm run docs:r2:upload` uploads only changed R2 objects, reports cache hits/misses, and refuses to turn a broken remote manifest read into a full-tree reupload.

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -6,6 +6,7 @@ import { parseArgs } from "node:util";
 
 import { stripMdxForLlms, firstHeading, titleize, textFromHtml, fileSlug, normalizeSlug } from "./document-text.mjs";
 import { ignoredDocDirs, ignoredDocFiles, localeFlags, localeLabels, mintlifyLocaleToDir, rtlLocales } from "./config.mjs";
+import { walkDocs } from "./document-files.mjs";
 import { siteCss } from "./site-css.mjs";
 import { siteJs } from "./site-js.mjs";
 import { chromeStringsForLocale } from "./chrome-strings.mjs";
@@ -159,7 +160,7 @@ function collectPages(localeList) {
       const raw = fs.readFileSync(file, "utf8");
       const parsed = parseFrontmatter(raw);
       const slug = fileSlug(rel);
-      const title = parsed.data.title || firstHeading(parsed.content) || titleize(path.basename(slug));
+      const title = String(parsed.data.title ?? "") || firstHeading(parsed.content) || titleize(path.basename(slug));
       result.push({
         locale: locale.code,
         dir: locale.root ? "" : locale.code,
@@ -169,7 +170,7 @@ function collectPages(localeList) {
         sourcePath: frontmatterSourcePath(parsed.data),
         raw,
         title,
-        summary: parsed.data.summary ?? "",
+        summary: String(parsed.data.summary ?? ""),
         readWhen: parsed.data.read_when ?? [],
         body: parsed.content,
         meta: {
@@ -195,8 +196,8 @@ function elementsFixturePage() {
     file: path.join(siteAssetsDir, "elements-fixture.mjs"),
     rel: "__elements.md",
     raw: elementsFixture,
-    title: parsed.data.title || "Docs elements",
-    summary: parsed.data.summary ?? "",
+    title: String(parsed.data.title ?? "") || "Docs elements",
+    summary: String(parsed.data.summary ?? ""),
     readWhen: [],
     body: parsed.content,
     meta: {
@@ -209,16 +210,6 @@ function elementsFixturePage() {
     },
     hidden: true
   };
-}
-
-function walkDocs(dir, excludedRoots = new Set()) {
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    if (entry.name.startsWith(".")) return [];
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) return ignoredDocDirs.has(entry.name) || excludedRoots.has(entry.name) ? [] : walkDocs(full);
-    return /\.(md|mdx)$/.test(entry.name) ? [full] : [];
-  });
 }
 
 function buildNav(locale) {

--- a/scripts/docs-site/document-files.mjs
+++ b/scripts/docs-site/document-files.mjs
@@ -1,0 +1,13 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ignoredDocDirs } from "./config.mjs";
+
+export function walkDocs(dir, excludedRoots = new Set()) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name.startsWith(".")) return [];
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return ignoredDocDirs.has(entry.name) || excludedRoots.has(entry.name) ? [] : walkDocs(full);
+    return /\.(md|mdx)$/.test(entry.name) ? [full] : [];
+  });
+}

--- a/scripts/docs-site/llms-full.mjs
+++ b/scripts/docs-site/llms-full.mjs
@@ -4,7 +4,9 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { stripMdxForLlms, firstHeading, titleize, fileSlug } from "./document-text.mjs";
-import { ignoredDocDirs, ignoredDocFiles, localeLabels } from "./config.mjs";
+import { parseFrontmatter } from "../../.openclaw-sync/lib/docs-markdown.mjs";
+import { walkDocs } from "./document-files.mjs";
+import { ignoredDocFiles, localeLabels } from "./config.mjs";
 
 const root = process.cwd();
 const sourceRoot = process.env.DOCS_SOURCE_REPO_DIR
@@ -38,7 +40,7 @@ console.log(`llms-full ok: ${pages.length} pages, ${content.length} chars, ${pat
 
 function collectEnglishPages() {
   const result = [];
-  for (const file of walkDocs(docsDir)) {
+  for (const file of walkDocs(docsDir, new Set(Object.keys(localeLabels)))) {
     const rel = path.relative(docsDir, file).replaceAll(path.sep, "/");
     if (ignoredDocFiles.has(rel) || rel.endsWith("/AGENTS.md")) continue;
     const raw = fs.readFileSync(file, "utf8");
@@ -48,43 +50,11 @@ function collectEnglishPages() {
       slug,
       file,
       rel,
-      title: parsed.data.title || firstHeading(parsed.content) || titleize(path.basename(slug)),
+      title: String(parsed.data.title ?? "") || firstHeading(parsed.content) || titleize(path.basename(slug)),
       body: parsed.content,
     });
   }
   return result;
-}
-
-function parseFrontmatter(raw) {
-  const match = raw.match(/^---\n([\s\S]*?)\n---\n?/);
-  if (!match) return { data: {}, content: raw };
-  const data = {};
-  const frontmatter = match[1].split("\n");
-  for (const line of frontmatter) {
-    const property = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
-    if (!property) continue;
-    data[property[1]] = unquoteYamlScalar(property[2]);
-  }
-  return { data, content: raw.slice(match[0].length).replace(/^\n+/, "") };
-}
-
-function unquoteYamlScalar(value) {
-  const trimmed = value.trim();
-  if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
-}
-
-function walkDocs(dir) {
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    if (entry.name.startsWith(".")) return [];
-    if (entry.isDirectory() && (ignoredDocDirs.has(entry.name) || localeLabels[entry.name])) return [];
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) return walkDocs(full);
-    return /\.(md|mdx)$/.test(entry.name) ? [full] : [];
-  });
 }
 
 function renderLlmsFull(pages) {

--- a/scripts/docs-site/og-cards.mjs
+++ b/scripts/docs-site/og-cards.mjs
@@ -3,11 +3,11 @@ import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { renderPageOgSvg } from "./og-card-template.mjs";
 import { createOgCache } from "./og-cache.mjs";
-import { activeTabTitle, groupForPage } from "./navigation.mjs";
+import { activeTabTitle, groupForPage, flattenNav } from "./navigation.mjs";
 
 export async function renderPageOgCards({ pages, enNav, outDir, cacheDir, siteName }) {
   const renderedPageOgCards = new Set();
-  const navSlugs = collectNavSlugs(enNav);
+  const navSlugs = new Set(flattenNav(enNav).map((page) => page.slug));
   const ogDir = path.join(outDir, "og");
   const targets = pages.filter((page) =>
     page.locale === "en" && page.slug !== "index" && navSlugs.has(page.slug)
@@ -73,17 +73,4 @@ function renderOgPng(svg) {
       reject(new Error(`og render worker exit ${code}`));
     });
   });
-}
-
-function collectNavSlugs(nav) {
-  const slugs = new Set();
-  for (const tab of nav) {
-    for (const group of tab.groups ?? []) {
-      for (const entry of group.pages ?? []) {
-        if (entry.group) for (const sub of entry.pages ?? []) slugs.add(sub.slug);
-        else if (entry.slug) slugs.add(entry.slug);
-      }
-    }
-  }
-  return slugs;
 }

--- a/scripts/docs-site/publishing-indexes.test.mjs
+++ b/scripts/docs-site/publishing-indexes.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { DomUtils, parseDocument } from "htmlparser2";
+import { fixture, run, write } from "./test-helpers/redirect-fixture.mjs";
+
+function generate(f, script) {
+  const result = run(f.root, script);
+  assert.equal(result.status, 0, result.stderr);
+  return result;
+}
+
+test("search and corpus use the same YAML titles and summaries as pages", (t) => {
+  const f = fixture(t, [], {
+    "folded.md": '---\ntitle: >-\n  Friendly guide\nsummary: >-\n  A useful\n  summary.\n---\n# Fallback\n\nReadable body.\n',
+    "quoted.mdx": '\uFEFF---\r\ntitle: "Quoted \\"title\\""\r\nsummary: "Reader\'s guide"\r\n---\r\n# Fallback\r\n\r\nQuoted body.\r\n',
+    "numeric.md": '---\ntitle: 2026\nsummary: 123\n---\n# Fallback\n\nNumeric body.\n',
+    "zero.md": '---\ntitle: 0\nsummary: 0\n---\n# Fallback\n\nZero body.\n',
+  });
+  const built = f.build();
+  assert.equal(built.status, 0, built.stderr);
+  generate(f, "search-index.mjs");
+  generate(f, "llms-full.mjs");
+  const site = path.join(f.root, "dist/docs-site");
+  const entries = JSON.parse(fs.readFileSync(path.join(site, "docs-search.json"), "utf8")).entries;
+  const corpus = fs.readFileSync(path.join(f.root, "dist/docs-llms-full/llms-full.txt"), "utf8");
+  for (const [route, title, summary] of [
+    ["folded", "Friendly guide", "A useful summary."],
+    ["quoted", 'Quoted "title"', "Reader's guide"],
+    ["numeric", "2026", "123"],
+    ["zero", "0", "0"],
+  ]) {
+    const entry = entries.find((item) => item.url === `/${route}`);
+    assert.equal(entry?.title, title, route);
+    assert.equal(entry.snippet, summary, route);
+    assert.ok(corpus.includes(`# ${title}\nSource: https://docs.openclaw.ai/${route}\n`), route);
+    const html = fs.readFileSync(path.join(site, route, "index.html"), "utf8");
+    const document = parseDocument(html);
+    const heading = DomUtils.findOne((node) => node.name === "h1", document.children);
+    const description = DomUtils.findOne((node) => node.name === "meta" && node.attribs.name === "description", document.children);
+    assert.equal(DomUtils.textContent(heading), title, route);
+    assert.equal(description.attribs.content, summary, route);
+  }
+  assert.doesNotMatch(corpus, /title: >-|summary: >-/);
+});
+
+test("the English corpus includes nested locale names and excludes locale roots", (t) => {
+  const f = fixture(t, [], {
+    "guide/fr/topic.md": "# Nested French-named directory\n\nEnglish content.\n",
+    "guide/de/other.mdx": "# Another nested directory\n",
+    "fr/translated.md": "# Translated locale root\n",
+  });
+  const built = f.build();
+  assert.equal(built.status, 0, built.stderr);
+  generate(f, "llms-full.mjs");
+  const corpus = fs.readFileSync(path.join(f.root, "dist/docs-llms-full/llms-full.txt"), "utf8");
+  for (const route of ["guide/fr/topic", "guide/de/other"]) {
+    assert.ok(fs.existsSync(path.join(f.root, "dist/docs-site", route, "index.html")));
+    assert.ok(corpus.includes(`Source: https://docs.openclaw.ai/${route}\n`), route);
+  }
+  assert.doesNotMatch(corpus, /Translated locale root/);
+});
+
+test("deep navigation pages receive a rendered page-specific preview image", (t) => {
+  const f = fixture(t, [], { "guide/deep.md": "---\ntitle: Deep Navigation Guide\nsummary: A synthetic documentation example.\n---\n# Deep Navigation Guide\n" });
+  write(f.root, "docs/docs.json", JSON.stringify({
+    name: "OpenClaw",
+    navigation: { languages: [{ language: "en", tabs: [{ tab: "Docs", groups: [{
+      group: "Guides", pages: [{ group: "Outer", pages: [{ group: "Inner", pages: ["guide/deep"] }] }],
+    }] }] }] },
+  }));
+  const built = f.build();
+  assert.equal(built.status, 0, built.stderr);
+  const site = path.join(f.root, "dist/docs-site");
+  const png = fs.readFileSync(path.join(site, "og/guide/deep.png"));
+  assert.equal(png.subarray(0, 8).toString("hex"), "89504e470d0a1a0a");
+  const html = fs.readFileSync(path.join(site, "guide/deep/index.html"), "utf8");
+  assert.match(html, /property="og:image" content="https:\/\/docs\.openclaw\.ai\/og\/guide\/deep\.png\?v=/);
+});

--- a/scripts/docs-site/search-index.mjs
+++ b/scripts/docs-site/search-index.mjs
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { parseFrontmatter } from "../../.openclaw-sync/lib/docs-markdown.mjs";
 import { mintlifyLocaleToDir } from "./config.mjs";
 
 const root = process.cwd();
@@ -28,9 +29,9 @@ for (const file of walk(site)) {
   }
 
   const raw = fs.readFileSync(file, "utf8");
-  const { frontmatter, body } = parseFrontmatter(raw);
-  const title = frontmatter.title || headingTitle(body) || titleFromPath(rel);
-  const summary = frontmatter.summary || firstParagraph(body);
+  const { data: frontmatter, content: body } = parseFrontmatter(raw);
+  const title = String(frontmatter.title ?? "") || headingTitle(body) || titleFromPath(rel);
+  const summary = String(frontmatter.summary ?? "") || firstParagraph(body);
   const route = routeForMarkdown(rel);
   const searchable = normalizeSearchText([title, summary, body].filter(Boolean).join("\n\n"));
   if (!searchable) continue;
@@ -66,20 +67,6 @@ function* walk(dir) {
       yield fullPath;
     }
   }
-}
-
-function parseFrontmatter(raw) {
-  const match = /^---\n([\s\S]*?)\n---\n?/.exec(raw);
-  if (!match) {
-    return { frontmatter: {}, body: raw };
-  }
-  const frontmatter = {};
-  for (const line of match[1].split("\n")) {
-    const field = /^(title|summary):\s*(.*)$/u.exec(line.trim());
-    if (!field) continue;
-    frontmatter[field[1]] = field[2].replace(/^["']|["']$/g, "").trim();
-  }
-  return { frontmatter, body: raw.slice(match[0].length) };
 }
 
 function headingTitle(body) {


### PR DESCRIPTION
## What Problem This Solves

Search and LLM exports could show YAML marker text or omit English pages, while deeply nested navigation pages received generic social preview images.

## User Impact

Titles and summaries match the page metadata, including folded or quoted YAML and explicit zero values. English pages under nested directories such as `guide/fr/` stay in the corpus, and deeply nested pages get their own preview images.

## Why This Change Was Made

Reuse the renderer's frontmatter parser and document walker, and the sidebar's recursive navigation traversal. Normalize explicit metadata before fallback so a numeric zero remains text instead of disappearing.

## Evidence

Three end-to-end regression cases reproduced the old failures and pass after the fix. They cover folded YAML, BOM/CRLF, escaped quotes, positive and zero numeric values, nested locale-name directories, and actual PNG generation. Independent review caught the zero-value boundary; the corrected complete patch has no actionable P0–P2 findings.

The real generator CLIs produced a searchable folded title, a corpus containing the nested English page, and the page-specific PNG shown below. Both pictures contain only public branding and a synthetic documentation example; the before image is the generic fallback previously used for that page.

All 177 Node tests pass. `make docs-check` passed on the final code, validating 62,686 files and 91,201 R2 objects; the rebuild reused 15,492 articles and 1,128 OG images. The complete LLM corpus also built successfully: 1,319 pages. No tests were skipped.

![Before: generic fallback](https://github.com/user-attachments/assets/1b3512a3-6e4c-47ce-8116-0d0f526ffdbc)

![After: page-specific image for the synthetic example](https://github.com/user-attachments/assets/4465aa4c-57eb-4ed9-879d-3474af50a0ff)
