### PR TITLE
fix: publish versioned preview images before page metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix redundant locale rendering by excluding locale-owned roots from English page collection, including accidental localized `AGENTS.md` pages and duplicate locale-root Markdown exports.
 - Keep YAML titles and summaries consistent across pages, search and the LLM corpus, and retain nested English paths whose directory names match locales.
 - Generate page-specific social preview images for deeply nested navigation groups.
+- Version preview-image URLs from their PNG bytes and upload assets before HTML so edited cards refresh correctly without churning unchanged images.
 - Reject malformed remote R2 manifests before scoped uploads can replace the catalog and lose unrelated pages; thanks @SebTardif.
 - Reject source-index write and file-close failures before publishing completion metadata or logging success; thanks @SebTardif.
 - Skip locale publication when the source metadata is missing, unreadable, or empty, while preserving publication for matching source snapshots; thanks @SebTardif.

--- a/CLOUDFLARE.md
+++ b/CLOUDFLARE.md
@@ -139,6 +139,16 @@ also bypasses this cache, without creating or pruning it. The renderer uses the
 locked `@resvg/resvg-js` package with embedded fonts, not `rsvg-convert`, so the
 workflow does not install `librsvg2-bin`.
 
+Published image URLs include a version derived from the actual PNG bytes. Title,
+summary, or renderer changes that alter an image therefore refresh client caches;
+unchanged images retain their URL, including locale pages using the generic card.
+The public image path remains stable.
+
+Within the selected upload scope, R2 publication completes non-HTML objects
+before publishing HTML. This keeps a newly versioned image URL from becoming
+visible before its PNG is available. A prerequisite upload failure stops HTML
+publication; deletions and the final catalog update still follow successful uploads.
+
 Pagefind still builds a complete current index. Its immutable-file reuse is not
 enabled here: retaining an old output directory without an exact current-file
 inventory would also retain obsolete search fragments. Publication order, search

--- a/scripts/docs-site/build.mjs
+++ b/scripts/docs-site/build.mjs
@@ -47,10 +47,8 @@ const defaultShellAssetVersion = createHash("sha256")
   .digest("hex")
   .slice(0, 12);
 const shellAssetVersion = process.env.DOCS_SITE_SHELL_ASSET_VERSION ?? defaultShellAssetVersion;
-const ogAssetVersion = createHash("sha256")
-  .update(fs.readFileSync(new URL("./og-card-template.mjs", import.meta.url)))
-  .update("\0")
-  .update(fs.readFileSync(new URL("./og-card.svg", import.meta.url)))
+const defaultOgVersion = createHash("sha256")
+  .update(fs.readFileSync(path.join(siteAssetsDir, "og-card.png")))
   .digest("hex")
   .slice(0, 12);
 const { values: { page: requestedPages } } = parseArgs({
@@ -102,7 +100,7 @@ fs.rmSync(redirectMetadataPath, { force: true });
 fs.rmSync(outDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 fs.mkdirSync(outDir, { recursive: true });
 copyPublicFiles();
-const renderedPageOgCards = previewMode ? new Set() : await renderPageOgCards({
+const pageOgVersions = previewMode ? new Map() : await renderPageOgCards({
   pages, enNav: navByLocale.get("en") ?? [], outDir,
   cacheDir: path.join(root, ".cache", "docs-og"), siteName: config.name,
 });
@@ -295,10 +293,11 @@ function layout({ page, nav, activeTab, html, toc, prev, next }) {
   const description = page.summary || config.description || "";
   const ogTitle = page.slug === "index" ? `${config.name} Docs` : `${page.title} · ${config.name}`;
   const canonicalUrl = canonicalOrigin ? `${canonicalOrigin}${pageRoute(page)}` : "";
-  const pageOgPath = page.locale === "en" && renderedPageOgCards.has(page.slug)
+  const pageOgVersion = page.locale === "en" ? pageOgVersions.get(page.slug) : undefined;
+  const pageOgPath = pageOgVersion
     ? `/og/${page.slug}.png`
     : ogImagePath;
-  const ogImageUrl = `${canonicalOrigin ? `${canonicalOrigin}${pageOgPath}` : publicPath(pageOgPath)}?v=${ogAssetVersion}`;
+  const ogImageUrl = `${canonicalOrigin ? `${canonicalOrigin}${pageOgPath}` : publicPath(pageOgPath)}?v=${pageOgVersion ?? defaultOgVersion}`;
   return `<!doctype html>
 <html lang="${lang}" dir="${dir}">
 <head>

--- a/scripts/docs-site/og-cards.mjs
+++ b/scripts/docs-site/og-cards.mjs
@@ -1,12 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { Worker } from "node:worker_threads";
 import { renderPageOgSvg } from "./og-card-template.mjs";
 import { createOgCache } from "./og-cache.mjs";
 import { activeTabTitle, groupForPage, flattenNav } from "./navigation.mjs";
 
 export async function renderPageOgCards({ pages, enNav, outDir, cacheDir, siteName }) {
-  const renderedPageOgCards = new Set();
+  const pageOgVersions = new Map();
   const navSlugs = new Set(flattenNav(enNav).map((page) => page.slug));
   const ogDir = path.join(outDir, "og");
   const targets = pages.filter((page) =>
@@ -28,8 +29,9 @@ export async function renderPageOgCards({ pages, enNav, outDir, cacheDir, siteNa
       const outFile = path.join(ogDir, `${page.slug}.png`);
       fs.mkdirSync(path.dirname(outFile), { recursive: true });
       try {
-        fs.writeFileSync(outFile, await (cache ? cache.render(page.slug, svg) : renderOgPng(svg)));
-        renderedPageOgCards.add(page.slug);
+        const png = await (cache ? cache.render(page.slug, svg) : renderOgPng(svg));
+        fs.writeFileSync(outFile, png);
+        pageOgVersions.set(page.slug, createHash("sha256").update(png).digest("hex").slice(0, 12));
         count++;
       } catch (err) {
         failures.push(`${page.slug}: ${err.message}`);
@@ -47,7 +49,7 @@ export async function renderPageOgCards({ pages, enNav, outDir, cacheDir, siteNa
     console.log(`og cache: disabled, ${count} rendered`);
   }
   console.log(`prepared ${count}/${targets.length} per-page og cards in ${Date.now() - start}ms`);
-  return renderedPageOgCards;
+  return pageOgVersions;
 }
 
 function renderOgPng(svg) {

--- a/scripts/docs-site/og-cards.test.mjs
+++ b/scripts/docs-site/og-cards.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fixture, write } from "./test-helpers/redirect-fixture.mjs";
+
+test("preview image URLs follow PNG changes without churning for body-only edits", (t) => {
+  const f = fixture(t, [], { "guide.md": "# Guide\n", "fr/guide.md": "# Guide français\n" });
+  write(f.root, "docs/docs.json", JSON.stringify({
+    name: "OpenClaw", navigation: { languages: ["en", "fr"].map((language) => ({
+      language, tabs: [{ tab: "Docs", groups: [{ group: "Guides", pages: ["guide"] }] }],
+    })) },
+  }));
+  const build = (title, body) => {
+    write(f.root, "docs/guide.md", `---\ntitle: ${title}\n---\n# Guide\n\n${body}\n`);
+    const result = f.build();
+    assert.equal(result.status, 0, result.stderr);
+    const site = path.join(f.root, "dist/docs-site");
+    const imageUrl = (locale = "") => fs.readFileSync(path.join(site, locale, "guide/index.html"), "utf8")
+      .match(/property="og:image" content="([^"]+)"/)[1];
+    return { url: imageUrl(), fallback: imageUrl("fr"), png: fs.readFileSync(path.join(site, "og/guide.png")) };
+  };
+  const before = build("Original guide", "Original body.");
+  const changed = build("Updated guide", "Original body.");
+  assert.notDeepEqual(changed.png, before.png, "the title update changes the rendered image");
+  assert.notEqual(changed.url, before.url, "clients must receive a new cache key for the new image");
+  assert.equal(new URL(changed.url).pathname, new URL(before.url).pathname, "the public image path stays stable");
+  assert.equal(changed.fallback, before.fallback, "the unchanged locale fallback keeps its own image version");
+  const bodyOnly = build("Updated guide", "A different article body.");
+  assert.deepEqual(bodyOnly.png, changed.png);
+  assert.equal(bodyOnly.url, changed.url, "unchanged image bytes retain their cache key");
+});

--- a/scripts/docs-site/r2-upload.mjs
+++ b/scripts/docs-site/r2-upload.mjs
@@ -450,17 +450,22 @@ async function listBucketKeys() {
 }
 
 async function uploadEntries(entries) {
-  let next = 0;
+  const isHtml = (entry) => String(entry.contentType ?? "").split(";")[0].trim().toLowerCase() === "text/html";
+  // Publish prerequisites before HTML exposes their new versioned URLs.
+  const phases = [entries.filter((entry) => !isHtml(entry)), entries.filter(isHtml)];
   let done = 0;
-  const workers = Array.from({ length: Math.min(concurrency, entries.length) }, async () => {
-    while (next < entries.length) {
-      const entry = entries[next++];
-      await putObject(entry);
-      done++;
-      if (done % 500 === 0 || done === entries.length) console.log(`r2 upload progress: ${done}/${entries.length}`);
-    }
-  });
-  await Promise.all(workers);
+  for (const phase of phases) {
+    let next = 0;
+    const workers = Array.from({ length: Math.min(concurrency, phase.length) }, async () => {
+      while (next < phase.length) {
+        const entry = phase[next++];
+        await putObject(entry);
+        done++;
+        if (done % 500 === 0 || done === entries.length) console.log(`r2 upload progress: ${done}/${entries.length}`);
+      }
+    });
+    await Promise.all(workers);
+  }
 }
 
 async function deleteEntries(entries) {

--- a/scripts/docs-site/r2-upload.test.mjs
+++ b/scripts/docs-site/r2-upload.test.mjs
@@ -407,3 +407,45 @@ globalThis.fetch = async (input, init) => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /r2 remote manifest: missing from r2 \(0 entries\)/);
 });
+
+for (const failImage of [false, true]) {
+  test(`R2 publishes image prerequisites before HTML (image failure: ${failImage})`, (t) => {
+    const root = fetchUploadRoot(t);
+    const local = JSON.parse(fs.readFileSync(path.join(root, "dist/local.json"), "utf8")).entries;
+    const bytes = Buffer.from("synthetic image");
+    write(root, "files/image.png", bytes);
+    local.push({
+      key: "og/page.png", sourceKey: "og/page.png", file: "files/image.png", size: bytes.length,
+      contentType: "image/png", cacheControl: "public, max-age=31536000, immutable",
+      sha256: crypto.createHash("sha256").update(bytes).digest("hex"),
+      md5: crypto.createHash("md5").update(bytes).digest("hex"),
+    });
+    write(root, "dist/local.json", JSON.stringify(manifest(local)));
+    write(root, "dist/remote.json", JSON.stringify(manifest([])));
+    write(root, "image-order.mjs", `
+import assert from "node:assert/strict";
+import fs from "node:fs";
+let imageReady = false;
+const calls = [];
+globalThis.fetch = async (input, init) => {
+  const url = new URL(input);
+  assert.equal(url.origin, "https://synthetic-r2.invalid");
+  assert.equal(init.method, "PUT");
+  const key = decodeURIComponent(url.pathname.slice("/synthetic-bucket/".length));
+  calls.push(key);
+  fs.writeFileSync("image-order.json", JSON.stringify(calls));
+  if (key === "og/page.png") {
+    if (${failImage}) return new Response("synthetic failure", { status: 503 });
+    imageReady = true;
+  } else {
+    assert.ok(imageReady, "HTML and the catalog must wait for their image");
+  }
+  return new Response(null, { status: 200 });
+};
+`);
+    const result = run(root, "r2-upload.mjs", syntheticR2, [path.join(root, "image-order.mjs")]);
+    assert.equal(result.status, failImage ? 1 : 0, result.stderr);
+    const calls = JSON.parse(fs.readFileSync(path.join(root, "image-order.json"), "utf8"));
+    assert.deepEqual(calls, failImage ? ["og/page.png"] : ["og/page.png", "page", ".openclaw-docs-r2-manifest.json"]);
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Editing a page title changed its preview PNG but kept the same image URL, allowing clients to keep showing an old card. Concurrent uploads could also expose new page metadata before its image was ready.

## User Impact

Changed images receive a new content version in their URL. Unchanged images keep their cache key, public paths remain stable, and locale fallback cards retain their own version.

## Why This Change Was Made

Derive versions from the actual PNG bytes and complete selected non-HTML uploads before HTML. Asset failures withhold dependent pages and the final catalog. Upload scope, deletion rules, concurrency limits and progress totals stay intact.

## Evidence

All 184 Node tests passed with no skips. Regressions fail on the old code and cover title updates, body-only edits, locale fallback stability, image-before-HTML order, and asset-upload failure. Isolated Codex autoreview of the complete change found no actionable P0–P2 findings.

The real generator changed the synthetic card URL from `v=37f9f801810d` to `v=80d25c405f09` when its PNG changed; before the fix both versions used the same template-only URL. The actual uploader, pointed at a loopback HTTP server with synthetic credentials, published `og/page.png` → `page` → catalog.

The pictures below show the synthetic original and updated cards. The fix ensures that refreshing page metadata requests the updated image instead of reusing the original card's cache key.

![Synthetic original card whose image URL was previously reused](https://github.com/user-attachments/assets/665f99ce-7506-4965-a2b5-ed80ed7f413c)

![Updated synthetic card served through a new content-versioned URL](https://github.com/user-attachments/assets/0440958f-e53f-4164-9c98-78d933478e50)
